### PR TITLE
Support nested data in python modules

### DIFF
--- a/ayon_server/installer/models.py
+++ b/ayon_server/installer/models.py
@@ -1,6 +1,7 @@
 from typing import Literal, Optional
 
 from pydantic import Field
+from typing import Union
 
 from ayon_server.types import OPModel, Platform
 
@@ -62,7 +63,7 @@ class DependencyPackageManifest(BasePackageModel):
         description="mapping of addon_name:addon_version used to create the package",
         example={"ftrack": "1.2.3", "maya": "2.4"},
     )
-    python_modules: dict[str, str] = Field(
+    python_modules: dict[str, Union[str, dict[str, str]]] = Field(
         default_factory=dict,
         title="Python modules",
         description="mapping of module_name:module_version used to create the package",
@@ -83,7 +84,7 @@ class InstallerManifest(BasePackageModel):
         description="Version of Python that the installer is created with",
         example="3.11",
     )
-    python_modules: dict[str, str] = Field(
+    python_modules: dict[str, Union[str, dict[str, str]]] = Field(
         default_factory=dict,
         title="Python modules",
         description="mapping of module_name:module_version used to create the installer",


### PR DESCRIPTION
## Description
Added option to use full potential of poetry dependencies structure by allowing nested dictionary as value of pacakge.

### Example
We use git repositories in python modules which are defined as `{"git": "<url>", "branch": "<branch>"}`. There are more options what can be inside.