### PR TITLE
Disallow listing users from unassigned projects

### DIFF
--- a/ayon_server/graphql/__init__.py
+++ b/ayon_server/graphql/__init__.py
@@ -10,6 +10,7 @@ from strawberry.fastapi import GraphQLRouter
 from strawberry.types import ExecutionContext
 
 from ayon_server.api.dependencies import CurrentUser
+from ayon_server.exceptions import AyonException
 from ayon_server.graphql.connections import (
     EventsConnection,
     InboxConnection,
@@ -156,6 +157,9 @@ class AyonSchema(strawberry.Schema):
         execution_context: ExecutionContext | None = None,
     ) -> None:
         for error in errors:
+            if isinstance(error.original_error, AyonException):
+                error.extensions = {"status": error.original_error.status}
+
             tb = traceback.extract_tb(error.__traceback__)
             if not tb:
                 continue

--- a/ayon_server/graphql/resolvers/users.py
+++ b/ayon_server/graphql/resolvers/users.py
@@ -75,6 +75,9 @@ async def get_users(
         cnd = f"({cnd1} OR {cnd2} OR {cnd3})"
         sql_conditions.append(cnd)
 
+    # TODO: allow listing users from all project for normal users, but only if they are
+    #       assigned to the project
+
     #
     # Pagination
     #

--- a/ayon_server/graphql/resolvers/users.py
+++ b/ayon_server/graphql/resolvers/users.py
@@ -64,6 +64,10 @@ async def get_users(
         sql_conditions.append(f"users.name IN {SQLTool.array(names)}")
 
     if project_name is not None:
+        if not user.is_manager:
+            if project_name not in user.data.get("accessGroups", {}):
+                raise ForbiddenException("You don't have access to this project")
+
         cnd1 = "users.data->>'isAdmin' = 'true'"
         cnd2 = "users.data->>'isManager' = 'true'"
         cnd3 = f"""(users.data->'accessGroups'->'{project_name}' IS NOT NULL


### PR DESCRIPTION
Fixes: https://github.com/ynput/ayon-backend/issues/236

It is no longer possible to list users from project that you are not assigned to.
Additionally, a status code from AyonException is passed to graphql error extensions.