### PR TITLE
Handle postgres exceptions directly

### DIFF
--- a/ayon_server/api/postgres_exceptions.py
+++ b/ayon_server/api/postgres_exceptions.py
@@ -1,0 +1,66 @@
+import re
+
+from asyncpg.exceptions import (
+    ForeignKeyViolationError,
+    IntegrityConstraintViolationError,
+    NotNullViolationError,
+    UniqueViolationError,
+)
+
+
+def parse_posgres_exception(exc: IntegrityConstraintViolationError):
+
+    if isinstance(exc, NotNullViolationError):
+        return {
+            "detail": f"Missing required field: {exc.column_name}",
+            "status_code": 400,
+        }
+
+    elif isinstance(exc, ForeignKeyViolationError):
+        pg_detail = exc.detail
+
+        # exctract field name and tail from pg_detail
+
+        m = re.match(
+            r"Key \((?P<field>.*)\)=\((?P<value>.*)\) (?P<tail>.*)",
+            pg_detail,
+        )
+        if m is None:
+            detail = exc.message
+        else:
+            field = m.group("field")
+            value = m.group("value")
+            tail = m.group("tail")
+            detail = f"{field} '{value}' {tail}"
+        return {
+            "detail": detail,
+            "code": 409,
+        }
+
+        return {
+            "detail": f"Invalid foreign key: {exc.constraint_name}",
+            "code": 400,
+        }
+
+    elif isinstance(exc, UniqueViolationError):
+        pg_detail = exc.detail
+        # exctract field name and value from pg_detail
+
+        m = re.match(
+            r"Key \((?P<field>.*)\)=\((?P<value>.*)\) already exists.", pg_detail
+        )
+        if m is None:
+            detail = "Unique constraint violation."
+        else:
+            record_type = exc.table_name.rstrip("s").capitalize()
+            detail = f"{record_type} with {m.group('field')} '{m.group('value')}' already exists."
+
+        return {
+            "detail": detail,
+            "code": 409,
+        }
+
+    return {
+        "detail": exc.message,
+        "code": 500,
+    }

--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -16,6 +16,10 @@ from ayon_server.access.access_groups import AccessGroups
 from ayon_server.addons import AddonLibrary
 from ayon_server.api.messaging import Messaging
 from ayon_server.api.metadata import app_meta, tags_meta
+from ayon_server.api.postgres_exceptions import (
+    IntegrityConstraintViolationError,
+    parse_posgres_exception,
+)
 from ayon_server.api.responses import ErrorResponse
 from ayon_server.auth.session import Session
 from ayon_server.background.workers import background_workers
@@ -171,6 +175,28 @@ async def validation_exception_handler(
         status_code=400,
         content=ErrorResponse(code=400, detail=detail).dict(),
     )
+
+
+@app.exception_handler(IntegrityConstraintViolationError)
+async def integrity_constraint_violation_error_handler(
+    request: fastapi.Request,
+    exc: IntegrityConstraintViolationError,
+) -> fastapi.responses.JSONResponse:
+    path = f"[{request.method.upper()}]"
+    path += f" {request.url.path.removeprefix('/api')}"
+
+    tb = traceback.extract_tb(exc.__traceback__)
+    fname, line_no, func, _ = tb[-1]
+
+    payload = {
+        "path": path,
+        "file": fname,
+        "function": func,
+        "line": line_no,
+        **parse_posgres_exception(exc),
+    }
+
+    return fastapi.responses.JSONResponse(status_code=payload["code"], content=payload)
 
 
 @app.exception_handler(AssertionError)


### PR DESCRIPTION
Added exception handler for Postgresql exceptions, so catching them in the endpoints is no longer needed (when the request should fail). Handler does its best to format the exception to human-readable description returned in response detail.

This should avoid passing cryptic unhandled postgres to users.

![image](https://github.com/ynput/ayon-backend/assets/5007200/dcc7bb49-ce9a-4a3f-a4a6-ab0db879e444)
