### PR TITLE
Return target entity type on entities resolved from URI

### DIFF
--- a/api/resolve/__init__.py
+++ b/api/resolve/__init__.py
@@ -73,6 +73,11 @@ class ResolvedEntityModel(OPModel):
         description="Path to the file if a representation is specified",
         example="/path/to/file.ma",
     )
+    target: ProjectLevelEntityType | None = Field(
+        None,
+        title="Target entity type",
+        description="The deepest entity type queried",
+    )
 
 
 class ResolvedURIModel(OPModel):
@@ -320,8 +325,6 @@ async def resolve_entities(
 
     query += " LIMIT 1000"
 
-    _ = target_entity_type
-
     statement = await conn.prepare(query)
     async for row in statement.cursor():
         file_path = None
@@ -342,6 +345,7 @@ async def resolve_entities(
             ResolvedEntityModel(
                 project_name=req.project_name,
                 file_path=file_path,
+                target=target_entity_type,
                 **row,
             )
         )


### PR DESCRIPTION
Entities item now contains `target` field, which specifies the deepest entity type specified in the URI.

This may be used to determine, what was selected without prior knowledge of the data model.

```json
[
    {
        "uri": "ayon://demo_Commercial/assets/environments/00_sqionguoks?product=setdressMain&version=v004",
        "entities": [
            {
                "projectName": "demo_Commercial",
                "folderId": "b0790c9e4c9911eeb6d40242ac140004",
                "productId": "b07a1ba24c9911eeb6d40242ac140004",
                "versionId": "b07ad3ee4c9911eeb6d40242ac140004",
                "target": "version"
            }
        ]
    }
]
```
