### PR TITLE
added __primary__ and __builtin__ anatomy presets

### DIFF
--- a/api/anatomy/__init__.py
+++ b/api/anatomy/__init__.py
@@ -143,6 +143,26 @@ async def set_primary_preset(preset_name: str, user: CurrentUser) -> EmptyRespon
     return EmptyResponse()
 
 
+@router.delete("/presets/{preset_name}/primary", status_code=204)
+async def unset_primary_preset(preset_name: str, user: CurrentUser) -> EmptyResponse:
+    """Unset the primary preset."""
+
+    if not user.is_manager:
+        raise ForbiddenException("Only managers can unset primary preset.")
+
+    async with Postgres.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                """
+                UPDATE anatomy_presets
+                SET is_primary = FALSE
+                WHERE name = $1
+                """,
+                preset_name,
+            )
+    return EmptyResponse()
+
+
 @router.delete("/presets/{preset_name}", status_code=204)
 async def delete_anatomy_preset(preset_name: str, user: CurrentUser) -> EmptyResponse:
     """Delete the anatomy preset with the given name."""

--- a/api/anatomy/__init__.py
+++ b/api/anatomy/__init__.py
@@ -66,14 +66,27 @@ async def get_anatomy_presets(user: CurrentUser) -> AnatomyPresetListModel:
 async def get_anatomy_preset(preset_name: str, user: CurrentUser) -> Anatomy:
     """Returns the anatomy preset with the given name.
 
-    Use `_` character as a preset name to return the default preset.
+    - Use `__builtin__` character as a preset name to return the builtin preset.
+    - Use `__primary__` character as a preset name to return the primary preset.
+    - `_` is an alias for built in preset (deprecated, kept for backward compatibility).
     """
-    if preset_name == "_":
+
+    if preset_name == "__builtin__" or preset_name == "_":
         tpl = Anatomy()
         return tpl
-    query = "SELECT * FROM anatomy_presets WHERE name = $1 AND version = $2"
+
+    if preset_name == "__primary__":
+        query = "SELECT * FROM anatomy_presets WHERE is_primary = TRUE"
+    else:
+        query = "SELECT * FROM anatomy_presets WHERE name = $1 AND version = $2"
+
     async for row in Postgres.iterate(query, preset_name, VERSION):
         tpl = Anatomy(**row["data"])
+        return tpl
+
+    if preset_name == "__primary__":
+        # Primary preset not found, return the builtin preset
+        tpl = Anatomy()
         return tpl
     raise NotFoundException(f"Anatomy preset {preset_name} not found.")
 

--- a/ayon_server/settings/enum.py
+++ b/ayon_server/settings/enum.py
@@ -52,12 +52,19 @@ async def secrets_enum(project_name: str | None = None) -> list[str]:
 
 
 async def anatomy_presets_enum():
-    result = [{"label": "<built-in>", "value": "_"}]
     query = "SELECT name, is_primary FROM anatomy_presets ORDER BY name"
+    primary: str | None = None
+    result = []
     async for row in Postgres.iterate(query):
         if row["is_primary"]:
-            label = f"{row['name']} (default)"
+            label = f"{row['name']} (primary)"
+            primary = row["name"]
         else:
             label = row["name"]
         result.append({"label": label, "value": row["name"]})
+
+    if primary is not None:
+        result.insert(0, "__primary__")
+    else:
+        result.insert(0, "__builtin__")
     return result


### PR DESCRIPTION
Instead of the original `_` magic value, anatomy presets may be queried using `__primary__` and `__builtin__` 
original `_` is now alias to `__builtin__` to maintain backward compatibility.

Enum resolver for settings is available so it is possible to create fields such as:

```python
    anatomy_preset: str = Field(
        "__primary__",
        title="Anatomy preset",
        description="Anatomy preset to use",
        enum_resolver=anatomy_presets_enum,
    )
```

in that case, settings value will always point to the primary preset. 
If no primary preset is defined, it will point to the built-in.
User may then override the value with a an explicit preset name.
