### PR TITLE
REST API: Unify SiteID specifications 

### DIFF
--- a/api/addons/project_settings.py
+++ b/api/addons/project_settings.py
@@ -6,7 +6,7 @@ from nxtools import logging
 from pydantic.error_wrappers import ValidationError
 
 from ayon_server.addons import AddonLibrary
-from ayon_server.api.dependencies import CurrentUser, ProjectName
+from ayon_server.api.dependencies import CurrentUser, ProjectName, SiteID
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.config import ayonconfig
 from ayon_server.entities import ProjectEntity
@@ -37,8 +37,8 @@ async def get_addon_project_settings_schema(
     version: str,
     project_name: ProjectName,
     user: CurrentUser,
+    site_id: SiteID,
     variant: str = Query("production"),
-    site: str | None = Query(None, regex="^[a-z0-9-]+$"),
 ) -> dict[str, Any]:
     """Return the JSON schema of the addon settings."""
 
@@ -55,7 +55,7 @@ async def get_addon_project_settings_schema(
         "addon": addon,
         "project_name": project_name,
         "settings_variant": variant,
-        "site_id": site,
+        "site_id": site_id,
         "user_name": user.name,
     }
 
@@ -75,16 +75,16 @@ async def get_addon_project_settings(
     version: str,
     project_name: ProjectName,
     user: CurrentUser,
+    site_id: SiteID,
     variant: str = Query("production"),
-    site: str | None = Query(None, regex="^[a-z0-9-]+$"),
     as_version: str | None = Query(None, alias="as"),
 ) -> BaseSettingsModel:
     if (addon := AddonLibrary.addon(addon_name, version)) is None:
         raise NotFoundException(f"Addon {addon_name} {version} not found")
 
