### PR TITLE
Propagate publishes to activity feed

### DIFF
--- a/ayon_server/activities/event_hook.py
+++ b/ayon_server/activities/event_hook.py
@@ -121,8 +121,7 @@ class ActivityFeedEventHook:
             body=f"Published [{version.name}](version:{version.id})",
             user_name=version.author or event.user,
             data={
-                "publish": {
-                    "version": version.version,
+                "context": {
                     "folderId": row["folder_id"],
                     "folderName": row["folder_name"],
                     "folderLabel": row["folder_label"],

--- a/ayon_server/activities/models.py
+++ b/ayon_server/activities/models.py
@@ -4,8 +4,21 @@ from typing import Any, Literal
 from ayon_server.types import Field, OPModel
 from ayon_server.utils import create_uuid
 
-ActivityType = Literal["comment", "status.change", "assignee.add", "assignee.remove"]
-ActivityReferenceType = Literal["origin", "mention", "author", "relation"]
+ActivityType = Literal[
+    "comment",
+    "status.change",
+    "assignee.add",
+    "assignee.remove",
+    "version.publish",
+]
+
+ActivityReferenceType = Literal[
+    "origin",
+    "mention",
+    "author",
+    "relation",
+]
+
 ReferencedEntityType = Literal[
     "activity",
     "user",
@@ -16,6 +29,7 @@ ReferencedEntityType = Literal[
     "representation",
     "workfile",
 ]
+
 EntityLinkTuple = tuple[ReferencedEntityType, str]
 
 


### PR DESCRIPTION
Creating a new version now propagates to activity feed. activityData.context contains additional information to construct the message body.

![image](https://github.com/ynput/ayon-backend/assets/5007200/e36a7654-2578-49da-9723-d80fb2b2715f)
