### PR TITLE
Added addon on_settings_changed hook

### DIFF
--- a/api/addons/router.py
+++ b/api/addons/router.py
@@ -1,8 +1,10 @@
+from typing import Any
+
 from fastapi import APIRouter
 
 from ayon_server.api import ResponseFactory
 
-route_meta = {
+route_meta: dict[str, Any] = {
     "tags": ["Addon settings"],
 }
 

--- a/api/system/info.py
+++ b/api/system/info.py
@@ -165,7 +165,7 @@ async def get_additional_info(user: UserEntity, request: Request):
     for row in attribute_library.info_data:
         row = {**row}
         if row["name"] in enums:
-            row["enum"] = enums[row["name"]]
+            row["data"]["enum"] = enums[row["name"]]
         try:
             attr_list.append(AttributeModel(**row))
         except ValidationError:

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -472,6 +472,16 @@ class BaseServerAddon:
 
         return site_settings_model(**data).dict()
 
+    async def on_settings_changed(
+        self,
+        old_settings: BaseSettingsModel,
+        new_settings: BaseSettingsModel,
+        variant: str = "production",
+        project_name: str | None = None,
+    ) -> None:
+        """Hook called when the addon settings are changed."""
+        pass
+
     #
     # Overridable settings-related methods
     #

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -477,7 +477,9 @@ class BaseServerAddon:
         old_settings: BaseSettingsModel,
         new_settings: BaseSettingsModel,
         variant: str = "production",
-        project_name: str | None = None,
+        project_name: str | None = None,  # for project overrides
+        site_id: str | None = None,  # for site overrides
+        user_name: str | None = None,  # for site overrides
     ) -> None:
         """Hook called when the addon settings are changed."""
         pass


### PR DESCRIPTION
Adds a "on_settings_changed" hook to BaseServerAddon class, which is triggered, when the settings of the addon are changed. This is useful for addons that need to react to settings changes.

on_settings_changed method, accepts old_settings and new_settings arguments, as well as optional variant, project_name, site_id and user_name when applicable.
