### PR TITLE
Provide detailed release information in /api/info

### DIFF
--- a/api/system/info.py
+++ b/api/system/info.py
@@ -24,6 +24,50 @@ from .sites import SiteInfo
 BOOT_TIME = time.time()
 
 
+class ReleaseInfo(OPModel):
+    version: str = Field(..., title="Backend version", example="1.0.0")
+    build_date: str = Field(..., title="Build date", example="20231013")
+    build_time: str = Field(..., title="Build time", example="1250")
+    frontend_branch: str = Field(..., title="Frontend branch", example="main")
+    backend_branch: str = Field(..., title="Backend branch", example="main")
+    frontend_commit: str = Field(..., title="Frontend commit", example="1234567")
+    backend_commit: str = Field(..., title="Backend commit", example="1234567")
+
+
+release_info = {}
+
+
+def get_release_info() -> ReleaseInfo | None:
+    """
+    Get the release info from RELEASE file.
+    This file is created when building the docker image.
+    and contains key=value pairs.
+
+    If file is not found, return None - server is probably running from
+    a mounted local directory.
+    """
+
+    try:
+        if release_info.get("error", False):
+            return None
+
+        if release_info:
+            return ReleaseInfo(**release_info)
+
+        if not os.path.isfile("RELEASE"):
+            release_info["error"] = True
+            return None
+
+        with open("RELEASE") as f:
+            for line in f:
+                key, value = line.strip().split("=")
+                release_info[key] = value
+
+        return ReleaseInfo(**release_info)
+    except Exception:
+        return None
+
+
 def get_uptime():
     return time.time() - BOOT_TIME
 
@@ -66,6 +110,11 @@ class InfoResponseModel(OPModel):
         default=ayonconfig.login_page_brand,
         title="Brand logo",
         description="URL of the brand logo for the login page",
+    )
+    release_info: ReleaseInfo | None = Field(
+        default_factory=get_release_info,
+        title="Release info",
+        description="Information about the current release",
     )
     version: str = Field(
         default_factory=get_version,

--- a/ayon_server/__init__.py
+++ b/ayon_server/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 
 # Initialize logging


### PR DESCRIPTION
`/api/info` endpoints now provides information on branches and commits the image was created from. Pushing the information there is a responsibility of CI. Information is taken from `/backend/RELEASE` file, which is structured as follows:

```
version=0.5.2
build_date=20231013
build_time=1108
frontend_branch=develop
backend_branch=enhancement/return_release_info
frontend_commit=30409b9
backend_commit=b86bc7e
```

`releaseInfo` field in `api/info` is nullable and is null when the file is not available (for example when running from a locally mounted copy of the backend repository.
