### PR TITLE
Server-side restart_required handler

### DIFF
--- a/api/system/__init__.py
+++ b/api/system/__init__.py
@@ -1,10 +1,12 @@
-from fastapi import Depends, Response
+from fastapi import Response
 from nxtools import logging
 
-from ayon_server.api import dep_current_user
-from ayon_server.entities import UserEntity
+from ayon_server.api.dependencies import CurrentUser
+from ayon_server.api.system import clear_server_restart_required, require_server_restart
 from ayon_server.events import dispatch_event
 from ayon_server.exceptions import ForbiddenException
+from ayon_server.lib.postgres import Postgres
+from ayon_server.types import Field, OPModel
 
 from . import info, metrics, secrets, sites
 from .router import router
@@ -16,7 +18,7 @@ assert sites
 
 
 @router.post("/system/restart", response_class=Response, tags=["System"])
-async def request_server_restart(user: UserEntity = Depends(dep_current_user)):
+async def request_server_restart(user: CurrentUser):
     if not user.is_manager:
         raise ForbiddenException(
             "Only managers and administrators can restart the server"
@@ -28,3 +30,38 @@ async def request_server_restart(user: UserEntity = Depends(dep_current_user)):
     logging.info(f"{user.name} requested server restart", user=user.name)
     await dispatch_event("server.restart_requested", user=user.name)
     return Response(status_code=204)
+
+
+class RestartRequiredModel(OPModel):
+    required: bool = Field(..., description="Whether the server requires a restart")
+
+
+@router.get("/system/restartRequired", tags=["System"])
+async def get_restart_required() -> RestartRequiredModel:
+    # we ignore super new restart required events,
+    # because they might not be cleared yet.
+
+    await Postgres.fetch(
+        """
+        SELECT * FROM events
+        WHERE topic='server.restart_required'
+        AND created_at < now() - interval ' 2 seconds'
+        """
+    )
+
+    return RestartRequiredModel(required=False)
+
+
+@router.post("/system/restartRequired", tags=["System"])
+async def set_restart_required(
+    request: RestartRequiredModel,
+    user: CurrentUser,
+):
+    """Set the server restart required flag."""
+    if request.required:
+        await require_server_restart(user.name)
+    else:
+        await clear_server_restart_required()
+
+    if not user.is_admin:
+        raise ForbiddenException("Only administrators can set server restart required")

--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -21,6 +21,7 @@ from ayon_server.api.postgres_exceptions import (
     parse_posgres_exception,
 )
 from ayon_server.api.responses import ErrorResponse
+from ayon_server.api.system import clear_server_restart_required
 from ayon_server.auth.session import Session
 from ayon_server.background.workers import background_workers
 from ayon_server.config import ayonconfig
@@ -552,6 +553,8 @@ async def startup_event() -> None:
                 status="finished",
                 description="Server started",
             )
+
+        asyncio.create_task(clear_server_restart_required())
         logging.goodnews("Server is now ready to connect")
 
 

--- a/ayon_server/api/system.py
+++ b/ayon_server/api/system.py
@@ -3,13 +3,45 @@ import signal
 
 from nxtools import logging
 
+from ayon_server.events import dispatch_event
+from ayon_server.exceptions import ConstraintViolationException
+
 
 def restart_server():
-    """Force the server to restart."""
+    """Force the server to restart.
+
+    This is usually called from ayon_server.api.messaging,
+    when `server.restart_requested` event is triggered.
+    """
     logging.warning("Server is restarting")
 
-    # Send a SIGHUP to the parent process (gunicorn) to request a reload
+    # Send a SIGHUP to the parent process (gunicorn/granian) to request a reload
     # Gunicorn will restart the server when it receives this signal,
     # but it won't quit itself, so the container will keep running.
 
     os.kill(os.getppid(), signal.SIGHUP)
+
+
+async def require_server_restart(
+    user_name: str | None = None, description: str | None = None
+):
+    """Mark the server as requiring a restart.
+
+    This will notify the administrators that the server needs to be restarted.
+    When the server is ready to restart, the administrator can use
+    restart_server (using /api/system/restart) to trigger server.restart_requested
+    event, which (captured by messaging) will trigger restart_server function
+    and restart the server.
+    """
+
+    topic = "server.restart_requested"
+    if description is None:
+        description = "Server restart is required"
+
+    try:
+        await dispatch_event(topic, hash=topic, description=description, user=user_name)
+    except ConstraintViolationException:
+        # we don't need to do anything here. If the event fails,
+        # it means the event was already triggered, and the server
+        # is pending restart.
+        pass

--- a/ayon_server/api/system.py
+++ b/ayon_server/api/system.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import signal
 
@@ -25,7 +24,8 @@ def restart_server():
 
 
 async def require_server_restart(
-    user_name: str | None = None, description: str | None = None
+    user_name: str | None = None,
+    reason: str | None = None,
 ):
     """Mark the server as requiring a restart.
 
@@ -37,11 +37,11 @@ async def require_server_restart(
     """
 
     topic = "server.restart_required"
-    if description is None:
-        description = "Server restart is required"
+    if reason is None:
+        reason = "Server restart is required"
 
     try:
-        await dispatch_event(topic, hash=topic, description=description, user=user_name)
+        await dispatch_event(topic, hash=topic, description=reason, user=user_name)
     except ConstraintViolationException:
         # we don't need to do anything here. If the event fails,
         # it means the event was already triggered, and the server
@@ -59,6 +59,4 @@ async def clear_server_restart_required():
     restarted.
     """
 
-    await asyncio.sleep(5)
     await Postgres.execute("DELETE FROM events WHERE hash = 'server.restart_required'")
-    logging.debug("Server restart required flag cleared")

--- a/ayon_server/events/base.py
+++ b/ayon_server/events/base.py
@@ -128,6 +128,7 @@ async def dispatch_event(
         description=description,
         summary=summary,
         payload=payload,
+        retries=0,
     )
 
     if store:


### PR DESCRIPTION
We're introducing a couple of new API endpoints to help us keep tabs on when our server needs a bit of a time-out (a restart, that is). 

**Checking if a Restart is Needed**

`[GET] /api/system/restartRequired` 

```
{
  "required" : true,
  "reason": "Server needs to be restarted because of something"
}
```

This endpoint is your go-to for finding out if the server is signaling for a restart. It answers a simple question: "Does our server need to reboot?" and if so, "Why?" 

The frontend should check this endpoint and if `required` is true, display a banner to administrators with a button triggering the actual restart.

To reduce the latency, administrators could also listen for `server.restart_required` topic in the WS event stream. In that case, the reason for restarting is in the 'description' field of the mesage.

**Flagging for a Restart** 

All server-side action that require server restart should create `server.restart_required` event, so no action from the frontend should be necessary. But it is still possible to use`[POST] /api/system/restartRequired` (with the same payload as the get request). To set/flip the flag from FE or a service.







