### PR TITLE
Addons library: More api options to receive addons

### DIFF
--- a/ayon_server/addons/library.py
+++ b/ayon_server/addons/library.py
@@ -145,25 +145,26 @@ class AddonLibrary:
             output[addon_name] = addon
         return output
 
-    async def get_production_addon(self, addon_name: str) -> BaseServerAddon | None:
-        """Return a production instance of the addon."""
+    async def get_addon_by_variant(
+        self, addon_name: str, variant: str
+    ) -> BaseServerAddon | None:
+        """Return instance of the addon by variant."""
         active_versions = await self.get_active_versions()
         if addon_name not in active_versions:
             return None
-        production_version = active_versions[addon_name]["production"]
-        if production_version is None:
+        addon_version = active_versions[addon_name].get(variant)
+        if addon_version is None:
             return None
-        return self[addon_name][production_version]
+        return self[addon_name][addon_version]
+
+
+    async def get_production_addon(self, addon_name: str) -> BaseServerAddon | None:
+        """Return a production instance of the addon."""
+        return await self.get_addon_by_variant(addon_name, "production")
 
     async def get_staging_addon(self, addon_name: str) -> BaseServerAddon | None:
         """Return a staging instance of the addon."""
-        active_versions = await self.get_active_versions()
-        if addon_name not in active_versions:
-            return None
-        staging_version = active_versions[addon_name]["staging"]
-        if staging_version is None:
-            return None
-        return self[addon_name][staging_version]
+        return await self.get_addon_by_variant(addon_name, "staging")
 
     @classmethod
     def unload_addon(

--- a/ayon_server/addons/library.py
+++ b/ayon_server/addons/library.py
@@ -95,11 +95,14 @@ class AddonLibrary:
 
     async def get_active_versions(self) -> dict[str, dict[str, Optional[str]]]:
         bundles = await Postgres.fetch(
-            "SELECT name, is_production, is_staging, is_dev, data->'addons' as addons FROM bundles"
+            """
+            SELECT name, is_production, is_staging, is_dev, data->'addons' as addons
+            FROM bundles
+            """
         )
         bundles_by_variant: dict[str, Optional[dict[str, Any]]] = {
             "production": None,
-            "staging": None
+            "staging": None,
         }
         for bundle in bundles:
             if bundle["is_dev"]:
@@ -156,7 +159,6 @@ class AddonLibrary:
         if addon_version is None:
             return None
         return self[addon_name][addon_version]
-
 
     async def get_production_addon(self, addon_name: str) -> BaseServerAddon | None:
         """Return a production instance of the addon."""

--- a/ayon_server/addons/library.py
+++ b/ayon_server/addons/library.py
@@ -80,9 +80,9 @@ class AddonLibrary:
         return instance.data.items()
 
     @classmethod
-    def get(cls, key: str) -> ServerAddonDefinition | None:
+    def get(cls, key: str, default: Any = None) -> ServerAddonDefinition | None:
         instance = cls.getinstance()
-        return instance.data.get(key, None)
+        return instance.data.get(key, default)
 
     def __getitem__(self, key) -> ServerAddonDefinition:
         return self.data[key]


### PR DESCRIPTION
## Description of changes
`AddonLibrary` has api functions to get addons by variant, not just `"production"` and `"staging"` but dev bundles too.

### Technical details
Modified `get_active_versions` to also collect addon versions for dev bundles. Implemented helper methods `get_addon_versions_by_variant`, `get_addons_by_variant` and `get_addon_by_variant` as api functions. Function `get_addon_by_variant` is also used by `get_production_addon` and `get_staging_addon`.
