### PR TITLE
Change 'Product types' to 'Families' attribute on version

### DIFF
--- a/setup/attributes.py
+++ b/setup/attributes.py
@@ -145,10 +145,10 @@ DEFAULT_ATTRIBUTES: dict[str, dict[str, Any]] = {
         "title": "Site",
         "example": "workstation42",
     },
-    "productTypes": {
+    "families": {
         "scope": "V",
         "type": "list_of_strings",
-        "title": "Product types",
+        "title": "Families",
     },
     "colorSpace": {
         "scope": "V",


### PR DESCRIPTION
## Description
The attribute on version should be named families and not product types.

## Additional information
I do expect this will require more changes, but this is must have change.