### PR TITLE
Brute force protection

### DIFF
--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -34,7 +34,7 @@ from ayon_server.utils import parse_access_token
 
 app = fastapi.FastAPI(
     docs_url=None,
-    redoc_url="/docs",
+    redoc_url="/docs" if not ayonconfig.disable_rest_docs else None,
     openapi_tags=tags_meta,
     **app_meta,
 )

--- a/ayon_server/config.py
+++ b/ayon_server/config.py
@@ -70,6 +70,16 @@ class AyonConfig(BaseModel):
         description="Session lifetime in seconds",
     )
 
+    max_failed_login_attempts: int = Field(
+        default=10,
+        description="Maximum number of failed login attempts",
+    )
+
+    failed_login_ban_time: int = Field(
+        default=30,
+        description="Interval in seconds to ban IP addresses with too many failed login attempts",
+    )
+
     motd: str | None = Field(
         default=None,
         description="Message of the day",

--- a/ayon_server/config.py
+++ b/ayon_server/config.py
@@ -103,6 +103,11 @@ class AyonConfig(BaseModel):
         description="Ensure creation of admin user on first run",
     )
 
+    disable_rest_docs: bool = Field(
+        default=False,
+        description="Disable REST API documentation",
+    )
+
     audit_trail: bool = Field(
         default=True,
         description="Enable audit trail",

--- a/ayon_server/lib/redis.py
+++ b/ayon_server/lib/redis.py
@@ -46,11 +46,19 @@ class Redis:
         await cls.redis_pool.delete(f"{namespace}-{key}")
 
     @classmethod
-    async def incr(cls, namespace: str, key: str) -> None:
+    async def incr(cls, namespace: str, key: str) -> int:
         """Increment a value in Redis"""
         if not cls.connected:
             await cls.connect()
-        await cls.redis_pool.incr(f"{namespace}-{key}")
+        res = await cls.redis_pool.incr(f"{namespace}-{key}")
+        return res
+
+    @classmethod
+    async def expire(cls, namespace: str, key: str, ttl: int) -> None:
+        """Set a TTL for a key in Redis"""
+        if not cls.connected:
+            await cls.connect()
+        await cls.redis_pool.expire(f"{namespace}-{key}", ttl)
 
     @classmethod
     async def pubsub(cls) -> PubSub:


### PR DESCRIPTION
Implementation of brute force protection of `/api/auth/login` endpoint. Disallows login for IP addresses which attempted to log in with a wrong password more than `ayonconfig.max_failed_login_attempts = 10` for next `ayonconfig.failed_login_ban_time = 600` seconds.