### PR TITLE
Add an option to load settings template from a mounted file

### DIFF
--- a/setup/__main__.py
+++ b/setup/__main__.py
@@ -102,6 +102,8 @@ async def main(force: bool | None = None) -> None:
                 data: dict[str, Any] = json_loads(raw_data)
             except Exception:
                 logging.warning("Invalid setup file provided. Using defaults")
+            else:
+                logging.debug("Setting up from /template.json")
         else:
             logging.warning("No setup file provided. Using defaults")
 

--- a/setup/__main__.py
+++ b/setup/__main__.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -95,6 +96,12 @@ async def main(force: bool | None = None) -> None:
                 critical_error("Invalid setup file provided")
 
             DATA.update(data)
+        elif os.path.exists("/template.json"):
+            try:
+                raw_data = Path("/template.json").read_text()
+                data: dict[str, Any] = json_loads(raw_data)
+            except Exception:
+                logging.warning("Invalid setup file provided. Using defaults")
         else:
             logging.warning("No setup file provided. Using defaults")
 


### PR DESCRIPTION
Providing settings template was only possible using stdin, now the setup script attempts to load the template from well-known `/template.json` file as well, so it possible to provide basic settings using a mounted volume.