### PR TITLE
User avatar endpoints

### DIFF
--- a/api/users/users.py
+++ b/api/users/users.py
@@ -607,3 +607,13 @@ async def password_reset(request: PasswordResetModel) -> LoginResponseModel:
         token=session.token,
         user=session.user,
     )
+
+
+@router.get("/avatar")
+async def get_avatar(user: CurrentUser):
+    pass
+
+
+@router.post("/avatar")
+async def set_avatar(user: CurrentUser):
+    pass


### PR DESCRIPTION
## Story

User profile picture (avatar) is only stored as "avatarUrl" attribute. 
This is automatically filled when SSO is used, but not when the user is created manually,
but there's no easy way for the user to upload their own picture.

Additionally, SSO providers such as goolgle implements CORS headers that prevent the browser from loading the image,
so the image is not displayed in the user profile.

## Solution

Add two endpoints to the API:

- `[GET] /api/users/{username}/avatar` that returns the avatar image of the user.
- `[PUT] /api/users/{username}/avatar` that allows the user to upload a new avatar image.

### Setting the avatar

The PUT endpoint would store the uploaded image in the `/storage/avatars` directory, 
and update the cache in Redis with the new image. 

Since we need to store MIME information about the source image, 
we won't store binary representations of the image in Redis, 
but a JSON object with the following structure:

```json
{
  "mime": "image/png",
  "data": "base64-encoded-image"
}
```

### Getting the avatar

The GET enpoint would try to get the image from the cache in Redis,
and if it's not found, it would try to get the image from the `/storage/avatars` directory.

If the image is not found in the cache or in the filesystem, it would try to get the 
image from the `avatarUrl` attribute of the user, and cache it in Redis.


### Future improvements

- Add a `DELETE` endpoint to remove the avatar image.
- Server-side resize the image to a sane maximum size.


## Tasks

This would close the following tasks:

- https://app.clickup.com/t/6658547/AY-4482
- https://app.clickup.com/t/6658547/AY-1347
