### PR TITLE
Migrate settings rewrite

### DIFF
--- a/api/addons/studio_settings.py
+++ b/api/addons/studio_settings.py
@@ -87,6 +87,8 @@ async def set_addon_studio_settings(
     if not user.is_manager:
         raise ForbiddenException
 
+    explicit_pins = payload.pop("__pinned_fields__", None)
+
     addon = AddonLibrary.addon(addon_name, addon_version)
     original = await addon.get_studio_settings(variant=variant)
     existing = await addon.get_studio_overrides(variant=variant)
@@ -94,7 +96,12 @@ async def set_addon_studio_settings(
     if (original is None) or (model is None):
         raise BadRequestException("This addon does not have settings")
     try:
-        data = extract_overrides(original, model(**payload), existing)
+        data = extract_overrides(
+            original,
+            model(**payload),
+            existing,
+            explicit_pins=explicit_pins,
+        )
     except ValidationError as e:
         raise BadRequestException("Invalid settings", errors=e.errors()) from e
 

--- a/api/addons/studio_settings.py
+++ b/api/addons/studio_settings.py
@@ -99,7 +99,6 @@ async def set_addon_studio_settings(
         data = extract_overrides(
             original,
             model(**payload),
-            existing,
             explicit_pins=explicit_pins,
         )
     except ValidationError as e:

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -13,7 +13,7 @@ from ayon_server.addons.models import ServerSourceInfo, SourceInfo, SSOOption
 from ayon_server.exceptions import AyonException, BadRequestException, NotFoundException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.settings import BaseSettingsModel, apply_overrides
-from ayon_server.settings.common import migrate_settings
+from ayon_server.settings.common import migrate_settings_overrides
 
 if TYPE_CHECKING:
     from ayon_server.addons.definition import ServerAddonDefinition
@@ -549,12 +549,11 @@ class BaseServerAddon:
         has been changed from `str` to `list[str]`, you may use:
 
         ```python
-        await def convert_str_to_list_str(value: str | list[str]) -> list[str]:
+        async def convert_str_to_list_str(value: str | list[str]) -> list[str]:
             if isinstance(value, str):
                 return [value]
             elif isinstance(value, list):
                 return value
-            return []
 
         result = migrate_settings(
             overrides,
@@ -566,11 +565,14 @@ class BaseServerAddon:
 
         ```
         """
+
         model_class = self.get_settings_model()
         if model_class is None:
             return {}
         defaults = await self.get_default_settings()
-        result = migrate_settings(
-            overrides, new_model_class=model_class, defaults=defaults.dict()
+        assert defaults is not None
+        return migrate_settings_overrides(
+            overrides,
+            new_model_class=model_class,
+            defaults=defaults.dict(),
         )
-        return result.dict(exclude_unset=True, exclude_none=True, exclude_defaults=True)

--- a/ayon_server/settings/common.py
+++ b/ayon_server/settings/common.py
@@ -57,7 +57,8 @@ def migrate_settings_overrides(
                         key_path,
                     )
                 else:
-                    logging.warning(f"Unsupported type for {key_path} model: {value}")
+                    sval = str(value)[:70]
+                    logging.warning(f"Unsupported type for {key_path} model: {sval}")
             else:
                 try:
                     validated_value = parse_obj_as(field_type.outer_type_, value)

--- a/ayon_server/settings/common.py
+++ b/ayon_server/settings/common.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Type
 from nxtools import logging
 from pydantic import BaseModel, ValidationError, parse_obj_as
 
-from ayon_server.utils import json_dumps, json_loads, json_print
+from ayon_server.utils import json_dumps, json_loads  # , json_print
 
 pattern = re.compile(r"(?<!^)(?=[A-Z])")
 
@@ -26,71 +26,6 @@ class BaseSettingsModel(BaseModel):
         json_dumps = json_dumps
 
 
-def migrate_settings(
-    old_data: dict[str, Any],
-    new_model_class: Type[BaseSettingsModel],
-    defaults: dict[str, Any],
-    custom_conversions: dict[str, Callable[[Any], Any]] = {},
-    parent_key: str = "",
-) -> Any:
-    new_instance_data = {}
-    for field_name, field_type in new_model_class.__fields__.items():
-        # Construct the key path for nested fields
-        key_path = f"{parent_key}.{field_name}" if parent_key else field_name
-        if field_name in old_data:
-            old_value = old_data[field_name]
-            # Check if there's a custom conversion for this field
-            if key_path in custom_conversions:
-                new_instance_data[field_name] = custom_conversions[key_path](old_value)
-            elif (key := key_path.split(".")[-1]) in custom_conversions:
-                new_instance_data[field_name] = custom_conversions[key](old_value)
-            elif inspect.isclass(field_type.type_) and issubclass(
-                field_type.type_, BaseSettingsModel
-            ):
-                # Recurse nested models or lists of models
-                if isinstance(old_value, list):
-                    ndata = []
-                    for i, ov in enumerate(old_value):
-                        ndata.append(
-                            migrate_settings(
-                                ov,
-                                field_type.type_,
-                                {},
-                                custom_conversions,
-                                key_path,
-                            )
-                        )
-                    new_instance_data[field_name] = ndata
-
-                elif isinstance(old_value, dict):
-                    new_instance_data[field_name] = migrate_settings(
-                        old_value,
-                        field_type.outer_type_,
-                        defaults.get(field_name, {}),
-                        custom_conversions,
-                        key_path,
-                    )
-                else:
-                    logging.warning(
-                        f"Unsupported type for {key_path} model: {old_value}"
-                    )
-            else:
-                try:
-                    validated_value = parse_obj_as(field_type.outer_type_, old_value)
-                    new_instance_data[field_name] = validated_value
-                except ValidationError:
-                    logging.warning(
-                        f"Failed to validate {field_name} with value {old_value}"
-                    )
-                    # Skip incompatible fields
-                    continue
-        else:
-            if field_name in defaults:
-                new_instance_data[field_name] = defaults.get(field_name, None)
-
-    return new_model_class.parse_obj(new_instance_data)
-
-
 def migrate_settings_overrides(
     old_data: dict[str, Any],
     new_model_class: Type[BaseSettingsModel],
@@ -102,8 +37,8 @@ def migrate_settings_overrides(
 
     new_data = {}
 
-    if not parent_key:
-        json_print(old_data, "Old data")
+    # if not parent_key:
+    #     json_print(old_data, "Old data")
 
     for key, value in old_data.items():
         if key in new_model_class.__fields__:
@@ -134,7 +69,7 @@ def migrate_settings_overrides(
         else:
             logging.warning(f"Skipping unknown key: {key}")
 
-    if not parent_key:
-        json_print(new_data, "New data")
+    # if not parent_key:
+    #     json_print(new_data, "New data")
 
     return new_data

--- a/ayon_server/settings/overrides.py
+++ b/ayon_server/settings/overrides.py
@@ -165,7 +165,6 @@ def paths_to_dict(paths: list[list[str]]):
 def extract_overrides(
     default: BaseSettingsModel,
     overriden: BaseSettingsModel,
-    existing: dict[str, Any] | None = None,
     explicit_pins: list[list[str]] | None = None,
 ) -> dict[str, Any]:
     result: dict[str, Any] = {}

--- a/ayon_server/settings/overrides.py
+++ b/ayon_server/settings/overrides.py
@@ -151,12 +151,26 @@ def list_overrides(
     return result
 
 
+def paths_to_dict(paths: list[list[str]]):
+    root = {}
+    for path in paths:
+        current = root
+        for key in path:
+            if key not in current:
+                current[key] = {}
+            current = current[key]
+    return root
+
+
 def extract_overrides(
     default: BaseSettingsModel,
     overriden: BaseSettingsModel,
     existing: dict[str, Any] | None = None,
+    explicit_pins: list[list[str]] | None = None,
 ) -> dict[str, Any]:
     result: dict[str, Any] = {}
+
+    existing = paths_to_dict(explicit_pins or [])
 
     def crawl(obj, ovr, ex, target):
         for name, _field in obj.__fields__.items():
@@ -170,4 +184,5 @@ def extract_overrides(
                     target[name] = ovr.dict()[name]
 
     crawl(default, overriden, existing or {}, result)
+
     return result

--- a/ayon_server/settings/overrides.py
+++ b/ayon_server/settings/overrides.py
@@ -132,12 +132,13 @@ def list_overrides(
                         }
 
         elif isinstance(child, tuple):
-            result[path] = {
-                "path": chcrumbs,
-                "value": override[name] if name in override else list(child),
-                "level": level if name in override else "default",
-                "inGroup": in_group,
-            }
+            if name in override:
+                result[path] = {
+                    "path": chcrumbs,
+                    "value": override[name] if name in override else list(child),
+                    "level": level if name in override else "default",
+                    "inGroup": in_group,
+                }
 
         elif name in override:
             result[path] = {

--- a/ayon_server/utils.py
+++ b/ayon_server/utils.py
@@ -4,6 +4,7 @@ import asyncio
 import datetime
 import functools
 import hashlib
+import json
 import random
 import threading
 import time
@@ -24,6 +25,16 @@ def isinstance_namedtuple(obj) -> bool:
     return (
         isinstance(obj, tuple) and hasattr(obj, "_asdict") and hasattr(obj, "_fields")
     )
+
+
+def json_print(data: Any, header: str | None = None) -> None:
+    """Print JSON data."""
+    if header:
+        print()
+        print(header, flush=True)
+    print(json.dumps(data, indent=2), flush=True)
+    if header:
+        print()
 
 
 def json_default_handler(value: Any) -> Any:


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

`migrate_settings` function in `BaseServerAddon.convert_settings_overrides` is replaced by `migrate_settings_overrides`.

### Technical details

The new function does not return BaseSettingsModel which needs to be postprocessed, rather it returns a dict, so input and output have the same format and it makes it possible to know which values actually have overrides.

The new function drops the original custom_conversions functionality as it was overengineered and not used.

Additionally, modify_settings endpoints now accept `__pinned_fields__` list, that enables explicit pinning of default values via settings editor (without pin_override function). 
