### PR TITLE
Settings: resolver for addon app host names

### DIFF
--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -579,3 +579,18 @@ class BaseServerAddon:
             new_model_class=model_class,
             defaults=defaults.dict(),
         )
+
+    async def get_app_host_names(self) -> list[str]:
+        """Return a list of application host names that the addon uses.
+
+        Addon may reimplment this method to return a list of host names that
+        the addon uses.
+
+        By default, it returns a single host name from the
+        addon's attributes. If the addon uses multiple host names, you should
+        override this method.
+        """
+
+        if self.app_host_name is None:
+            return []
+        return [self.app_host_name]


### PR DESCRIPTION
Added `addon_all_app_host_names_enum` resolver:

```
    app_host_names: list[str] = Field(
        default_factory=list,
        title="App host names",
        enum_resolver=addon_all_app_host_names_enum,
    )
```

![image](https://github.com/ynput/ayon-backend/assets/5007200/750c1756-c68e-4753-88d7-d65fb0378099)

`all_` is used to allow future expansion to `addon_production_app_host_names_enum` and `addon_staging_app_host_names_enum` which are out of the scope of this PR
