### PR TITLE
Addons distribution: Change type and content of client zip file

### DIFF
--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -141,14 +141,13 @@ class BaseServerAddon:
         """Returns information on local copy of the client code."""
         if (pdir := self.get_private_dir()) is None:
             return None
-        if base_url is None:
-            base_url = ""
-        local_path = os.path.join(pdir, "client.zip")
+        filename = "client.zip"
+        local_path = os.path.join(pdir, filename)
         if not os.path.exists(local_path):
             return None
         return {
-            "type": "http",
-            "path": f"{base_url}/addons/{self.name}/{self.version}/private/client.zip",
+            "type": "server",
+            "filename": filename
         }
 
     async def get_client_source_info(


### PR DESCRIPTION
## Description
Addon by default returns `type` of client code as `"server"` with `"filename"` instead of `http` with `"url"`.

### Additional information
It is easier to know that source of addon client code is from server then receiving url from server (that can potentially lead to wrong server as server may not know the base url correctly).