### PR TITLE
Bug: fix line ends in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -21,3 +21,4 @@ exec gunicorn \
   --log-level warning \
   -b :5000 \
   ayon_server.api:app
+  


### PR DESCRIPTION
## Description

Just fixing EOL issue in `start.sh` that was crashing docker container on start - converting from windows to linux EOL.