### PR TITLE
Add support for ayon_soft_required_addons

### DIFF
--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -117,11 +117,11 @@ async def check_bundle(
 
         # Check for required addons.
         # If the required addon is not present, it's an error.
-        # If it is present, it must be compatible.
+        # If it is present, it must match soft_required.
+        # If it doesn't match compatibility, it's an warning
         # If the requirement is set to None, it must not be present.
 
         for r_name, r_version in (compat.required_addons or {}).items():
-            print(addon_name, r_name, r_version)
             b_version = bundle.addons.get(r_name)
 
             if b_version is None:
@@ -147,6 +147,33 @@ async def check_bundle(
                     )
                 )
 
+            elif not is_compatible(b_version, r_version):
+                msg = f"{r_name} {r_version} is required"
+                issues.append(
+                    BundleIssueModel(
+                        severity="error",
+                        addon=addon_name,
+                        message=msg,
+                        required_addon=r_name,
+                    )
+                )
+
+        # Check for soft required addons.
+
+        for r_name, r_version in (compat.soft_required_addons or {}).items():
+            b_version = bundle.addons.get(r_name)
+            if b_version is None or r_version is None:
+                # compatible addon is not required
+                continue
+            if b_version is None:
+                issues.append(
+                    BundleIssueModel(
+                        severity="error",
+                        addon=addon_name,
+                        message=f"{r_name} is required",
+                        required_addon=r_name,
+                    )
+                )
             elif not is_compatible(b_version, r_version):
                 msg = f"{r_name} {r_version} is required"
                 issues.append(

--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -165,16 +165,7 @@ async def check_bundle(
             if b_version is None or r_version is None:
                 # compatible addon is not required
                 continue
-            if b_version is None:
-                issues.append(
-                    BundleIssueModel(
-                        severity="error",
-                        addon=addon_name,
-                        message=f"{r_name} is required",
-                        required_addon=r_name,
-                    )
-                )
-            elif not is_compatible(b_version, r_version):
+            if not is_compatible(b_version, r_version):
                 msg = f"{r_name} {r_version} is required"
                 issues.append(
                     BundleIssueModel(

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -27,6 +27,7 @@ METADATA_KEYS = [
     "ayon_server_version",
     "ayon_launcher_version",
     "ayon_required_addons",
+    "ayon_soft_required_addons",
     "ayon_compatible_addons",
 ]
 
@@ -35,6 +36,7 @@ class AddonCompatibilityModel(BaseSettingsModel):
     server_version: str | None = None
     launcher_version: str | None = None
     required_addons: dict[str, str | None] | None = None
+    soft_required_addons: dict[str, str | None] | None = None
     compatible_addons: dict[str, str | None] | None = None
 
 
@@ -67,6 +69,7 @@ class BaseServerAddon:
             server_version=kwargs.pop("ayon_server_version", None),
             launcher_version=kwargs.pop("ayon_launcher_version", None),
             required_addons=kwargs.pop("ayon_required_addons", None),
+            soft_required_addons=kwargs.pop("ayon_soft_required_addons", None),
             compatible_addons=kwargs.pop("ayon_compatible_addons", None),
         )
 


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes

## Description of changes

Addons may now provide `ayon_soft_required_addons` field, which specifies addons, which MUST be in the given version, if the addon is in a bundle. It is similar to `ayon_compatible_addons` with the difference this returns error instead of warning when the condition is not met.

