### PR TITLE
Display addons with broken settings in the addon list

### DIFF
--- a/api/settings/settings.py
+++ b/api/settings/settings.py
@@ -1,3 +1,4 @@
+import traceback
 from typing import Any
 
 from fastapi import Query
@@ -177,8 +178,20 @@ async def get_all_settings(
                 settings = await addon.get_studio_settings(variant)
 
         except Exception:
-            log_traceback(
-                "fUnable to load settings of {addon_name} {addon_version}. Skipping."
+            log_traceback(f"Unable to load {addon_name} {addon_version} settings")
+            addon_result.append(
+                AddonSettingsItemModel(
+                    name=addon_name,
+                    title=addon_name,
+                    version=addon_version,
+                    settings={},
+                    site_settings=None,
+                    is_broken=True,
+                    reason={
+                        "error": "Unable to load settings",
+                        "traceback": traceback.format_exc(),
+                    },
+                )
             )
             continue
 


### PR DESCRIPTION
![image](https://github.com/ynput/ayon-backend/assets/5007200/64a7be1c-dc52-4a7e-bcb5-89327c963a41)

Addons with broken settings (for example because of incompatible model) are now listed in settings addon list in red (similarly to unloaded addons), so it is possible to use low-level settings editor to repair them. /api/settings also provide a full traceback in that case (to display it in the UX)