### PR TITLE
Add gitattributes to handle EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
** Handling end of lines

This is adding `.gitattributes` file to help resovling EOL characters on multiple platforms, mainly because `.sh` file were check out with Windows CR/LF effectively breaking run in the Docker.

