### PR TITLE
Added bundle.status_changed event

### DIFF
--- a/api/bundles/actions.py
+++ b/api/bundles/actions.py
@@ -1,4 +1,5 @@
 from ayon_server.entities.user import UserEntity
+from ayon_server.events import EventStream
 from ayon_server.exceptions import BadRequestException, ForbiddenException
 
 from .models import BundleModel
@@ -65,3 +66,14 @@ async def promote_bundle(bundle: BundleModel, user: UserEntity, conn):
         # TODO: Do we want this?
         #
         # for project_name in project_names:
+
+    await EventStream.dispatch(
+        "bundle.status_changed",
+        user=user.name,
+        description=f"Bundle {bundle.name} promoted to production",
+        summary={
+            "name": bundle.name,
+            "status": "production",
+        },
+        payload=data,
+    )


### PR DESCRIPTION
Adds bundle.status_changed event which is triggered whenever a bundle is set to production or staging or achieved. Details on the new state are available in the event summary.