### PR TITLE
Folder list endpoint

### DIFF
--- a/api/folders/__init__.py
+++ b/api/folders/__init__.py
@@ -1,3 +1,4 @@
 __all__ = ["router"]
 
-from folders.folders import router
+from . import folders, list_folders  # noqa
+from .router import router

--- a/api/folders/folders.py
+++ b/api/folders/folders.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, BackgroundTasks, Header, Query
+from fastapi import BackgroundTasks, Header, Query
 
 from ayon_server.api.dependencies import CurrentUser, FolderID, ProjectName
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
@@ -9,7 +9,7 @@ from ayon_server.events.patch import build_pl_entity_change_events
 from ayon_server.exceptions import ForbiddenException
 from ayon_server.lib.postgres import Postgres
 
-router = APIRouter(prefix="/projects/{project_name}/folders", tags=["Folders"])
+from .router import router
 
 #
 # [GET]

--- a/api/folders/list_folders.py
+++ b/api/folders/list_folders.py
@@ -1,0 +1,74 @@
+import time
+
+from ayon_server.access.utils import folder_access_list
+from ayon_server.api.dependencies import CurrentUser, ProjectName
+from ayon_server.helpers.hierarchy_cache import rebuild_hierarchy_cache
+from ayon_server.lib.redis import Redis
+from ayon_server.types import OPModel
+from ayon_server.utils import json_loads
+
+from .router import router
+
+# Models here are just for documentation. We don't use them in the code.
+
+
+class FolderListItem(OPModel):
+    id: str
+    path: str
+    parent_id: str | None = None
+    name: str
+    folder_type: str
+    status: str
+    attrib: dict[str, str]
+    own_attrib: list[str]
+
+
+class FolderListModel(OPModel):
+    detail: str
+    entities: list[FolderListItem]
+
+
+async def get_entities(project_name: str) -> list[dict[str, str]]:
+    entities_data = await Redis.get("project.folders", project_name)
+    if entities_data is None:
+        return await rebuild_hierarchy_cache(project_name)
+    else:
+        return json_loads(entities_data)
+
+
+@router.get("")
+async def get_folder_list(
+    user: CurrentUser,
+    project_name: ProjectName,
+) -> FolderListModel:
+    """Return all folders in the project. Fast.
+
+    This is a similar endpoint to /hierarchy, but the result
+    is a flat list. additionally, this endpoint should be faster
+    since it uses a cache. The cache is updated every time a
+    folder is created, updated, or deleted.
+
+    The endpoint handles ACL and also returns folder attributes.
+    """
+
+    start_time = time.monotonic()
+    access_list = await folder_access_list(user, project_name, "read")
+    entities = await get_entities(project_name)
+
+    result = {
+        "detail": "",
+        "entities": [
+            entity
+            for entity in entities
+            if access_list is None or entity["path"] in access_list
+        ],
+    }
+
+    elapsed_time = time.monotonic() - start_time
+    detail = (
+        f"{len(result['entities'])} folders "
+        f"of {project_name} fetched in {elapsed_time:.2f} seconds"
+    )
+    result["detail"] = detail
+    # skip constructing the model. it just slows things down
+    return result  # type: ignore

--- a/api/folders/list_folders.py
+++ b/api/folders/list_folders.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 
 from ayon_server.access.utils import folder_access_list
@@ -9,18 +10,21 @@ from ayon_server.utils import json_loads
 
 from .router import router
 
-# Models here are just for documentation. We don't use them in the code.
-
 
 class FolderListItem(OPModel):
     id: str
     path: str
     parent_id: str | None = None
+    parents: list[str]
     name: str
+    label: str | None = None
     folder_type: str
+    has_tasks: bool = False
+    task_names: list[str] | None
     status: str
     attrib: dict[str, str]
     own_attrib: list[str]
+    updated_at: datetime.datetime
 
 
 class FolderListModel(OPModel):
@@ -70,5 +74,6 @@ async def get_folder_list(
         f"of {project_name} fetched in {elapsed_time:.2f} seconds"
     )
     result["detail"] = detail
-    # skip constructing the model. it just slows things down
-    return result  # type: ignore
+
+    # we need to do the validation here in order to convert snake_case to camelCase
+    return FolderListModel(**result)

--- a/api/folders/router.py
+++ b/api/folders/router.py
@@ -1,0 +1,3 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/projects/{project_name}/folders", tags=["Folders"])

