### PR TITLE
Avatar: Better center initials

### DIFF
--- a/api/users/avatar.py
+++ b/api/users/avatar.py
@@ -68,7 +68,7 @@ def create_initials_svg(
       <text
         x="50%"
         y="50%"
-        dominant-baseline="middle"
+        dominant-baseline="central"
         text-anchor="middle"
         fill="{text_color}"
         font-size="{height // 2}px"


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
Uses `central` instead of `middle` for a better centering of the text in the avatar.
