### PR TITLE
feat: disable check session ip by config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test_*.py
 .python-version
 .vscode
 BUILD_DATE
+venv/

--- a/ayon_server/auth/session.py
+++ b/ayon_server/auth/session.py
@@ -68,7 +68,7 @@ class Session:
                 session.client_info = get_client_info(request)
                 session.last_used = time.time()
                 await Redis.set(cls.ns, token, session.json())
-            else:
+            elif not ayonconfig.disable_check_session_ip:
                 real_ip = get_real_ip(request)
                 if not is_local_ip(real_ip):
                     if session.client_info.ip != real_ip:

--- a/ayon_server/config.py
+++ b/ayon_server/config.py
@@ -70,6 +70,11 @@ class AyonConfig(BaseModel):
         description="Session lifetime in seconds",
     )
 
+    disable_check_session_ip: bool = Field(
+        default=False,
+        description="Skip checking session IP match real IP",
+    )
+
     max_failed_login_attempts: int = Field(
         default=10,
         description="Maximum number of failed login attempts",


### PR DESCRIPTION
When client real IP changes constantly, due the connection via mobile internet for example, sessions can often be invalid.
Added the probability to skip checking the session IP matches the real IP via config.