--- a/api/hierarchy/hierarchy.py
+++ b/api/hierarchy/hierarchy.py
@@ -138,10 +138,12 @@ async def get_folder_hierarchy(
         hierarchy.commit()
         hresult = hierarchy()
 
-    elapsed = round(time.time() - start_time, 4)
-
-    return HierarchyResponseModel.construct(
-        detail=f"Hierarchy loaded in {elapsed}s",
+    res = HierarchyResponseModel.construct(
+        detail="Working",
         projectName=project_name,
         hierarchy=hresult,
     )
+    elapsed = round(time.time() - start_time, 4)
+    detail = f"Hierarchy loaded in {elapsed}s"
+    res.detail = detail
+    return res

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -11,6 +11,7 @@ from ayon_server.exceptions import (
     ForbiddenException,
     NotFoundException,
 )
+from ayon_server.helpers.hierarchy_cache import rebuild_hierarchy_cache
 from ayon_server.lib.postgres import Postgres
 from ayon_server.types import ProjectLevelEntityType
 from ayon_server.utils import EntityID, SQLTool, dict_exclude
@@ -252,6 +253,7 @@ class FolderEntity(ProjectLevelEntity):
                 row["path"],
                 attr,
             )
+        await rebuild_hierarchy_cache(self.project_name, transaction=transaction)
 
     async def delete(self, transaction=None, **kwargs) -> bool:
         if kwargs.get("force", False):
@@ -269,6 +271,7 @@ class FolderEntity(ProjectLevelEntity):
                 self.path.lstrip("/"),
             )
         return await super().delete(transaction=transaction, **kwargs)
+        await rebuild_hierarchy_cache(self.project_name, transaction=transaction)
 
     async def get_versions(self, transaction=None):
         """Return of version ids associated with this folder."""

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -184,6 +184,7 @@ class FolderEntity(ProjectLevelEntity):
                 """
             )
             await rebuild_inherited_attributes(self.project_name, transaction=conn)
+            await rebuild_hierarchy_cache(self.project_name, transaction=conn)
 
         if transaction is not None:
             await _commit(transaction)

--- a/ayon_server/helpers/hierarchy_cache.py
+++ b/ayon_server/helpers/hierarchy_cache.py
@@ -1,0 +1,46 @@
+import time
+from typing import Any
+
+import asyncpg
+from nxtools import logging
+
+from ayon_server.lib.postgres import Postgres
+from ayon_server.lib.redis import Redis
+from ayon_server.utils import json_dumps
+
+
+async def rebuild_hierarchy_cache(
+    project_name: str,
+    transaction: asyncpg.Connection | None = None,
+) -> list[dict[str, Any]]:
+    start_time = time.monotonic()
+    query = f"""
+        SELECT
+            f.id, f.parent_id, f.name, f.folder_type, f.status, f.attrib,
+            ea.attrib as all_attrib, ea.path as path
+        FROM
+            project_{project_name}.folders f
+        INNER JOIN
+            project_{project_name}.exported_attributes ea
+        ON f.id = ea.folder_id
+    """
+
+    result = []
+    async for row in Postgres.iterate(query, transaction=transaction):
+        # save microseconds by not converting to entity type
+        result.append(
+            {
+                "id": row["id"],
+                "path": row["path"],
+                "parent_id": row["parent_id"],
+                "name": row["name"],
+                "folder_type": row["folder_type"],
+                "status": row["status"],
+                "attrib": row["all_attrib"],
+                "own_attrib": list(row["attrib"].keys()),
+            }
+        )
+    await Redis.set("project.folders", project_name, json_dumps(result), 3600)
+    elapsed_time = time.monotonic() - start_time
+    logging.debug(f"Rebuilt hierarchy cache for {project_name} in {elapsed_time:.2f} s")
+    return result


### PR DESCRIPTION
Added a new endpoint `[GET] /api/projects/{project_name}/folders` which returns all folders in a project.
This endpoint is heavily optimized for performance and should replace `hierarchy` endpoint and several GraphQL queries
from the editor. 

Folder data is stored in Redis cache and recached when a folder is created, updated or deleted.
The endpoint itself only handles retrieving from the cache and ACL checks. 

With 10 000 folders in the project, data loading takes ~10ms. The biggest bottleneck is HTTP request/response time.
But the main goal is not to have blazing fast response times, but to reduce the number of queries to the database.

Using a boolean query argument `attrib` it is possible to query attributes (including ownAttrib list) as well.
