### PR TITLE
System addons mandatory in bundles

### DIFF
--- a/api/bundles/bundles.py
+++ b/api/bundles/bundles.py
@@ -245,6 +245,13 @@ async def create_new_bundle(
                 continue
             _ = AddonLibrary.addon(addon_name, addon_version)
 
+    for system_addon_name, addon_definition in AddonLibrary.items():
+        if addon_definition.is_system:
+            if system_addon_name not in bundle.addons:
+                raise BadRequestException(
+                    f"System addon {system_addon_name} is missing from bundle"
+                )
+
     await create_bundle(bundle, user, x_sender)
 
     return EmptyResponse(status_code=201)

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -29,7 +29,7 @@ class BaseServerAddon:
     site_settings_model: Type[BaseSettingsModel] | None = None
     frontend_scopes: dict[str, Any] = {}
     services: dict[str, Any] = {}
-    system: bool = False  # Hide settings for non-admins
+    system: bool = False  # Hide settings for non-admins and make the addon mandatory
 
     def __init__(self, definition: "ServerAddonDefinition", addon_dir: str):
         assert self.name and self.version

--- a/ayon_server/addons/definition.py
+++ b/ayon_server/addons/definition.py
@@ -99,6 +99,13 @@ class ServerAddonDefinition:
 
         return self._versions
 
+    @property
+    def is_system(self) -> bool:
+        for version in self.versions.values():
+            if version.system:
+                return True
+        return False
+
     def __getitem__(self, item) -> BaseServerAddon:
         return self.versions[item]
 


### PR DESCRIPTION
Addons have a `system` attribute - until now, we used this attribute only to hide it from the interface for guests. This PR repurposes this attribute so now, when an addon with `system=True` set is mandatory in bundles.

`[PUT] /api/bundles` does now allow creating a bundle without system addons included  - this is especially useful for authentication addons where not including it to a production bundle prevents users to log in, but it could be used for the core addon, subscriptions etc.

This does not ensure the addon is in the latest version - this should still be the responsibility of the administrator.