### PR TITLE
Custom link names

### DIFF
--- a/api/links/links.py
+++ b/api/links/links.py
@@ -192,7 +192,7 @@ async def create_entity_link(
             INSERT INTO project_{project_name}.links
                 (id, name, input_id, output_id, link_type, author, data)
             VALUES
-                ($1, $2, $3, $4, $5)
+                ($1, $2, $3, $4, $5, $6, $7)
             """,
             link_id,
             post_data.name,

--- a/api/links/links.py
+++ b/api/links/links.py
@@ -133,7 +133,11 @@ class CreateLinkRequestModel(OPModel):
         description="Link type to create. This is deprecated. Use linkType instead.",
         example="reference|folder|version",
     )
-    link_type: str | None = Field(None, description="Link type to create.")
+    link_type: str | None = Field(
+        None,
+        description="Link type to create.",
+        example="reference|folder|version",
+    )
     data: dict[str, Any] = Field(default_factory=dict, description="Link data")
 
 

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -66,7 +66,9 @@ class BaseNode:
         self,
         info: Info,
         direction: str | None = None,
-        link_types: list[str] = [],
+        link_types: list[str] | None = None,
+        names: list[str] | None = None,
+        name_ex: str | None = None,
         first: int = 100,
         after: str | None = None,
     ) -> LinksConnection:
@@ -76,6 +78,8 @@ class BaseNode:
             info=info,
             direction=direction,
             link_types=link_types,
+            names=names,
+            name_ex=name_ex,
             first=first,
             after=after,
         )

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -19,6 +19,7 @@ class LinkEdge(BaseEdge):
     project_name: str = strawberry.field()
     entity_type: str = strawberry.field()
     entity_id: str = strawberry.field()
+    name: str | None = strawberry.field(default=None)
     link_type: str = strawberry.field(default="something")
     direction: str = strawberry.field(default="in")
     description: str = strawberry.field(default="")

--- a/ayon_server/graphql/resolvers/links.py
+++ b/ayon_server/graphql/resolvers/links.py
@@ -30,15 +30,15 @@ async def get_links(
 
     type_conditions = []
     for lt in link_types:
-        type_conditions.append(f"link_name LIKE '{lt}|%'")
+        type_conditions.append(f"link_type LIKE '{lt}|%'")
     if type_conditions:
         sql_conditions.append(f"({' or '.join(type_conditions)})")
 
     if after is not None and after.isdigit():
-        sql_conditions.append(f"id > {after}")
+        sql_conditions.append(f"creation_order > {after}")
 
     query = f"""
-        SELECT id, input_id, output_id, link_name, data, created_at
+        SELECT id, name, input_id, output_id, link_type, author, data, created_at
         FROM project_{project_name}.links
         {SQLTool.conditions(sql_conditions)}
         ORDER BY creation_order
@@ -49,7 +49,7 @@ async def get_links(
         if first <= len(edges):
             break
 
-        link_type, input_type, output_type = row["link_name"].split("|")
+        link_type, input_type, output_type = row["link_type"].split("|")
         input_id = row["input_id"]
         output_id = row["output_id"]
         link_id = row["id"]
@@ -74,10 +74,11 @@ async def get_links(
                 direction=direction,
                 entity_id=entity_id,
                 entity_type=entity_type,
+                name=row["name"],
                 link_type=link_type,
                 cursor=link_id,
                 description=description,
-                author=row["data"].get("author"),
+                author=row["author"],
             )
         )
 

--- a/ayon_server/graphql/resolvers/links.py
+++ b/ayon_server/graphql/resolvers/links.py
@@ -22,10 +22,6 @@ async def get_links(
 
     edges: list[LinkEdge] = []
 
-    print("names", names)
-    print("name_ex", name_ex)
-    print("link_types", link_types)
-
     sql_conditions = []
     if direction == "in":
         sql_conditions.append(f"output_id = '{root.id}'")
@@ -49,8 +45,6 @@ async def get_links(
 
     if name_ex is not None:
         sql_conditions.append(f"name ~ '{name_ex}'")
-
-    print(sql_conditions)
 
     query = f"""
         SELECT id, name, input_id, output_id, link_type, author, data, created_at

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -110,7 +110,7 @@ async def get_versions(
             return VersionsConnection()
         sql_conditions.append(f"versions.id IN {SQLTool.id_array(ids)}")
     if version:
-        sql_conditions.append(f"version.version = {version}")
+        sql_conditions.append(f"versions.version = {version}")
     if versions is not None:
         if not versions:
             return VersionsConnection()

--- a/linker/__main__.py
+++ b/linker/__main__.py
@@ -8,8 +8,8 @@ from ayon_server.lib.postgres import Postgres
 from linker.linker import make_links
 
 
-async def create_link_type(project_name: str, link_type_name: str) -> None:
-    link_type, input_type, output_type = link_type_name.split("|")
+async def create_link_type(project_name: str, link_type: str) -> None:
+    link_type_name, input_type, output_type = link_type.split("|")
     await Postgres.execute(
         f"""
         INSERT INTO project_{project_name}.link_types
@@ -17,10 +17,10 @@ async def create_link_type(project_name: str, link_type_name: str) -> None:
         VALUES
             ($1, $2, $3, $4)
         """,
-        link_type_name,
+        link_type,
         input_type,
         output_type,
-        link_type,
+        link_type_name,
     )
 
 

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -269,9 +269,11 @@ CREATE UNIQUE INDEX link_type_unique_idx ON link_types(input_type, output_type, 
 
 CREATE TABLE links (
     id UUID NOT NULL PRIMARY KEY,
+    name VARCHAR,
+    link_type VARCHAR NOT NULL REFERENCES link_types(name) ON DELETE CASCADE,
     input_id UUID NOT NULL,
     output_id UUID NOT NULL,
-    link_name VARCHAR NOT NULL REFERENCES link_types(name) ON DELETE CASCADE,
+    author VARCHAR, -- REFERENCES public.users(name) ON UPDATE CASCADE ON DELETE SET NULL,
     data JSONB NOT NULL DEFAULT '{}'::JSONB,
     created_at TIMESTAMPTZ DEFAULT NOW(),
     creation_order SERIAL NOT NULL

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -282,7 +282,6 @@ CREATE TABLE links (
 CREATE INDEX link_input_idx ON links(input_id);
 CREATE INDEX link_output_idx ON links(output_id);
 CREATE UNIQUE INDEX link_creation_order_idx ON links(creation_order);
-CREATE UNIQUE INDEX link_unique_idx ON links(input_id, output_id, link_name);
 
 --------------
 -- SETTINGS --


### PR DESCRIPTION
link table is changed to contain a custom `name` field.

The name is nullable and it may be used to use an integration-specific identifier. Links of the same type no longer need to be unique.

On the database level, the following has changed:

- Renamed `link_name`  to `link_type`
- Added `name`  column 
- Moving `author`  from `data` to its own column
- Remove `link_unique_IDX` 

API-wise, this PR should be 100% backward compatible, but `link` field in `[POST] /api/{project_name}/links` is now deprecated. Instead, please use `link_type` (for now, both may be used).

Graphql and rest both expose new optional `name` field.

### Testing

This PR is now in `ayon:experimental` image. In order to migrate existing projects to the new schema, the container must start (reloading only won't trigger the migration script).

If you restore an older project, restart the container afterward, so it is converted as well - projects with older schemas should work, only links will be broken.

link types weren't changed in any way.