-    if site:
+    if site_id:
         settings = await addon.get_project_site_settings(
-            project_name, user.name, site, variant=variant, as_version=as_version
+            project_name, user.name, site_id, variant=variant, as_version=as_version
         )
     else:
         settings = await addon.get_project_settings(
@@ -102,8 +102,8 @@ async def get_addon_project_overrides(
     version: str,
     project_name: ProjectName,
     user: CurrentUser,
+    site_id: SiteID,
     variant: str = Query("production"),
-    site: str | None = Query(None, regex="^[a-z0-9-]+$"),
     as_version: str | None = Query(None, alias="as"),
 ):
     addon = AddonLibrary.addon(addon_name, version)
@@ -135,17 +135,17 @@ async def get_addon_project_overrides(
     ).items():
         result[k] = v
 
-    if site:
+    if site_id:
         site_overrides = await addon.get_project_site_overrides(
             project_name,
             user.name,
-            site,
+            site_id,
             as_version=as_version,
         )
         site_settings = await addon.get_project_site_settings(
             project_name,
             user.name,
-            site,
+            site_id,
             as_version=as_version,
         )
         if site_settings:
@@ -166,8 +166,8 @@ async def set_addon_project_settings(
     version: str,
     project_name: ProjectName,
     user: CurrentUser,
+    site_id: SiteID,
     variant: str = Query("production"),
-    site: str | None = Query(None, regex="^[a-z0-9-]+$"),
 ) -> EmptyResponse:
     """Set the project overrides of the given addon."""
 
@@ -178,7 +178,7 @@ async def set_addon_project_settings(
 
     explicit_pins = payload.pop("__pinned_fields__", None)
 
-    if not site:
+    if not site_id:
         if not user.is_manager:
             raise ForbiddenException
 
@@ -247,9 +247,9 @@ async def set_addon_project_settings(
     # site settings
 
     original = await addon.get_project_site_settings(
-        project_name, user.name, site, variant=variant
+        project_name, user.name, site_id, variant=variant
     )
-    existing = await addon.get_project_site_overrides(project_name, user.name, site)
+    existing = await addon.get_project_site_overrides(project_name, user.name, site_id)
     if original is None:
         # This addon does not have settings
         raise BadRequestException(f"Addon {addon_name} has no settings")
@@ -273,13 +273,13 @@ async def set_addon_project_settings(
         """,
         addon_name,
         version,
-        site,
+        site_id,
         user.name,
         data,
     )
 
     new_settings = await addon.get_project_site_settings(
-        project_name, user.name, site, variant=variant
+        project_name, user.name, site_id, variant=variant
     )
     if new_settings:
         await addon.on_settings_changed(
@@ -287,7 +287,7 @@ async def set_addon_project_settings(
             new_settings=new_settings,
             project_name=project_name,
             variant=variant,
-            site_id=site,
+            site_id=site_id,
             user_name=user.name,
         )
     return EmptyResponse()
@@ -301,14 +301,14 @@ async def delete_addon_project_overrides(
     version: str,
     user: CurrentUser,
     project_name: ProjectName,
+    site_id: SiteID,
     variant: str = Query("production"),
-    site: str | None = Query(None, regex="^[a-z0-9-]+$"),
 ):
     # Ensure the addon and the project exist
     addon = AddonLibrary.addon(addon_name, version)
     _ = await ProjectEntity.load(project_name)
 
-    if not site:
+    if not site_id:
         if not user.is_manager:
             raise ForbiddenException
 
@@ -361,12 +361,12 @@ async def delete_addon_project_overrides(
         """,
         addon_name,
         version,
-        site,
+        site_id,
         user.name,
     )
 
     old_settings = await addon.get_project_site_settings(
-        project_name, user.name, site, variant=variant
+        project_name, user.name, site_id, variant=variant
     )
     new_settings = await addon.get_project_settings(project_name, variant=variant)
 
@@ -376,7 +376,7 @@ async def delete_addon_project_overrides(
             new_settings=new_settings,
             project_name=project_name,
             variant=variant,
-            site_id=site,
+            site_id=site_id,
             user_name=user.name,
         )
 
@@ -392,16 +392,16 @@ async def modify_project_overrides(
     version: str,
     project_name: ProjectName,
     user: CurrentUser,
+    site_id: SiteID,
     variant: str = Query("production"),
-    site: str | None = Query(None, regex="^[a-z0-9-]+$"),
 ):
     addon = AddonLibrary.addon(addon_name, version)
     if not addon:
         raise NotFoundException(f"Addon {addon_name}:{version} not found")
 
-    if site:
+    if site_id:
         old_settings = await addon.get_project_site_settings(
-            project_name, user.name, site, variant=variant
+            project_name, user.name, site_id, variant=variant
         )
 
         if payload.action == "delete":
@@ -409,7 +409,7 @@ async def modify_project_overrides(
                 addon_name,
                 version,
                 project_name,
-                site,
+                site_id,
                 user.name,
                 payload.path,
             )
@@ -419,13 +419,13 @@ async def modify_project_overrides(
                 addon_name,
                 version,
                 project_name,
-                site,
+                site_id,
                 user.name,
                 payload.path,
             )
 
         new_settings = await addon.get_project_site_settings(
-            project_name, user.name, site, variant=variant
+            project_name, user.name, site_id, variant=variant
         )
 
         if new_settings and old_settings:
@@ -434,7 +434,7 @@ async def modify_project_overrides(
                 new_settings=new_settings,
                 project_name=project_name,
                 variant=variant,
-                site_id=site,
+                site_id=site_id,
                 user_name=user.name,
             )
 
@@ -481,10 +481,10 @@ async def get_raw_addon_project_overrides(
     addon_version: str,
     user: CurrentUser,
     project_name: ProjectName,
+    site_id: SiteID,
     variant: str = Query("production"),
-    site: str | None = Query(None, regex="^[a-z0-9-]+$"),
 ) -> dict[str, Any]:
-    if site:
+    if site_id:
         result = await Postgres.fetch(
             f"""
             SELECT data FROM project_{project_name}.project_site_settings
@@ -495,7 +495,7 @@ async def get_raw_addon_project_overrides(
             """,
             addon_name,
             addon_version,
-            site,
+            site_id,
             user.name,
         )
 
@@ -531,8 +531,8 @@ async def set_raw_addon_project_overrides(
     payload: dict[str, Any],
     user: CurrentUser,
     project_name: ProjectName,
+    site_id: SiteID,
     variant: str = Query("production"),
-    site: str | None = Query(None, regex="^[a-z0-9-]+$"),
 ) -> EmptyResponse:
     """Set raw studio overrides for an addon.
 
@@ -544,7 +544,7 @@ async def set_raw_addon_project_overrides(
     behaviour if used incorrectly.
     """
 
-    if site:
+    if site_id:
         await Postgres.execute(
             f"""
             INSERT INTO project_{project_name}.project_site_settings
@@ -556,7 +556,7 @@ async def set_raw_addon_project_overrides(
             """,
             addon_name,
             addon_version,
-            site,
+            site_id,
             user.name,
             payload,
         )

--- a/api/projects/roots.py
+++ b/api/projects/roots.py
@@ -77,7 +77,7 @@ async def set_project_roots_overrides(
 async def get_project_site_roots(
     project_name: ProjectName,
     user: CurrentUser,
-    site_id: SiteID | None = None,
+    site_id: SiteID,
     platform: Platform | None = None,
 ) -> dict[str, str]:
     """Return roots for a project on a specific site.

--- a/api/projects/roots.py
+++ b/api/projects/roots.py
@@ -1,6 +1,6 @@
 from fastapi import Path
 
-from ayon_server.api.dependencies import CurrentUser, ProjectName, SiteID
+from ayon_server.api.dependencies import ClientSiteID, CurrentUser, ProjectName
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.entities import ProjectEntity
 from ayon_server.helpers.roots import get_roots_for_projects
@@ -51,7 +51,7 @@ async def set_project_roots_overrides(
     for root_name in project.config["roots"]:
         if root_name not in payload:
             payload.pop(root_name, None)
-        if not payload[root_name]:
+        elif not payload.get(root_name):
             payload.pop(root_name, None)
 
     if payload:
@@ -77,7 +77,7 @@ async def set_project_roots_overrides(
 async def get_project_site_roots(
     project_name: ProjectName,
     user: CurrentUser,
-    site_id: SiteID,
+    site_id: ClientSiteID,
     platform: Platform | None = None,
 ) -> dict[str, str]:
     """Return roots for a project on a specific site.
@@ -91,6 +91,9 @@ async def get_project_site_roots(
     """
 
     all_roots = await get_roots_for_projects(
-        user.name, site_id, [project_name], platform
+        user.name,
+        site_id,
+        [project_name],
+        platform,
     )
     return all_roots[project_name]

--- a/api/resolve/__init__.py
+++ b/api/resolve/__init__.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qs, urlparse
 
 from fastapi import APIRouter, Query
 
-from ayon_server.api.dependencies import CurrentUser, SiteID
+from ayon_server.api.dependencies import ClientSiteID, CurrentUser
 from ayon_server.exceptions import BadRequestException, ServiceUnavailableException
 from ayon_server.helpers.roots import get_roots_for_projects
 from ayon_server.lib.postgres import Postgres
@@ -377,7 +377,7 @@ async def get_platform_for_site_id(site_id: str) -> str:
 @router.post("/resolve", response_model_exclude_none=True)
 async def resolve_uris(
     request: ResolveRequestModel,
-    site_id: SiteID,
+    site_id: ClientSiteID,
     user: CurrentUser,
     path_only: bool = Query(
         False,

--- a/api/resolve/__init__.py
+++ b/api/resolve/__init__.py
@@ -380,7 +380,9 @@ async def resolve_uris(
     site_id: SiteID,
     user: CurrentUser,
     path_only: bool = Query(
-        False, alias="pathOnly", description="Return only file paths"
+        False,
+        alias="pathOnly",
+        description="Return only file paths",
     ),
 ) -> list[ResolvedURIModel]:
     """Resolve a list of ayon:// URIs to entities.

--- a/api/settings/settings.py
+++ b/api/settings/settings.py
@@ -5,7 +5,7 @@ from fastapi import Query
 from nxtools import log_traceback, logging
 
 from ayon_server.addons import AddonLibrary
-from ayon_server.api.dependencies import CurrentUser
+from ayon_server.api.dependencies import CurrentUser, SiteID
 from ayon_server.exceptions import NotFoundException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.settings import BaseSettingsModel
@@ -52,6 +52,7 @@ class AllSettingsResponseModel(OPModel):
 @router.get("/settings", response_model_exclude_none=True)
 async def get_all_settings(
     user: CurrentUser,
+    site_id: SiteID,
     bundle_name: str | None = Query(
         None,
         title="Bundle name",
@@ -63,10 +64,6 @@ async def get_all_settings(
         title="Project name",
         description="Studio settings if not set",
         regex=NAME_REGEX,
-    ),
-    site_id: str | None = Query(
-        None,
-        title="Site ID",
     ),
     variant: str = Query("production"),
     summary: bool = Query(False, title="Summary", description="Summary mode"),

--- a/ayon_server/api/dependencies.py
+++ b/ayon_server/api/dependencies.py
@@ -435,7 +435,10 @@ async def dep_site_id(
         ),
     ),
 ) -> str | None:
-    """Validate and return a site id specified in an endpoint header."""
+    """Validate and return a site id
+
+    SiteID may be specified in an endpoint header or query parameter.
+    """
     return param1 or param2 or x_ayon_site_id
 
 

--- a/ayon_server/api/dependencies.py
+++ b/ayon_server/api/dependencies.py
@@ -432,7 +432,7 @@ def validate_site_id(site_id: str | None) -> None:
         raise ValueError(f"Invalid site id: {site_id}")
 
 
-async def dep_site_id(
+async def dep_client_site_id(
     param1: str | None = Query(
         None, title="Site ID", alias="site_id", include_in_schema=False
     ),
@@ -458,10 +458,10 @@ async def dep_site_id(
     return site_id
 
 
-ClientSiteID = Annotated[str | None, Depends(dep_site_id)]
+ClientSiteID = Annotated[str | None, Depends(dep_client_site_id)]
 
 
-async def dep_client_site_id(
+async def dep_site_id(
     param1: str | None = Query(
         None,
         title="Site ID",
@@ -488,4 +488,4 @@ async def dep_client_site_id(
     return site_id
 
 
-SiteID = Annotated[str | None, Depends(dep_client_site_id)]
+SiteID = Annotated[str | None, Depends(dep_site_id)]

--- a/ayon_server/api/dependencies.py
+++ b/ayon_server/api/dependencies.py
@@ -420,13 +420,26 @@ LinkType = Annotated[tuple[str, str, str], Depends(dep_link_type)]
 
 
 async def dep_site_id(
-    x_ayon_site_id: str | None = Header(None, title="Site ID"),
+    param1: str | None = Query(
+        None, title="Site ID", alias="site_id", include_in_schema=False
+    ),
+    param2: str | None = Query(
+        None, title="Site ID", alias="site", include_in_schema=False
+    ),
+    x_ayon_site_id: str | None = Header(
+        None,
+        title="Site ID",
+        description=(
+            "Site ID may be specified either "
+            "as a query parameter (`site_id` or `site`) or in a header."
+        ),
+    ),
 ) -> str | None:
     """Validate and return a site id specified in an endpoint header."""
-    return x_ayon_site_id
+    return param1 or param2 or x_ayon_site_id
 
 
-SiteID = Annotated[str, Depends(dep_site_id)]
+SiteID = Annotated[str | None, Depends(dep_site_id)]
 
 
 async def dep_ynput_cloud_key() -> str:


### PR DESCRIPTION
This PR unifies site_id dependency across rest endpoints. Two dependencies `SiteID` and `ClientSiteID` are used as specified in the linked issue.

### Discussion & future

Endpoints `/api/projects/{project_name}/roots/{root_name}` still use site_id provided in path. This is inconsistent, but probably not worthed breaking the backwards compatibility.

`/api/settings` still expect site id to be provided as a query argument. Should it also accept header option as it is called from the client application and site_id is by default sent with the request? or do we need granularity here and option to get just project settings? @iLLiCiTiT 

### Testing

- Save project site settings and ensure they are correctly stored when different sites are used
- Save different site overrides for project roots
- Ensure site overrides for settings and roots are correctly propagated to the client
