### PR TITLE
Enhancement / Use dynamic resolver for attribute enumerators

### DIFF
--- a/ayon_server/entities/models/__init__.py
+++ b/ayon_server/entities/models/__init__.py
@@ -45,6 +45,8 @@ class AttribModelConfig:
     own entity attributes and which are inherited).
     """
 
+    _is_attrib_model = True
+
     # On the other hand, in demogen, we need to be able to
     # set attributes on the fly, so we need to allow it.
     # TODO: How to handle this situation?

--- a/ayon_server/entities/models/generator.py
+++ b/ayon_server/entities/models/generator.py
@@ -11,7 +11,7 @@ from typing import Any, List, Literal, Optional, Type, TypeVar, Union
 from nxtools import logging
 from pydantic import BaseModel, Field, create_model
 
-from ayon_server.types import AttributeType
+from ayon_server.types import AttributeEnumItem, AttributeType
 
 C = TypeVar("C", bound=type)
 
@@ -69,13 +69,6 @@ FIELD_FACORIES = {
 # 'extra',
 
 
-class EnumFieldDefinition(BaseModel):
-    """Enum field definition."""
-
-    value: str
-    label: str
-
-
 class FieldDefinition(BaseModel):
     """Field definition model."""
 
@@ -108,7 +101,7 @@ class FieldDefinition(BaseModel):
     min_items: Optional[int] = Field(title="Minimum items")
     max_items: Optional[int] = Field(title="Maximum items")
     regex: Optional[str] = Field(title="Field regex")
-    enum: Optional[list[EnumFieldDefinition]] = Field(None, title="Enum values")
+    enum: Optional[list[AttributeEnumItem]] = Field(None, title="Enum values")
 
 
 def generate_model(
@@ -156,6 +149,9 @@ def generate_model(
         ):
             if getattr(fdef, k):
                 field[k] = getattr(fdef, k)
+
+        if field.get("enum"):
+            field["_attrib_enum"] = True
         #
         # Default value
         #

--- a/ayon_server/types.py
+++ b/ayon_server/types.py
@@ -4,7 +4,7 @@ __all__ = [
 ]
 
 import re
-from typing import Literal, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 from pydantic import BaseModel, Field
 
@@ -215,3 +215,10 @@ class ColorRGBA_float(NamedTuple):
     g: float
     b: float
     a: float
+
+
+class AttributeEnumItem(OPModel):
+    """Attribute enum item."""
+
+    value: Any = Field(..., title="Enum value")
+    label: str = Field(..., title="Enum label")


### PR DESCRIPTION
enumerator on `string` and `list_of_strings` attribute types are not enforced by model validators and they are mostly informative (to create dropdowns in UX), so it is not crucial to restart the server when an enumerator list changes.

In this PR, postprocess_settings_schema is modified, so anatomy model always load the enumerator from the database instead of using locally loaded `EntityModel.model.attrib_model`. The same is applied to `/api/info` request, so initial list of attributes return updated enumerators instead of cached ones. 

To get the current enumerator it is possible just to reload the page instead restarting the server. This applies only for enumerators. Other attribute settings have a direct impact on their Pydantic model and REST API, so the restart is necessary. 