### PR TITLE
Settings: Add default imageio models for hosts

### DIFF
--- a/ayon_server/settings/__init__.py
+++ b/ayon_server/settings/__init__.py
@@ -7,7 +7,6 @@ __all__ = [
     "MultiplatformPathModel",
     "MultiplatformPathListModel",
     "TemplateWorkfileBaseOptions",
-    "TemplateWorkfileOptions",
     "apply_overrides",
     "list_overrides",
     "extract_overrides",
@@ -26,7 +25,6 @@ from ayon_server.settings.models import (
     MultiplatformPathListModel,
     MultiplatformPathModel,
     TemplateWorkfileBaseOptions,
-    TemplateWorkfileOptions,
 )
 from ayon_server.settings.overrides import (
     apply_overrides,

--- a/ayon_server/settings/__init__.py
+++ b/ayon_server/settings/__init__.py
@@ -7,6 +7,9 @@ __all__ = [
     "MultiplatformPathModel",
     "MultiplatformPathListModel",
     "TemplateWorkfileBaseOptions",
+    "ImageIOConfigModel",
+    "ImageIOFileRulesModel",
+    "ImageIOBaseModel",
     "apply_overrides",
     "list_overrides",
     "extract_overrides",
@@ -25,6 +28,9 @@ from ayon_server.settings.models import (
     MultiplatformPathListModel,
     MultiplatformPathModel,
     TemplateWorkfileBaseOptions,
+    ImageIOConfigModel,
+    ImageIOFileRulesModel,
+    ImageIOBaseModel,
 )
 from ayon_server.settings.overrides import (
     apply_overrides,

--- a/ayon_server/settings/models.py
+++ b/ayon_server/settings/models.py
@@ -30,33 +30,6 @@ class CustomTemplateModel(BaseSettingsModel):
     )
 
 
-class ContextModel(BaseSettingsModel):
-    _layout = "expanded"
-
-    subsset_name_filter: list[str] = Field(
-        default_factory=list, title="Subset name filters"
-    )
-    families: list[str] = Field(default_factory=list, title="Families")
-    repre_names: list[str] = Field(default_factory=list, title="Repre names")
-    loaders: list[str] = Field(default_factory=list, title="Loaders")
-
-
-class ProfileModel(BaseSettingsModel):
-    task_types: list[str] = Field(
-        default_factory=list, title="Task types", enum_resolver=task_types_enum
-    )
-
-    tasks: list[str] = Field(default_factory=list, title="Task names")
-
-    current_context: list[ContextModel] = Field(
-        default_factory=list, title="""**Current context**"""
-    )
-
-    linked_assets: list[ContextModel] = Field(
-        default_factory=list, title="""**Linked Assets/Shots**"""
-    )
-
-
 class TemplateWorkfileBaseOptions(BaseSettingsModel):
     create_first_version: bool = Field(
         False,
@@ -68,17 +41,3 @@ class TemplateWorkfileBaseOptions(BaseSettingsModel):
     )
 
 
-class TemplateWorkfileOptions(BaseSettingsModel):
-    create_first_version: bool = Field(
-        False,
-        title="Create first workfile",
-    )
-    custom_templates: list[CustomTemplateModel] = Field(
-        default_factory=list,
-        title="Custom templates",
-    )
-    builder_on_start: bool = Field(False, title="Run Builder Profiles on first launch")
-    profiles: list[ProfileModel] = Field(
-        default_factory=list,
-        title="Profiles",
-    )

--- a/ayon_server/settings/models.py
+++ b/ayon_server/settings/models.py
@@ -41,3 +41,42 @@ class TemplateWorkfileBaseOptions(BaseSettingsModel):
     )
 
 
+# --- Host 'imageio' models ---
+class ImageIOConfigModel(BaseSettingsModel):
+    enabled: bool = Field(False)
+    ocio_config: list[str] = Field(
+        defaul_factory=list,
+        title="Config path"
+    )
+
+
+class ImageIOFileRuleModel(BaseSettingsModel):
+    name: str = Field("", title="Rule name")
+    pattern: str = Field("", title="Regex pattern")
+    colorspace: str = Field("", title="Colorspace name")
+    ext: str = Field("", title="File extension")
+
+
+class ImageIOFileRulesModel(BaseSettingsModel):
+    enabled: bool = Field(False)
+    rules: list[ImageIOFileRuleModel] = Field(
+        default_factory=list,
+        title="Rules"
+    )
+
+    @validator("rules")
+    def validate_unique_outputs(cls, value):
+        ensure_unique_names(value)
+        return value
+
+
+# Base model that can be used as is if host does not need any custom fields
+class ImageIOBaseModel(BaseSettingsModel):
+    ocio_config: ImageIOConfigModel = Field(
+        default_factory=ImageIOConfigModel,
+        title="OCIO config"
+    )
+    file_rules: ImageIOFileRulesModel = Field(
+        default_factory=ImageIOFileRulesModel,
+        title="File Rules"
+    )


### PR DESCRIPTION
## Description
All host addons must have `imageio` settings which is using the same models so they should be available in common models thus they are added.

Removed few unused models `ContextModel`, `ProfileModel` and `TemplateWorkfileOptions`.