### PR TITLE
Task thumbnails

### DIFF
--- a/api/thumbnails/thumbnails.py
+++ b/api/thumbnails/thumbnails.py
@@ -63,10 +63,10 @@ async def store_thumbnail(
         DO UPDATE SET data = EXCLUDED.data
         RETURNING id
     """
-    await Postgres.execute(query, thumbnail_id, mime, payload)
     for entity_type in ["workfiles", "versions", "folders", "tasks"]:
         async with Postgres.acquire() as conn:
             async with conn.transaction():
+                await conn.execute(query, thumbnail_id, mime, payload)
                 await conn.execute(
                     f"""
                     UPDATE project_{project_name}.{entity_type}

--- a/api/thumbnails/thumbnails.py
+++ b/api/thumbnails/thumbnails.py
@@ -63,10 +63,10 @@ async def store_thumbnail(
         DO UPDATE SET data = EXCLUDED.data
         RETURNING id
     """
-    for entity_type in ["workfiles", "versions", "folders", "tasks"]:
-        async with Postgres.acquire() as conn:
-            async with conn.transaction():
-                await conn.execute(query, thumbnail_id, mime, payload)
+    async with Postgres.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(query, thumbnail_id, mime, payload)
+            for entity_type in ["workfiles", "versions", "folders", "tasks"]:
                 await conn.execute(
                     f"""
                     UPDATE project_{project_name}.{entity_type}

--- a/api/thumbnails/thumbnails.py
+++ b/api/thumbnails/thumbnails.py
@@ -6,6 +6,7 @@ from ayon_server.api.dependencies import (
     CurrentUser,
     FolderID,
     ProjectName,
+    TaskID,
     ThumbnailContentType,
     ThumbnailID,
     VersionID,
@@ -13,6 +14,7 @@ from ayon_server.api.dependencies import (
 )
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.entities.folder import FolderEntity
+from ayon_server.entities.task import TaskEntity
 from ayon_server.entities.version import VersionEntity
 from ayon_server.entities.workfile import WorkfileEntity
 from ayon_server.exceptions import (
@@ -301,3 +303,46 @@ async def get_workfile_thumbnail(
     except AyonException:
         return get_fake_thumbnail()
     return await retrieve_thumbnail(project_name, workfile.thumbnail_id)
+
+
+#
+# Task endpoints
+#
+
+
+@router.post("/projects/{project_name}/tasks/{task_id}/thumbnail", status_code=201)
+async def create_task_thumbnail(
+    request: Request,
+    user: CurrentUser,
+    project_name: ProjectName,
+    task_id: TaskID,
+    content_type: ThumbnailContentType,
+) -> CreateThumbnailResponseModel:
+    payload = await request.body()
+    task = await TaskEntity.load(project_name, task_id)
+    await task.ensure_update_access(user)
+
+    thumbnail_id = EntityID.create()
+    await store_thumbnail(
+        project_name=project_name,
+        thumbnail_id=thumbnail_id,
+        mime=content_type,
+        payload=payload,
+    )
+    task.thumbnail_id = thumbnail_id
+    await task.save()
+    return CreateThumbnailResponseModel(id=thumbnail_id)
+
+
+@router.get(
+    "/projects/{project_name}/tasks/{task_id}/thumbnail",
+)
+async def get_task_thumbnail(
+    user: CurrentUser, project_name: ProjectName, task_id: TaskID
+) -> Response:
+    try:
+        task = await TaskEntity.load(project_name, task_id)
+        await task.ensure_read_access(user)
+    except AyonException:
+        return get_fake_thumbnail()
+    return await retrieve_thumbnail(project_name, task.thumbnail_id)

--- a/api/thumbnails/thumbnails.py
+++ b/api/thumbnails/thumbnails.py
@@ -64,10 +64,10 @@ async def store_thumbnail(
         RETURNING id
     """
     await Postgres.execute(query, thumbnail_id, mime, payload)
-    for entity_type in ["workfiles", "versions", "folders"]:
+    for entity_type in ["workfiles", "versions", "folders", "tasks"]:
         async with Postgres.acquire() as conn:
             async with conn.transaction():
-                conn.execute(
+                await conn.execute(
                     f"""
                     UPDATE project_{project_name}.{entity_type}
                     SET updated_at = NOW() WHERE thumbnail_id = $1

--- a/ayon_server/entities/models/fields.py
+++ b/ayon_server/entities/models/fields.py
@@ -175,6 +175,14 @@ task_fields = [
         "example": "Modeling",
     },
     {
+        "name": "thumbnail_id",
+        "type": "string",
+        "title": "Thumbnail ID",
+        "required": False,
+        "regex": ENTITY_ID_REGEX,
+        "example": ENTITY_ID_EXAMPLE,
+    },
+    {
         "name": "assignees",
         "type": "list_of_strings",
         "title": "Assignees",

--- a/ayon_server/entities/task.py
+++ b/ayon_server/entities/task.py
@@ -140,3 +140,11 @@ class TaskEntity(ProjectLevelEntity):
     @property
     def entity_subtype(self) -> str:
         return self.task_type
+
+    @property
+    def thumbnail_id(self) -> str | None:
+        return self._payload.thumbnail_id
+
+    @thumbnail_id.setter
+    def thumbnail_id(self, value: str) -> None:
+        self._payload.thumbnail_id = value

--- a/ayon_server/entities/task.py
+++ b/ayon_server/entities/task.py
@@ -37,6 +37,7 @@ class TaskEntity(ProjectLevelEntity):
                 t.name as name,
                 t.label as label,
                 t.task_type as task_type,
+                t.thumbnail_id as thumbnail_id,
                 t.assignees as assignees,
                 t.folder_id as folder_id,
                 t.attrib as attrib,

--- a/ayon_server/graphql/dataloaders/__init__.py
+++ b/ayon_server/graphql/dataloaders/__init__.py
@@ -110,6 +110,7 @@ async def task_loader(keys: list[KeyType]) -> list[dict | None]:
             tasks.label AS label,
             tasks.folder_id AS folder_id,
             tasks.task_type AS task_type,
+            tasks.thumbnail_id AS thumbnail_id,
             tasks.assignees AS assignees,
             tasks.attrib AS attrib,
             tasks.data AS data,

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -29,6 +29,7 @@ class TaskAttribType:
 class TaskNode(BaseNode):
     label: str | None
     task_type: str
+    task_id: str | None = None
     assignees: list[str]
     folder_id: str
     status: str
@@ -105,6 +106,7 @@ def task_from_record(project_name: str, record: dict, context: dict) -> TaskNode
         name=record["name"],
         label=record["label"],
         task_type=record["task_type"],
+        thumbnail_id=record["thumbnail_id"],
         assignees=assignees,
         folder_id=record["folder_id"],
         status=record["status"],

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -29,7 +29,7 @@ class TaskAttribType:
 class TaskNode(BaseNode):
     label: str | None
     task_type: str
-    task_id: str | None = None
+    thumbnail_id: str | None = None
     assignees: list[str]
     folder_id: str
     status: str

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -86,6 +86,7 @@ async def get_tasks(
         "tasks.label AS label",
         "tasks.folder_id AS folder_id",
         "tasks.task_type AS task_type",
+        "tasks.thumbnail_id AS thumbnail_id",
         "tasks.assignees AS assignees",
         "tasks.attrib AS attrib",
         "tasks.data AS data",

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -57,7 +57,7 @@ CREATE TABLE folders(
     attrib JSONB NOT NULL DEFAULT '{}'::JSONB,
     data JSONB NOT NULL DEFAULT '{}'::JSONB,
     status VARCHAR NOT NULL REFERENCES statuses(name) ON UPDATE CASCADE,
-    tags VARCHAR[] NOT NULL DEFAULT '{}',
+    tags VARCHAR[] NOT NULL DEFAULT ARRAY[]::VARCHAR[],
     active BOOLEAN NOT NULL DEFAULT TRUE,
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW(),
@@ -118,18 +118,18 @@ CREATE TABLE exported_attributes(
 
 CREATE TABLE tasks(
     id UUID NOT NULL PRIMARY KEY,
-
     name VARCHAR NOT NULL,
     label VARCHAR,
     folder_id UUID NOT NULL REFERENCES folders(id) ON DELETE CASCADE,
     task_type VARCHAR REFERENCES task_types(name) ON UPDATE CASCADE,
-    assignees VARCHAR[] NOT NULL DEFAULT '{}',
+    assignees VARCHAR[] NOT NULL DEFAULT ARRAY[]::VARCHAR[],
+    thumbnail_id UUID REFERENCES thumbnails(id) ON DELETE SET NULL,
 
     attrib JSONB NOT NULL DEFAULT '{}'::JSONB,
     data JSONB NOT NULL DEFAULT '{}'::JSONB,
     active BOOLEAN NOT NULL DEFAULT TRUE,
     status VARCHAR NOT NULL REFERENCES statuses(name) ON UPDATE CASCADE,
-    tags VARCHAR[] NOT NULL DEFAULT '{}',
+    tags VARCHAR[] NOT NULL DEFAULT ARRAY[]::VARCHAR[],
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW(),
     creation_order SERIAL NOT NULL
@@ -155,7 +155,7 @@ CREATE TABLE products(
     data JSONB NOT NULL DEFAULT '{}'::JSONB,
     active BOOLEAN NOT NULL DEFAULT TRUE,
     status VARCHAR NOT NULL REFERENCES statuses(name) ON UPDATE CASCADE,
-    tags VARCHAR[] NOT NULL DEFAULT '{}',
+    tags VARCHAR[] NOT NULL DEFAULT ARRAY[]::VARCHAR[],
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW(),
     creation_order SERIAL NOT NULL
@@ -183,7 +183,7 @@ CREATE TABLE versions(
     data JSONB NOT NULL DEFAULT '{}'::JSONB,
     active BOOLEAN NOT NULL DEFAULT TRUE,
     status VARCHAR NOT NULL REFERENCES statuses(name) ON UPDATE CASCADE,
-    tags VARCHAR[] NOT NULL DEFAULT '{}',
+    tags VARCHAR[] NOT NULL DEFAULT ARRAY[]::VARCHAR[],
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW(),
     creation_order SERIAL NOT NULL
@@ -223,7 +223,7 @@ CREATE TABLE representations(
     data JSONB NOT NULL DEFAULT '{}'::JSONB,
     active BOOLEAN NOT NULL DEFAULT TRUE,
     status VARCHAR NOT NULL REFERENCES statuses(name) ON UPDATE CASCADE,
-    tags VARCHAR[] NOT NULL DEFAULT '{}',
+    tags VARCHAR[] NOT NULL DEFAULT ARRAY[]::VARCHAR[],
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW(),
     creation_order SERIAL NOT NULL
@@ -251,7 +251,7 @@ CREATE TABLE workfiles(
     data JSONB NOT NULL DEFAULT '{}'::JSONB,
     active BOOLEAN NOT NULL DEFAULT TRUE,
     status VARCHAR NOT NULL REFERENCES statuses(name) ON UPDATE CASCADE,
-    tags VARCHAR[] NOT NULL DEFAULT '{}',
+    tags VARCHAR[] NOT NULL DEFAULT ARRAY[]::VARCHAR[],
     created_at TIMESTAMPTZ DEFAULT NOW(),
     updated_at TIMESTAMPTZ DEFAULT NOW(),
     creation_order SERIAL NOT NULL

--- a/schemas/schema.public.update.sql
+++ b/schemas/schema.public.update.sql
@@ -130,3 +130,29 @@ END $$;
 
 DROP TABLE IF EXISTS public.addon_versions; -- replaced by bundles
 DROP TABLE IF EXISTS public.dependency_packages; -- stored as json files
+
+---------------
+-- Ayon 0.6 --
+---------------
+
+-- To every project project schema, add thumbnail_id column to tasks table
+-- and create a foreign key constraint to the thumbnails table
+
+CREATE OR REPLACE FUNCTION add_thumbnail_id_to_tasks () 
+   RETURNS VOID  AS
+   $$
+   DECLARE rec RECORD; 
+   BEGIN
+        FOR rec IN select distinct nspname from pg_namespace where nspname like 'project_%'  
+        LOOP
+             EXECUTE 
+              'ALTER TABLE IF EXISTS ' || rec.nspname || '.tasks ' || 
+              'ADD COLUMN IF NOT EXISTS thumbnail_id UUID ' ||
+              'REFERENCES ' || rec.nspname || '.thumbnails(id) ON DELETE SET NULL';
+        END LOOP; 
+        RETURN; 
+   END;
+   $$ LANGUAGE plpgsql;
+
+SELECT add_thumbnail_id_to_tasks();
+DROP FUNCTION IF EXISTS add_thumbnail_id_to_tasks();


### PR DESCRIPTION
Add thumbnails support for tasks using the same mechanism as in folders, versions and workfiles.

Setup automatically adds thumbnail_id column to all existing projects if it does not exist, so this update does not break anything.

Testing:
- Switching to this version should run the update script when container starts, which adds the thumbnail_id column. You can check that using `SELECT thumbnail_id FROM  project_PROJECTNAME.tasks;`

- It also exposes task.thumbnailId property in graphql and rest. If something is wrong, would break.