### PR TITLE
Settings: fix copying deeply nested lists of submodels

### DIFF
--- a/ayon_server/settings/common.py
+++ b/ayon_server/settings/common.py
@@ -1,6 +1,7 @@
 import inspect
 import re
-from typing import Any, Callable, GenericAlias, Type
+from types import GenericAlias
+from typing import Any, Callable, Type
 
 from nxtools import logging
 from pydantic import BaseModel, ValidationError, parse_obj_as

--- a/ayon_server/settings/common.py
+++ b/ayon_server/settings/common.py
@@ -36,7 +36,7 @@ def migrate_settings_overrides(
 ) -> dict[str, Any]:
     """Migrate settings overrides from old data to new model class."""
 
-    new_data = {}
+    new_data: dict[str, Any] = {}
 
     # if not parent_key:
     #     json_print(old_data, "Old data")
@@ -66,9 +66,12 @@ def migrate_settings_overrides(
                     ]
 
                 elif isinstance(value, dict):
+                    # TODO: ensure that the field is indeed a submodel
+                    # it should, but we should check
+
                     new_data[key] = migrate_settings_overrides(
                         value,
-                        field_type.outer_type_,
+                        field_type.outer_type_,  # type: ignore
                         defaults.get(key, {}),
                         custom_conversions,
                         key_path,


### PR DESCRIPTION
## Description of changes

Fixes setting migration when overrides are on list of submodels.

### Technical details

`migrate_settings_overrides` now check whether a field is a list of submodels and in that case,
iterate over all elements and parses them individually.

### Testing

see the linked issue

### Additional context

![image](https://github.com/ynput/ayon-backend/assets/5007200/1c37512b-2755-4425-9ee1-7ffa604a6192)
