### PR TITLE
Resolve user full names in assignee changed event hook

### DIFF
--- a/ayon_server/activities/event_hook.py
+++ b/ayon_server/activities/event_hook.py
@@ -80,20 +80,48 @@ class ActivityFeedEventHook:
         added = set(new_value) - set(old_value)
         removed = set(old_value) - set(new_value)
 
+        all_assignees = list(set(old_value) | set(new_value))
+
+        # Get all assignees full names
+
+        if not all_assignees:
+            return  # this shouldn't happen, but let's keep mypy happy
+
+        name_tags: dict[str, str] = {
+            name: f"[{name}](user:{name})" for name in all_assignees
+        }
+        q = """
+            SELECT name, attrib->>'fullName' as full_name
+            FROM users WHERE name = ANY($1)
+            AND attrib->>'fullName' IS NOT NULL
+        """
+
+        async for row in Postgres.iterate(q, all_assignees):
+            if not row["full_name"]:
+                continue
+            name_tag = f"[{row['full_name']}](user:{row['name']})"
+            name_tags[row["name"]] = name_tag
+
+        # create activities
+
+        entity_tag = f"[{entity.name}](task:{entity.id})"
+
         for assignee in added:
+            name_tag = name_tags[assignee]
             await create_activity(
                 entity,
                 activity_type="assignee.add",
-                body=f"Added {assignee} to [{entity.name}](task:{entity.id})",
+                body=f"Added {name_tag} to {entity_tag}",
                 user_name=event.user,
                 data={"assignee": assignee},
             )
 
         for assignee in removed:
+            name_tag = name_tags[assignee]
             await create_activity(
                 entity,
                 activity_type="assignee.remove",
-                body=f"Removed {assignee} from [{entity.name}](task:{entity.id})",
+                body=f"Removed {name_tag} from {entity_tag}",
                 user_name=event.user,
                 data={"assignee": assignee},
             )


### PR DESCRIPTION
## PR Checklist

Event hook creating activities when assignee list changes now resolves user full names
and populates the activity body with a correct link.

![image](https://github.com/ynput/ayon-backend/assets/5007200/af34e2eb-003f-4294-a7e8-23575a5d0921)
