### PR TITLE
Use universal bash definition

### DIFF
--- a/reload.sh
+++ b/reload.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 kill -15 `cat /var/run/ayon.pid`

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Starting the backend"
 python -m setup --ensure-installed
 


### PR DESCRIPTION
## Description
Use recommended `/usr/bin/env bash` instead of `/bin/bash` in shell scripts.

## Additional information
This fixes issue on windows launching the scripts in docker.