### PR TITLE
fix: support inherited attributes in fragments

### DIFF
--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -99,6 +99,13 @@ class FieldInfo:
                 return True
         return False
 
+    def any_endswith(self, *fields: str) -> bool:
+        for field in fields:
+            for f in self.fields:
+                if f.split(".")[-1] == field:
+                    return True
+        return False
+
 
 async def create_folder_access_list(root, info) -> list[str] | None:
     user = info.context["user"]

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -178,7 +178,7 @@ async def get_tasks(
     # Joins
     #
 
-    if ("attrib" in fields) or attributes:
+    if attributes or fields.any_endswith("attrib"):
         sql_columns.append("pf.attrib as parent_folder_attrib")
         sql_joins.append(
             f"""


### PR DESCRIPTION
In order to select exported attributes from the parent query, task resolver now looks for any field ending with `attrib` instead of explicit `attrib` field, which is not present when a fragment is used