### PR TITLE
Renamed staging_directories to staging_dir

### DIFF
--- a/ayon_server/settings/anatomy/templates.py
+++ b/ayon_server/settings/anatomy/templates.py
@@ -147,12 +147,12 @@ class Templates(BaseSettingsModel):
         title="Others",
     )
 
-    staging_directories: list[StagingDirectory] = Field(
+    staging_dir: list[StagingDirectory] = Field(
         default_factory=list,
         title="Staging directories",
     )
 
-    @validator("work", "publish", "hero", "delivery", "others", "staging_directories")
+    @validator("work", "publish", "hero", "delivery", "others", "staging_dir")
     def validate_template_group(cls, value):
         ensure_unique_names(value)
         return value


### PR DESCRIPTION
Warning! This change is not backward compatible. Previously saved staging_directories will be lost from anatomy presets as well as existing projects. 

Validators don't have access to raw data used to initialize the model, so we cannot pick the original staging_directories field and use it in `pre` validator.