### PR TITLE
Add more db indices

### DIFF
--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -51,6 +51,8 @@ CREATE TABLE IF NOT EXISTS activities (
     creation_order SERIAL NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_activity_type ON activities(activity_type);
+
 CREATE TABLE IF NOT EXISTS activity_references (
     id UUID PRIMARY KEY, -- generate uuid1 in python
     activity_id UUID NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
@@ -64,6 +66,9 @@ CREATE TABLE IF NOT EXISTS activity_references (
     updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     creation_order SERIAL NOT NULL
 );
+
+CREATE INDEX IF NOT EXISTS idx_activity_id ON activity_references(activity_id);
+CREATE INDEX IF NOT EXISTS idx_activity_entity_id ON activity_references(entity_id);
 CREATE INDEX IF NOT EXISTS idx_activity_reference_created_at ON activity_references(created_at);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_reference_unique ON activity_references(activity_id, entity_id, entity_name, reference_type);
 
@@ -121,6 +126,8 @@ CREATE TABLE IF NOT EXISTS files (
   created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
 );
+
+CREATE INDEX IF NOT EXISTS idx_files_activity_id ON files(activity_id);
 
 -------------------
 -- BASE ENTITIES --

--- a/schemas/schema.public.sql
+++ b/schemas/schema.public.sql
@@ -56,8 +56,8 @@ CREATE TABLE IF NOT EXISTS public.events(
   hash VARCHAR NOT NULL,
   topic VARCHAR NOT NULL,
   sender VARCHAR,
-  project_name VARCHAR, -- REFERENCES public.projects(name) ON DELETE CASCADE ON UPDATE CASCADE,
-  user_name VARCHAR, -- REFERENCES public.users(name) ON DELETE CASCADE ON UPDATE CASCADE,
+  project_name VARCHAR,
+  user_name VARCHAR,
   depends_on UUID REFERENCES public.events(id),
   status VARCHAR NOT NULL
     DEFAULT 'finished'
@@ -79,9 +79,15 @@ CREATE TABLE IF NOT EXISTS public.events(
   creation_order SERIAL NOT NULL
 );
 
--- TODO: some indices here
 CREATE UNIQUE INDEX IF NOT EXISTS unique_event_hash ON events(hash);
 CREATE UNIQUE INDEX IF NOT EXISTS unique_creation_order ON events(creation_order);
+
+CREATE INDEX IF NOT EXISTS event_topic_idx ON events USING GIN (topic public.gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS event_depends_on_idx ON events(depends_on);
+CREATE INDEX IF NOT EXISTS event_project_name_idx ON events (project_name);
+CREATE INDEX IF NOT EXISTS event_user_name_idx ON events (user_name);
+CREATE INDEX IF NOT EXISTS event_created_at_idx ON events (created_at);
+CREATE INDEX IF NOT EXISTS event_updated_at_idx ON events (updated_at);
 
 --------------
 -- Settings --

--- a/schemas/schema.public.update.sql
+++ b/schemas/schema.public.update.sql
@@ -249,6 +249,8 @@ CREATE OR REPLACE FUNCTION create_activity_feed_in_projects ()
                 creation_order SERIAL NOT NULL
             );
 
+            CREATE INDEX IF NOT EXISTS idx_activity_type ON activities(activity_type);
+
             CREATE TABLE IF NOT EXISTS activity_references (
                 id UUID PRIMARY KEY, -- generate uuid1 in python
                 activity_id UUID NOT NULL REFERENCES activities(id) ON DELETE CASCADE,
@@ -263,6 +265,8 @@ CREATE OR REPLACE FUNCTION create_activity_feed_in_projects ()
                 creation_order SERIAL NOT NULL
             );
 
+            CREATE INDEX IF NOT EXISTS idx_activity_id ON activity_references(activity_id);
+            CREATE INDEX IF NOT EXISTS idx_activity_entity_id ON activity_references(entity_id);
             CREATE INDEX IF NOT EXISTS idx_activity_reference_created_at 
               ON activity_references(created_at);
             CREATE UNIQUE INDEX IF NOT EXISTS idx_activity_reference_unique 
@@ -316,6 +320,7 @@ CREATE OR REPLACE FUNCTION create_activity_feed_in_projects ()
               created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
               updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
             );
+            CREATE INDEX IF NOT EXISTS idx_files_activity_id ON files(activity_id);
 
         END LOOP; 
         RETURN; 


### PR DESCRIPTION
Adds more (very needed) database indices to tables related to events and activity feed. This may cause slower server update when used for the first time as indices need to be created on existing data, but preliminary tests suggest it should take a few seconds. 