### PR TITLE
More common models

### DIFF
--- a/ayon_server/settings/__init__.py
+++ b/ayon_server/settings/__init__.py
@@ -4,6 +4,8 @@
 __all__ = [
     "BaseSettingsModel",
     "Field",
+    "MultiplatformPathModel",
+    "MultiplatformPathListModel",
     "TemplateWorkfileOptions",
     "apply_overrides",
     "list_overrides",
@@ -19,7 +21,11 @@ from pydantic import Field
 
 from ayon_server.settings.common import BaseSettingsModel, postprocess_settings_schema
 from ayon_server.settings.enum import folder_types_enum, task_types_enum
-from ayon_server.settings.models import TemplateWorkfileOptions
+from ayon_server.settings.models import (
+    MultiplatformPathModel,
+    MultiplatformPathListModel,
+    TemplateWorkfileOptions,
+)
 from ayon_server.settings.overrides import (
     apply_overrides,
     extract_overrides,

--- a/ayon_server/settings/__init__.py
+++ b/ayon_server/settings/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "Field",
     "MultiplatformPathModel",
     "MultiplatformPathListModel",
+    "TemplateWorkfileBaseOptions",
     "TemplateWorkfileOptions",
     "apply_overrides",
     "list_overrides",
@@ -25,6 +26,7 @@ from ayon_server.settings.models import (
     MultiplatformPathModel,
     MultiplatformPathListModel,
     TemplateWorkfileOptions,
+    TemplateWorkfileBaseOptions
 )
 from ayon_server.settings.overrides import (
     apply_overrides,

--- a/ayon_server/settings/models.py
+++ b/ayon_server/settings/models.py
@@ -58,6 +58,17 @@ class ProfileModel(BaseSettingsModel):
     )
 
 
+class TemplateWorkfileBaseOptions(BaseSettingsModel):
+    create_first_version: bool = Field(
+        False,
+        title="Create first workfile",
+    )
+    custom_templates: list[CustomTemplateModel] = Field(
+        default_factory=list,
+        title="Custom templates",
+    )
+
+
 class TemplateWorkfileOptions(BaseSettingsModel):
     create_first_version: bool = Field(
         False,

--- a/ayon_server/settings/models.py
+++ b/ayon_server/settings/models.py
@@ -3,10 +3,16 @@ from ayon_server.settings.common import BaseSettingsModel
 from ayon_server.settings.enum import task_types_enum
 
 
-class PathModel(BaseSettingsModel):
+class MultiplatformPathModel(BaseSettingsModel):
     windows: str = Field("", title="Windows")
     macos: str = Field("", title="MacOS")
     linux: str = Field("", title="Linux")
+
+
+class MultiplatformPathListModel(BaseSettingsModel):
+    windows: list[str] = Field(default_factory=list, title="Windows")
+    macos: list[str] = Field(default_factory=list, title="MacOS")
+    linux: list[str] = Field(default_factory=list, title="Linux")
 
 
 class CustomTemplateModel(BaseSettingsModel):
@@ -19,7 +25,10 @@ class CustomTemplateModel(BaseSettingsModel):
     # label:
     # Absolute path to workfile template or Ayon Anatomy text is accepted.
 
-    path: PathModel = Field(default_factory=PathModel, title="Path")
+    path: MultiplatformPathModel = Field(
+        default_factory=MultiplatformPathModel,
+        title="Path"
+    )
 
 
 class ContextModel(BaseSettingsModel):


### PR DESCRIPTION
## Description
Added more common models to settings models. `PathModel` was renamed to `MultiplatformPathModel` and was added variant with paths as list named `MultiplatformPathListModel`. Currently existing `TemplateWorkfileOptions` model is not usable in all cases as most of it's usage should have less attributes thus a `TemplateWorkfileBaseOptions` was implemented too.