### PR TITLE
enhancement: BaseServerAddon.get_client_source_info now returns stric…

### DIFF
--- a/api/addons/__init__.py
+++ b/api/addons/__init__.py
@@ -128,7 +128,9 @@ async def list_addons(
 
                 elif not all([isinstance(x, SourceInfo) for x in source_info]):
                     logging.error(f"Invalid source info for {addon.name} {version}")
-                    source_info = []
+                    source_info = [
+                        x for x in source_info if isinstance(x, SourceInfo)
+                    ]
                 vinf["client_source_info"] = source_info
 
                 vinf["services"] = addon.services or None

--- a/api/addons/__init__.py
+++ b/api/addons/__init__.py
@@ -6,6 +6,7 @@ from nxtools import logging
 
 from addons import project_settings, site_settings, studio_settings
 from ayon_server.addons import AddonLibrary
+from ayon_server.addons.models import SourceInfo
 from ayon_server.api.dependencies import dep_current_user
 from ayon_server.entities import UserEntity
 from ayon_server.exceptions import ForbiddenException
@@ -56,17 +57,12 @@ def register_addon_endpoints():
 register_addon_endpoints()
 
 
-class ClientSourceInfo(OPModel):
-    type: str
-    path: str
-
-
 class VersionInfo(OPModel):
     has_settings: bool = Field(default=False)
     has_site_settings: bool = Field(default=False)
     frontend_scopes: dict[str, Any] = Field(default_factory=dict)
     client_pyproject: dict[str, Any] | None = Field(None)
-    client_source_info: list[ClientSourceInfo] | None = Field(None)
+    client_source_info: list[SourceInfo] | None = Field(None)
     services: dict[str, Any] | None = Field(None)
 
 
@@ -125,9 +121,16 @@ async def list_addons(
             }
             if details:
                 vinf["client_pyproject"] = await addon.get_client_pyproject()
-                vinf["client_source_info"] = await addon.get_client_source_info(
-                    base_url=base_url
-                )
+
+                source_info = await addon.get_client_source_info(base_url=base_url)
+                if source_info is None:
+                    pass
+
+                elif not all([isinstance(x, SourceInfo) for x in source_info]):
+                    logging.error(f"Invalid source info for {addon.name} {version}")
+                else:
+                    vinf["client_source_info"] = source_info
+
                 vinf["services"] = addon.services or None
             versions[version] = VersionInfo(**vinf)
 

--- a/api/addons/__init__.py
+++ b/api/addons/__init__.py
@@ -128,8 +128,8 @@ async def list_addons(
 
                 elif not all([isinstance(x, SourceInfo) for x in source_info]):
                     logging.error(f"Invalid source info for {addon.name} {version}")
-                else:
-                    vinf["client_source_info"] = source_info
+                    source_info = []
+                vinf["client_source_info"] = source_info
 
                 vinf["services"] = addon.services or None
             versions[version] = VersionInfo(**vinf)

--- a/api/projects/projects.py
+++ b/api/projects/projects.py
@@ -88,6 +88,12 @@ async def create_project(
 
     This is different from the rest of the entities, which use POST
     requests to create new entities with a unique ID.
+
+    Important: this endpoint only creates a project entity. It does
+    not handle creating its anatomy and assigning users to the project,
+    so it should be used only in special cases, when you need a granular
+    control over a project creation process. Use `Deploy project`
+    ([POST] /api/projects) for general usage.
     """
 
     if not user.is_manager:

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -9,6 +9,12 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Type
 
 from nxtools import logging
 
+from ayon_server.addons.models import (
+    FilesystemSourceInfo,
+    HttpSourceInfo,
+    ServerSourceInfo,
+    SourceInfo,
+)
 from ayon_server.exceptions import AyonException, NotFoundException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.settings import BaseSettingsModel, apply_overrides
@@ -137,7 +143,7 @@ class BaseServerAddon:
     def get_local_client_info(
         self,
         base_url: str | None = None,
-    ) -> dict[str, Any] | None:
+    ) -> ServerSourceInfo | None:
         """Returns information on local copy of the client code."""
         if (pdir := self.get_private_dir()) is None:
             return None
@@ -145,15 +151,12 @@ class BaseServerAddon:
         local_path = os.path.join(pdir, filename)
         if not os.path.exists(local_path):
             return None
-        return {
-            "type": "server",
-            "filename": filename
-        }
+        return ServerSourceInfo(filename=filename)
 
     async def get_client_source_info(
         self,
         base_url: str | None = None,
-    ) -> list[dict[str, Any]] | None:
+    ) -> list[SourceInfo] | None:
         """Return a list of locations from where the client part of
         the addon can be downloaded.
         """

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -9,12 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Type
 
 from nxtools import logging
 
-from ayon_server.addons.models import (
-    FilesystemSourceInfo,
-    HttpSourceInfo,
-    ServerSourceInfo,
-    SourceInfo,
-)
+from ayon_server.addons.models import ServerSourceInfo, SourceInfo
 from ayon_server.exceptions import AyonException, NotFoundException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.settings import BaseSettingsModel, apply_overrides

--- a/ayon_server/addons/models.py
+++ b/ayon_server/addons/models.py
@@ -1,0 +1,32 @@
+from typing import Literal
+
+from ayon_server.types import Field, OPModel
+
+
+class ClientSourceInfo(OPModel):
+    type: Literal["filesystem", "server", "http"] = Field(...)
+
+
+class PathDefinition(OPModel):
+    plaform: str
+    path: str
+
+
+class FilesystemSourceInfo(ClientSourceInfo):
+    type: Literal["filesystem"] = Field("filesystem")
+    paths: list[PathDefinition] = Field(default_factory=list)
+
+
+class ServerSourceInfo(ClientSourceInfo):
+    type: Literal["server"] = Field("server")
+    filename: str | None = Field(None)
+    path: str | None = Field(None)
+
+
+class HttpSourceInfo(ClientSourceInfo):
+    type: Literal["http"] = Field("http")
+    url: str
+    headers: dict[str, str] | None = Field(None)
+
+
+SourceInfo = FilesystemSourceInfo | ServerSourceInfo | HttpSourceInfo

--- a/ayon_server/addons/models.py
+++ b/ayon_server/addons/models.py
@@ -8,13 +8,14 @@ class ClientSourceInfo(OPModel):
 
 
 class PathDefinition(OPModel):
-    plaform: str
-    path: str
+    windows: str
+    linux: str
+    darwin: str
 
 
 class FilesystemSourceInfo(ClientSourceInfo):
     type: Literal["filesystem"] = Field("filesystem")
-    paths: list[PathDefinition] = Field(default_factory=list)
+    path: PathDefinition = Field(default_factory=PathDefinition)
 
 
 class ServerSourceInfo(ClientSourceInfo):

--- a/ayon_server/graphql/__init__.py
+++ b/ayon_server/graphql/__init__.py
@@ -111,6 +111,7 @@ class Query:
             is_guest=False,  # TODO
             default_roles=user.data.get("defaultRoles", []),
             has_password=bool(user.data.get("password")),
+            apiKeyPreview=user.data.get("apiKeyPreview"),
         )
 
 


### PR DESCRIPTION
`get_client_source_info` is now expected to return one of the three stict models for source info, which are defined in `ayon_server.addons.models`

If the returned type is different, it won't crash the request, but the problem is logged. 

This change breaks the current implementation of the site sync addon, which already reimplements get_client_source_info.

Note that models are not yet well-typed and documented. @iLLiCiTiT feel free to add descriptions or modify the models. 