### PR TITLE
Filtering checklists in activity feed

### DIFF
--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -6,7 +6,11 @@ from ayon_server.activities.models import (
     ActivityType,
 )
 from ayon_server.activities.references import get_references_from_entity
-from ayon_server.activities.utils import MAX_BODY_LENGTH, extract_mentions
+from ayon_server.activities.utils import (
+    MAX_BODY_LENGTH,
+    extract_mentions,
+    is_body_with_checklist,
+)
 from ayon_server.entities.core import ProjectLevelEntity
 from ayon_server.exceptions import BadRequestException
 from ayon_server.lib.postgres import Postgres
@@ -53,6 +57,9 @@ async def create_activity(
     if hasattr(entity, "label"):
         origin["label"] = entity.label
     data["origin"] = origin
+
+    if activity_type == "comment" and is_body_with_checklist(body):
+        data["hasChecklist"] = True
 
     #
     # Extract references

--- a/ayon_server/activities/models.py
+++ b/ayon_server/activities/models.py
@@ -4,7 +4,6 @@ from typing import Any, Literal
 from ayon_server.types import Field, OPModel
 from ayon_server.utils import create_uuid
 
-EntityLinkTuple = tuple[str, str]
 ActivityType = Literal["comment", "status.change", "assignee.add", "assignee.remove"]
 ActivityReferenceType = Literal["origin", "mention", "author", "relation"]
 ReferencedEntityType = Literal[
@@ -17,6 +16,7 @@ ReferencedEntityType = Literal[
     "representation",
     "workfile",
 ]
+EntityLinkTuple = tuple[ReferencedEntityType, str]
 
 
 class ActivityReferenceModel(OPModel):

--- a/ayon_server/activities/update_activity.py
+++ b/ayon_server/activities/update_activity.py
@@ -3,7 +3,11 @@ from typing import Any
 from nxtools import logging
 
 from ayon_server.activities.models import ActivityReferenceModel
-from ayon_server.activities.utils import MAX_BODY_LENGTH, extract_mentions
+from ayon_server.activities.utils import (
+    MAX_BODY_LENGTH,
+    extract_mentions,
+    is_body_with_checklist,
+)
 from ayon_server.exceptions import (
     BadRequestException,
     NotFoundException,
@@ -50,6 +54,10 @@ async def update_activity(
     if data:
         data.pop("author", None)
         activity_data.update(data)
+
+    activity_data.pop("hasChecklist", None)
+    if activity_type == "comment" and is_body_with_checklist(body):
+        activity_data["hasChecklist"] = True
 
     references = []
     async for row in Postgres.iterate(

--- a/ayon_server/activities/utils.py
+++ b/ayon_server/activities/utils.py
@@ -56,3 +56,11 @@ def extract_mentions(
                 )
             )
     return references
+
+
+def is_body_with_checklist(md_text: str) -> bool:
+    """Check if the markdown text is a body with a checklist."""
+
+    checkbox_pattern = re.compile(r"^\s*[\-\*]\s*\[[ xX]\]", re.MULTILINE)
+    match = checkbox_pattern.search(md_text)
+    return match is not None

--- a/ayon_server/graphql/resolvers/activities.py
+++ b/ayon_server/graphql/resolvers/activities.py
@@ -56,7 +56,20 @@ async def get_activities(
 
     if activity_types is not None:
         validate_name_list(activity_types)
-        sql_conditions.append(f"activity_type IN {SQLTool.array(activity_types)}")
+
+        if "checklist" in activity_types:
+            if "comment" not in activity_types:
+                # comments include checklist items so we don't need to query both
+                sql_conditions.append(
+                    """(
+                        activity_type = 'comment'
+                        AND activity_data->>'hasChecklist' IS NOT NULL
+                    )"""
+                )
+            activity_types.remove("checklist")
+
+        if activity_types:
+            sql_conditions.append(f"activity_type IN {SQLTool.array(activity_types)}")
 
     if reference_types is not None:
         validate_name_list(reference_types)


### PR DESCRIPTION
Adds an option to filter comments containing checklists.

That way, users can easily find comments that contain checklists, which are often used to track progress on tasks.

## Solution

- when a comment is created or updated, it is checked for the presence of a checklist
- if a checklist is found, boolean `hasChecklist` is stored to activity.data
- virtual `checklist` activityType was added to the activityTypes filter on activities resolver

When activityTypes filter contains `comment` it lists both normal comments and comments with checklists. 
When it contains `checklist` (and not comment) it lists only comments with checklists.
