### PR TITLE
More options for settings enum resolvers

### DIFF
--- a/api/addons/project_settings.py
+++ b/api/addons/project_settings.py
@@ -53,6 +53,7 @@ async def get_addon_project_settings_schema(
         "project_name": project_name,
         "site_id": site,
         "user_name": user.name,
+        "addon": addon,
     }
 
     schema = copy.deepcopy(model.schema())

--- a/api/addons/project_settings.py
+++ b/api/addons/project_settings.py
@@ -36,6 +36,7 @@ async def get_addon_project_settings_schema(
     version: str,
     project_name: ProjectName,
     user: CurrentUser,
+    variant: str = Query("production"),
     site: str | None = Query(None, regex="^[a-z0-9-]+$"),
 ) -> dict[str, Any]:
     """Return the JSON schema of the addon settings."""
@@ -50,10 +51,11 @@ async def get_addon_project_settings_schema(
         return {}
 
     context = {
+        "addon": addon,
         "project_name": project_name,
+        "settings_variant": variant,
         "site_id": site,
         "user_name": user.name,
-        "addon": addon,
     }
 
     schema = copy.deepcopy(model.schema())

--- a/api/addons/site_settings.py
+++ b/api/addons/site_settings.py
@@ -32,8 +32,12 @@ async def get_addon_site_settings_schema(
         return {}
 
     schema = copy.deepcopy(model.schema())
+    context = {
+        "addon": addon,
+        "user_name": user.name,
+    }
 
-    await postprocess_settings_schema(schema, model)
+    await postprocess_settings_schema(schema, model, context=context)
     schema["title"] = addon.friendly_name
     return schema
 

--- a/api/addons/studio_settings.py
+++ b/api/addons/studio_settings.py
@@ -27,6 +27,7 @@ async def get_addon_settings_schema(
     addon_name: str,
     addon_version: str,
     user: CurrentUser,
+    variant: str = Query("production"),
 ) -> dict[str, Any]:
     """Return the JSON schema of the addon settings."""
 
@@ -40,6 +41,7 @@ async def get_addon_settings_schema(
 
     context = {
         "addon": addon,
+        "settings_variant": variant,
         "user_name": user.name,
     }
 

--- a/api/addons/studio_settings.py
+++ b/api/addons/studio_settings.py
@@ -38,8 +38,13 @@ async def get_addon_settings_schema(
     if model is None:
         return {}
 
+    context = {
+        "addon": addon,
+        "user_name": user.name,
+    }
+
     schema = copy.deepcopy(model.schema())
-    await postprocess_settings_schema(schema, model)
+    await postprocess_settings_schema(schema, model, context=context)
     schema["title"] = addon.friendly_name
     return schema
 

--- a/ayon_server/settings/enum.py
+++ b/ayon_server/settings/enum.py
@@ -1,10 +1,18 @@
-from ayon_server.exceptions import AyonException
 from ayon_server.lib.postgres import Postgres
+from ayon_server.settings.anatomy import Anatomy
+
+
+async def get_primary_anatomy_preset():
+    query = "SELECT * FROM anatomy_presets WHERE is_primary is TRUE"
+    async for row in Postgres.iterate(query):
+        return Anatomy(**row["data"])
+    return Anatomy()
 
 
 async def folder_types_enum(project_name: str | None = None):
     if project_name is None:
-        raise AyonException("Only available in project context")
+        anatomy = await get_primary_anatomy_preset()
+        return [folder_type.name for folder_type in anatomy.folder_types]
 
     return [
         row["name"]
@@ -20,7 +28,8 @@ async def folder_types_enum(project_name: str | None = None):
 
 async def task_types_enum(project_name: str | None = None):
     if project_name is None:
-        raise AyonException("Only available in project context")
+        anatomy = await get_primary_anatomy_preset()
+        return [task_type.name for task_type in anatomy.task_types]
 
     return [
         row["name"]

--- a/ayon_server/settings/postprocess.py
+++ b/ayon_server/settings/postprocess.py
@@ -29,12 +29,8 @@ async def process_enum(
 ) -> tuple[list[str], dict[str, str]]:
     if context is None:
         context = {}
-    # else:
-    #     ctx_data = copy.deepcopy(context)
 
     resolver_args = inspect.getfullargspec(enum_resolver).args
-    # available_keys = list(ctx_data.keys())
-    print("Keys: ", resolver_args)
 
     ctx_data = {}
     for key in resolver_args:
@@ -42,10 +38,6 @@ async def process_enum(
             ctx_data[key] = context[key]
         else:
             ctx_data[key] = None
-    # for key in available_keys:
-    #     if key not in resolver_args:
-    #         del ctx_data[key]
-    print("Context: ", ctx_data)
 
     if inspect.iscoroutinefunction(enum_resolver):
         enum = await enum_resolver(**ctx_data)
@@ -54,16 +46,17 @@ async def process_enum(
 
     enum_values = []
     enum_labels = {}
-    if type(enum) is list:
-        for item in enum:
-            if type(item) is str:
-                enum_values.append(item)
-            elif type(item) is dict:
-                if "value" not in item or "label" not in item:
-                    logging.warning(f"Invalid enumerator item: {item}")
-                    continue
-                enum_values.append(item["value"])
-                enum_labels[item["value"]] = item["label"]
+    if not isinstance(enum, list):
+        return [], []
+    for item in enum:
+        if type(item) is str:
+            enum_values.append(item)
+        elif type(item) is dict:
+            if "value" not in item or "label" not in item:
+                logging.warning(f"Invalid enumerator item: {item}")
+                continue
+            enum_values.append(item["value"])
+            enum_labels[item["value"]] = item["label"]
     return enum_values, enum_labels
 
 

--- a/ayon_server/settings/postprocess.py
+++ b/ayon_server/settings/postprocess.py
@@ -47,7 +47,7 @@ async def process_enum(
     enum_values = []
     enum_labels = {}
     if not isinstance(enum, list):
-        return [], []
+        return [], {}
     for item in enum:
         if type(item) is str:
             enum_values.append(item)

--- a/ayon_server/settings/postprocess.py
+++ b/ayon_server/settings/postprocess.py
@@ -1,5 +1,4 @@
 import collections
-import copy
 import inspect
 from typing import Any, Deque, Type
 
@@ -29,15 +28,24 @@ async def process_enum(
     context: dict[str, Any] | None = None,
 ) -> tuple[list[str], dict[str, str]]:
     if context is None:
-        ctx_data = {}
-    else:
-        ctx_data = copy.deepcopy(context)
+        context = {}
+    # else:
+    #     ctx_data = copy.deepcopy(context)
 
     resolver_args = inspect.getfullargspec(enum_resolver).args
-    available_keys = list(ctx_data.keys())
-    for key in available_keys:
-        if key not in resolver_args:
-            del ctx_data[key]
+    # available_keys = list(ctx_data.keys())
+    print("Keys: ", resolver_args)
+
+    ctx_data = {}
+    for key in resolver_args:
+        if key in context:
+            ctx_data[key] = context[key]
+        else:
+            ctx_data[key] = None
+    # for key in available_keys:
+    #     if key not in resolver_args:
+    #         del ctx_data[key]
+    print("Context: ", ctx_data)
 
     if inspect.iscoroutinefunction(enum_resolver):
         enum = await enum_resolver(**ctx_data)


### PR DESCRIPTION
Enum resolvers now can accept source addon itself and use its own settings


```python
async def recursive_enum_resolver(
    addon: "BaseServerAddon",
    settings_variant: str = "production",
    project_name: str | None = None,
) -> list[str]:
    if addon is None:
        return []

    if project_name:
        settings = await addon.get_project_settings(project_name=project_name, variant=settings_variant)
    else:
        settings = await addon.get_studio_settings(variant=settings_variant)

    return settings.list_of_strings
```

Additionally resolvers accept `settings_variant` field (defaults to production, requires the latest develop frontend ) and built-in `folder_types_enum` and `task_types_enum` now return folder/task types from the primary anatomy preset, when invoked from studio settings.