### PR TITLE
Do not return empty site root overrides

### DIFF
--- a/ayon_server/helpers/roots.py
+++ b/ayon_server/helpers/roots.py
@@ -50,6 +50,6 @@ async def get_roots_for_projects(
             """
             result = await Postgres.fetch(query, user_name, site_id, timeout=5)
             for row in result:
-                roots[project_name].update(row["data"])
+                roots[project_name].update({k: v for k, v in row["data"].items() if v})
 
     return roots


### PR DESCRIPTION
## PR Checklist

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

When using `api/projects/{project_name}/roots` endpoint (GET/PUT), empty values (nulls or empty strings)
are no longer returned. When no override is present, exclude that root (or site) from the result.
