### PR TITLE
Auto add system addons to bundles

### DIFF
--- a/api/bundles/bundles.py
+++ b/api/bundles/bundles.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 from fastapi import Header, Query
+from nxtools import logging
 
 from ayon_server.addons import AddonLibrary
 from ayon_server.api.dependencies import CurrentUser
@@ -247,9 +248,10 @@ async def create_new_bundle(
     for system_addon_name, addon_definition in AddonLibrary.items():
         if addon_definition.is_system:
             if system_addon_name not in bundle.addons:
-                raise BadRequestException(
-                    f"System addon {system_addon_name} is missing from bundle"
+                logging.debug(
+                    f"Adding missing system addon {system_addon_name} to bundle {bundle.name}"
                 )
+                bundle.addons[system_addon_name] = addon_definition.latest.version
 
     await create_bundle(bundle, user, x_sender)
 

--- a/ayon_server/addons/definition.py
+++ b/ayon_server/addons/definition.py
@@ -1,6 +1,7 @@
 import os
 from typing import TYPE_CHECKING
 
+import semver
 from nxtools import logging, slugify
 
 from ayon_server.addons.addon import BaseServerAddon
@@ -98,6 +99,14 @@ class ServerAddonDefinition:
                         self.restart_requested = True
 
         return self._versions
+
+    @property
+    def latest(self) -> BaseServerAddon | None:
+        if not self.versions:
+            return None
+        versions = list(self.versions.keys())
+        max_version = max(versions, key=semver.VersionInfo.parse)
+        return self.versions[max_version]
 
     @property
     def is_system(self) -> bool:


### PR DESCRIPTION
system addons must be present in all bundles. Previously an error was raised if an addon was not provided, which didn't work with re-bootstrapping properly. So now we add the latest version of the addon automatically. 