### PR TITLE
Project level data accessible via GraphQL. 

### DIFF
--- a/api/projects/projects.py
+++ b/api/projects/projects.py
@@ -25,6 +25,13 @@ async def get_project(
 ) -> ProjectEntity.model.main_model:  # type: ignore
     """Retrieve a project by its name."""
 
+    if not user.is_manager:
+        access_groups = user.data.get("accessGroups", {})
+        if project_name not in access_groups:
+            raise ForbiddenException(
+                f"You are not allowed to access {project_name} project"
+            )
+
     project = await ProjectEntity.load(project_name)
     return project.as_user(user)
 
@@ -37,6 +44,13 @@ async def get_project(
 @router.get("/projects/{project_name}/stats")
 async def get_project_stats(user: CurrentUser, project_name: ProjectName):
     """Retrieve a project statistics by its name."""
+
+    if not user.is_manager:
+        access_groups = user.data.get("accessGroups", {})
+        if project_name not in access_groups:
+            raise ForbiddenException(
+                f"You are not allowed to access {project_name} project statistics"
+            )
 
     counts = {}
     for entity in ["folders", "products", "versions", "representations", "tasks"]:

--- a/ayon_server/entities/core/projectlevel.py
+++ b/ayon_server/entities/core/projectlevel.py
@@ -92,7 +92,7 @@ class ProjectLevelEntity(BaseEntity):
         # TODO: Clean-up. use model.attrb_model.__fields__ to create blacklist
         attrib = self._payload.attrib.dict()
         if not user.is_manager:
-            kw["exclude"]["data"] = True
+            # kw["exclude"]["data"] = True
 
             attr_perm = user.permissions(self.project_name).attrib_read
             if attr_perm.enabled:

--- a/ayon_server/graphql/dataloaders/__init__.py
+++ b/ayon_server/graphql/dataloaders/__init__.py
@@ -45,6 +45,7 @@ async def folder_loader(keys: list[KeyType]) -> list[dict | None]:
             folders.tags AS tags,
             folders.created_at AS created_at,
             folders.updated_at AS updated_at,
+            folders.data as data,
             hierarchy.path AS path,
             pr.attrib AS project_attributes,
             ex.attrib AS inherited_attributes

--- a/ayon_server/graphql/nodes/event.py
+++ b/ayon_server/graphql/nodes/event.py
@@ -20,6 +20,7 @@ class EventNode:
     summary: str
     created_at: datetime
     updated_at: datetime
+    data: str | None
 
 
 def event_from_record(record: dict, context: dict) -> EventNode:
@@ -31,6 +32,7 @@ def event_from_record(record: dict, context: dict) -> EventNode:
             record["user_name"] = get_nickname(record["user_name"])
         if record["topic"].startswith("log") and record["description"]:
             record["description"] = obscure(record["description"])
+    data = record.get("data", {})
 
     return EventNode(
         id=record["id"],
@@ -46,6 +48,7 @@ def event_from_record(record: dict, context: dict) -> EventNode:
         summary=json_dumps(record["summary"]),
         created_at=record["created_at"],
         updated_at=record["updated_at"],
+        data=json_dumps(data) if data else None,
     )
 
 

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -9,6 +9,7 @@ from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.resolvers.products import get_products
 from ayon_server.graphql.resolvers.tasks import get_tasks
 from ayon_server.graphql.utils import parse_attrib_data
+from ayon_server.utils import json_dumps
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import ProductsConnection, TasksConnection
@@ -33,6 +34,7 @@ class FolderNode(BaseNode):
     tags: list[str]
     attrib: FolderAttribType
     own_attrib: list[str]
+    data: str
 
     # GraphQL specifics
 
@@ -94,6 +96,7 @@ def folder_from_record(project_name: str, record: dict, context: dict) -> Folder
     """Construct a folder node from a DB row."""
 
     own_attrib = list(record["attrib"].keys())
+    data = record.get("data")
 
     return FolderNode(
         project_name=project_name,
@@ -114,6 +117,7 @@ def folder_from_record(project_name: str, record: dict, context: dict) -> Folder
             project_attrib=record["project_attributes"],
             inherited_attrib=record["inherited_attributes"],
         ),
+        data=json_dumps(data) if data else None,
         created_at=record["created_at"],
         updated_at=record["updated_at"],
         child_count=record.get("child_count", 0),

--- a/ayon_server/graphql/nodes/product.py
+++ b/ayon_server/graphql/nodes/product.py
@@ -8,6 +8,7 @@ from ayon_server.entities import ProductEntity
 from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.resolvers.versions import get_versions
 from ayon_server.graphql.utils import parse_attrib_data
+from ayon_server.utils import json_dumps
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import VersionsConnection
@@ -45,6 +46,7 @@ class ProductNode(BaseNode):
     status: str
     tags: list[str]
     attrib: ProductAttribType
+    data: str | None
 
     # GraphQL specifics
 
@@ -115,6 +117,8 @@ def product_from_record(
     for id, vers in zip(record.get("version_ids", []), record.get("version_list", [])):
         vlist.append(VersionListItem(id=id, version=vers))
 
+    data = record.get("data", {})
+
     return ProductNode(
         project_name=project_name,
         id=record["id"],
@@ -129,6 +133,7 @@ def product_from_record(
             user=context["user"],
             project_name=project_name,
         ),
+        data=json_dumps(data) if data else None,
         active=record["active"],
         created_at=record["created_at"],
         updated_at=record["updated_at"],

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -17,6 +17,7 @@ from ayon_server.graphql.resolvers.versions import get_version, get_versions
 from ayon_server.graphql.resolvers.workfiles import get_workfile, get_workfiles
 from ayon_server.graphql.utils import parse_attrib_data
 from ayon_server.lib.postgres import Postgres
+from ayon_server.utils import json_dumps
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import (
@@ -74,6 +75,7 @@ class ProjectNode:
     project_name: str = strawberry.field()
     code: str = strawberry.field()
     attrib: ProjectAttribType
+    data: str | None
     active: bool
     library: bool
     created_at: datetime
@@ -195,6 +197,7 @@ class ProjectNode:
 
 def project_from_record(record: dict, context: dict) -> ProjectNode:
     """Construct a project node from a DB row."""
+    data = record.get("data", {})
     return ProjectNode(
         name=record["name"],
         code=record["code"],
@@ -207,6 +210,7 @@ def project_from_record(record: dict, context: dict) -> ProjectNode:
             user=context["user"],
             project_name=record["name"],
         ),
+        data=json_dumps(data) if data else None,
         created_at=record["created_at"],
         updated_at=record["updated_at"],
     )

--- a/ayon_server/graphql/nodes/representation.py
+++ b/ayon_server/graphql/nodes/representation.py
@@ -57,6 +57,7 @@ class RepresentationNode(BaseNode):
     status: str
     tags: list[str]
     attrib: RepresentationAttribType
+    data: str | None
 
     # GraphQL specifics
 
@@ -116,6 +117,7 @@ def representation_from_record(
             user=context["user"],
             project_name=project_name,
         ),
+        data=json_dumps(data) if data else None,
         active=record["active"],
         created_at=record["created_at"],
         updated_at=record["updated_at"],

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -9,7 +9,7 @@ from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.resolvers.versions import get_versions
 from ayon_server.graphql.resolvers.workfiles import get_workfiles
 from ayon_server.graphql.utils import parse_attrib_data
-from ayon_server.utils import get_nickname
+from ayon_server.utils import get_nickname, json_dumps
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import VersionsConnection, WorkfilesConnection
@@ -34,6 +34,7 @@ class TaskNode(BaseNode):
     status: str
     tags: list[str]
     attrib: TaskAttribType
+    data: str | None
     own_attrib: list[str]
 
     # GraphQL specifics
@@ -96,6 +97,7 @@ def task_from_record(project_name: str, record: dict, context: dict) -> TaskNode
         assignees = record["assignees"]
 
     own_attrib = list(record["attrib"].keys())
+    data = record.get("data", {})
 
     return TaskNode(
         project_name=project_name,
@@ -114,6 +116,7 @@ def task_from_record(project_name: str, record: dict, context: dict) -> TaskNode
             project_name=project_name,
             inherited_attrib=record["parent_folder_attrib"],
         ),
+        data=json_dumps(data) if data else None,
         active=record["active"],
         created_at=record["created_at"],
         updated_at=record["updated_at"],

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -8,7 +8,7 @@ from ayon_server.entities import VersionEntity
 from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.resolvers.representations import get_representations
 from ayon_server.graphql.utils import parse_attrib_data
-from ayon_server.utils import get_nickname
+from ayon_server.utils import get_nickname, json_dumps
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import RepresentationsConnection
@@ -34,6 +34,7 @@ class VersionNode(BaseNode):
     author: str | None
     status: str
     attrib: VersionAttribType
+    data: str | None
     tags: list[str]
 
     # GraphQL specifics
@@ -83,6 +84,8 @@ def version_from_record(project_name: str, record: dict, context: dict) -> Versi
     if current_user.is_guest and author is not None:
         author = get_nickname(author)
 
+    data = record.get("data", {})
+
     return VersionNode(  # type: ignore
         project_name=project_name,
         id=record["id"],
@@ -100,6 +103,7 @@ def version_from_record(project_name: str, record: dict, context: dict) -> Versi
             user=context["user"],
             project_name=project_name,
         ),
+        data=json_dumps(data) if data else None,
         created_at=record["created_at"],
         updated_at=record["updated_at"],
     )

--- a/ayon_server/graphql/nodes/workfile.py
+++ b/ayon_server/graphql/nodes/workfile.py
@@ -8,6 +8,7 @@ from strawberry.types import Info
 from ayon_server.entities import WorkfileEntity
 from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.utils import parse_attrib_data
+from ayon_server.utils import json_dumps
 
 if TYPE_CHECKING:
     from ayon_server.graphql.nodes.task import TaskNode
@@ -54,6 +55,8 @@ def workfile_from_record(
 ) -> WorkfileNode:
     """Construct a version node from a DB row."""
 
+    data = record.get("data", {})
+
     return WorkfileNode(  # type: ignore
         project_name=project_name,
         id=record["id"],
@@ -71,6 +74,7 @@ def workfile_from_record(
             user=context["user"],
             project_name=project_name,
         ),
+        data=json_dumps(data) if data else None,
         created_at=record["created_at"],
         updated_at=record["updated_at"],
     )

--- a/ayon_server/graphql/resolvers/events.py
+++ b/ayon_server/graphql/resolvers/events.py
@@ -124,6 +124,8 @@ async def get_events(
     )
     sql_conditions.extend(paging_conds)
 
+    # TODO: select data only when needed
+
     query = f"""
         SELECT {cursor}, * FROM events
         {SQLTool.conditions(sql_conditions)}

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -106,6 +106,7 @@ async def get_folders(
         "folders.created_at AS created_at",
         "folders.updated_at AS updated_at",
         "folders.creation_order AS creation_order",
+        "folders.data AS data",
         "pr.attrib AS project_attributes",
         "ex.attrib AS inherited_attributes",
     ]

--- a/ayon_server/graphql/resolvers/projects.py
+++ b/ayon_server/graphql/resolvers/projects.py
@@ -10,6 +10,7 @@ from ayon_server.graphql.resolvers.common import (
     ARGBefore,
     ARGFirst,
     ARGLast,
+    FieldInfo,
     argdesc,
     create_pagination,
     resolve,
@@ -42,6 +43,21 @@ async def get_projects(
         validate_name(name)
         sql_conditions.append(f"projects.name ILIKE '{name}'")
 
+    fields = FieldInfo(info, ["projects.edges.node", "project"])
+
+    cols = [
+        "name",
+        "code",
+        "library",
+        "attrib",
+        "active",
+        "created_at",
+        "updated_at",
+    ]
+
+    if fields.has_any("data"):
+        cols.append("data")
+
     #
     # Pagination
     #
@@ -51,13 +67,15 @@ async def get_projects(
         order_by, first, after, last, before
     )
     sql_conditions.extend(paging_conds)
+    cols.append(cursor)
 
     #
     #
     #
 
     query = f"""
-        SELECT {cursor}, * FROM projects
+        SELECT {', '.join(cols)}
+        FROM projects
         {SQLTool.conditions(sql_conditions)}
         {pagination}
     """


### PR DESCRIPTION
`data` field can be queried using GraphQL and it is returned as a stringified JSON. it is also now available to normal users via rest for reading. 

Storing data is still reserved for managers+ and custom addon endpoints. Limiting data access similarly to attribute whitelist is not yet implemented (nor needed).