### PR TITLE
Setup: support for bootstrapping access groups

### DIFF
--- a/setup/access_groups.py
+++ b/setup/access_groups.py
@@ -4,6 +4,9 @@ from ayon_server.lib.postgres import Postgres
 
 
 async def deploy_access_groups(access_groups: list[dict[str, Any]]) -> None:
+    if not access_groups:
+        return
+
     for access_group in access_groups:
         name = access_group["name"]
         data = access_group["data"]

--- a/setup/access_groups.py
+++ b/setup/access_groups.py
@@ -4,15 +4,28 @@ from ayon_server.lib.postgres import Postgres
 
 
 async def deploy_access_groups(access_groups: list[dict[str, Any]]) -> None:
-    existing_access_groups = await Postgres.fetch(
-        "SELECT name FROM public.access_groups"
-    )
-    if existing_access_groups:
-        return
+    for access_group in access_groups:
+        name = access_group["name"]
+        data = access_group["data"]
+        forceUpdate = access_group.get("forceUpdate", False)
 
-    await Postgres.execute(
-        """
-        INSERT INTO access_groups (name, data)
-        VALUES ('editor', '{}'::jsonb)
-        """
-    )
+        if forceUpdate:
+            await Postgres.execute(
+                """
+                INSERT INTO access_groups (name, data)
+                VALUES ($1, $2::jsonb) ON CONFLICT (name) DO UPDATE
+                SET data = $2::jsonb
+                """,
+                name,
+                data,
+            )
+        else:
+            await Postgres.execute(
+                """
+                INSERT INTO access_groups (name, data)
+                VALUES ($1, $2::jsonb)
+                ON CONFLICT (name) DO NOTHING
+                """,
+                name,
+                data,
+            )

--- a/setup/users.py
+++ b/setup/users.py
@@ -11,6 +11,9 @@ async def deploy_users(
     projects: list[str],
 ) -> None:
     """Create users in the database."""
+    if not users:
+        return
+
     for user in users:
         name = user["name"]
         attrib = {}


### PR DESCRIPTION
It is now possible to ensure access groups are created during setup.
Access groups are defined in template.json file as follows

```json
  "accessGroups": [
    {
      "name": "publisher",
      "forceUpdate": false,
      "data": {
        "read": { "enabled": false, "access_list": [] },
        "create": { "enabled": true, "access_list": [] },
        "delete": { "enabled": true, "access_list": [] },
        "update": { "enabled": true, "access_list": [] },
        "publish": {
          "enabled": true,
          "access_list": [{ "path": null, "access_type": "assigned" }]
        },
        "endpoints": { "enabled": false, "endpoints": [] },
        "attrib_read": { "enabled": false, "attributes": [] },
        "attrib_write": { "enabled": false, "attributes": [] }
      }
    }
  ]
```

- `data` field follows accessGroup model as specified in REST API,
- `forceUpdate` flag ensures existing accessGroup is always updated to configuration specified in the template