### PR TITLE
Addon type attribute

### DIFF
--- a/api/addons/__init__.py
+++ b/api/addons/__init__.py
@@ -1,9 +1,8 @@
 from typing import Any, Literal
 
+import semver
 from fastapi import Query, Request, Response
 from nxtools import logging
-
-import semver
 
 from ayon_server.addons import AddonLibrary
 from ayon_server.addons.models import SourceInfo

--- a/api/addons/__init__.py
+++ b/api/addons/__init__.py
@@ -3,6 +3,8 @@ from typing import Any, Literal
 from fastapi import Query, Request, Response
 from nxtools import logging
 
+import semver
+
 from ayon_server.addons import AddonLibrary
 from ayon_server.addons.models import SourceInfo
 from ayon_server.api.dependencies import CurrentUser
@@ -74,14 +76,13 @@ async def list_addons(
     # maybe some ttl here?
     active_versions = await library.get_active_versions()
 
-    # TODO: for each version, return the information
-    # whether it has settings (and don't show the addon in the settings editor if not)
-
-    for _name, definition in library.data.items():
+    for definition in library.data.values():
         vers = active_versions.get(definition.name, {})
         versions = {}
         is_system = False
-        for version, addon in definition.versions.items():
+        items = list(definition.versions.items())
+        items.sort(key=lambda x: semver.VersionInfo.parse(x[0]))
+        for version, addon in items:
             if addon.system:
                 if not user.is_admin:
                     continue
@@ -134,16 +135,6 @@ async def list_addons(
 AddonEnvironment = Literal["production", "staging"]
 
 
-def semver_sort_key(item):
-    parts = item.split(".")
-    for i in range(len(parts)):
-        if not parts[i].isdigit():
-            parts[i:] = ["".join(parts[i:])]
-            break
-    parts = [int(part) if part.isdigit() else part for part in parts]
-    return parts
-
-
 async def copy_addon_variant(
     addon_name: str,
     copy_from: AddonEnvironment,
@@ -178,7 +169,7 @@ async def copy_addon_variant(
         source_settings.append({"addon_version": source_version, "data": {}})
 
     source_settings.sort(
-        key=lambda x: semver_sort_key(x["addon_version"]),
+        key=lambda x: semver.VersionInfo.parse(x["addon_version"]),
         reverse=True,
     )
 

--- a/api/addons/__init__.py
+++ b/api/addons/__init__.py
@@ -48,6 +48,9 @@ class AddonListItem(OPModel):
         None,
         description="Staging version of the addon",
     )
+    addon_type: Literal["server", "pipeline"] = Field(
+        ..., description="Type of the addon"
+    )
     system: bool | None = Field(None, description="Is the addon a system addon?")
 
 
@@ -116,6 +119,7 @@ async def list_addons(
                 production_version=vers.get("production"),
                 system=is_system or None,
                 staging_version=vers.get("staging"),
+                addon_type=addon.addon_type,
             )
         )
     result.sort(key=lambda x: x.name)

--- a/api/bundles/bundles.py
+++ b/api/bundles/bundles.py
@@ -84,7 +84,7 @@ class BundlePatchModel(BaseBundleModel):
     addons: dict[str, str | None] = Field(
         default_factory=dict,
         title="Addons",
-        description="Changing addons is available only for dev bundles",
+        description="Changing addons is available only for dev bundles or server addons",
         example={"ftrack": None, "kitsu": "1.2.3"},
     )
     installer_version: str | None = Field(None, example="1.2.3")
@@ -351,7 +351,16 @@ async def patch_bundle(
             if bundle.addons and orig_bundle.is_dev:
                 addon_dict = bundle.addons.copy()
             else:
+                # otherwise, we need to check if the addon is a server addon
+                # we cannot change a version of a pipeline addon
                 addon_dict = orig_bundle.addons.copy()
+                for key, value in bundle.addons.items():
+                    if AddonLibrary.get(key).addon_type != "server":
+                        continue
+                    if value is None:
+                        addon_dict.pop(key, None)
+                    elif isinstance(value, str):
+                        addon_dict[key] = value
             orig_bundle.addons = addon_dict
 
             data = {**orig_bundle.dict(exclude_none=True)}

--- a/api/services/services.py
+++ b/api/services/services.py
@@ -20,6 +20,7 @@ class ServiceConfigModel(OPModel):
     mem_limit: str | None = Field(None, title="Memory Limit", example="1g")
     user: str | None = Field(None, title="User", example="1000")
     env: dict[str, Any] = Field(default_factory=dict)
+    storage_path: str | None = Field(None, title="Storage", example="/mnt/storage")
 
 
 class ServiceDataModel(ServiceConfigModel):

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -5,7 +5,7 @@ try:
 except ModuleNotFoundError:
     toml = None  # type: ignore
 
-from typing import TYPE_CHECKING, Any, Callable, Type
+from typing import TYPE_CHECKING, Any, Callable, Literal, Type
 
 from nxtools import logging
 
@@ -33,6 +33,7 @@ class BaseServerAddon:
     services: dict[str, Any] = {}
 
     # should be defined on addon class
+    addon_type: Literal["server", "pipeline"] = "pipeline"
     system: bool = False  # Hide settings for non-admins and make the addon mandatory
     settings_model: Type[BaseSettingsModel] | None = None
     site_settings_model: Type[BaseSettingsModel] | None = None

--- a/ayon_server/addons/definition.py
+++ b/ayon_server/addons/definition.py
@@ -202,6 +202,16 @@ class ServerAddonDefinition:
                 return True
         return False
 
+    @property
+    def addon_type(self) -> str:
+        sorted_versions = sorted(
+            self.versions.values(),
+            key=lambda x: semver.VersionInfo.parse(x.version),
+        )
+        if not sorted_versions:
+            return "pipeline"
+        return sorted_versions[-1].addon_type
+
     def __getitem__(self, item) -> BaseServerAddon:
         return self.versions[item]
 


### PR DESCRIPTION
New addon type attribute defines, whether the addon has ('server') or does not have ('pipeline') a client part. As for 1.0.4, this will only be used to allow changing the addon version in an existing bundle. In the future a dedicated 'server' bundle independent from pipeline will be introduced to simplify updating server-only addons without touching the pipeline part.