### PR TITLE
Exclude addon endpoints and auth headers from openapi

### DIFF
--- a/ayon_server/api/dependencies.py
+++ b/ayon_server/api/dependencies.py
@@ -33,9 +33,11 @@ from ayon_server.utils import (
 
 
 async def dep_access_token(
-    authorization: Annotated[str | None, Header()] = None,
-    token: Annotated[str | None, Query()] = None,
-    access_token: Annotated[str | None, Cookie(alias="accessToken")] = None,
+    authorization: Annotated[str | None, Header(include_in_schema=False)] = None,
+    token: Annotated[str | None, Query(include_in_schema=False)] = None,
+    access_token: Annotated[
+        str | None, Cookie(alias="accessToken", include_in_schema=False)
+    ] = None,
 ) -> str | None:
     """Parse and return an access token provided in the authorisation header."""
     if token is not None:
@@ -55,8 +57,8 @@ AccessToken = Annotated[str, Depends(dep_access_token)]
 
 
 async def dep_api_key(
-    authorization: str = Header(None),
-    x_api_key: str = Header(None),
+    authorization: str = Header(None, include_in_schema=False),
+    x_api_key: str = Header(None, include_in_schema=False),
 ) -> str | None:
     """Parse and return an api key provided in the authorisation header."""
     api_key: str | None
@@ -88,8 +90,10 @@ ThumbnailContentType = Annotated[str, Depends(dep_thumbnail_content_type)]
 
 async def dep_current_user(
     request: Request,
-    x_as_user: str | None = Header(None, regex=USER_NAME_REGEX),
-    x_api_key: str | None = Header(None, regex=API_KEY_REGEX),
+    x_as_user: str | None = Header(
+        None, regex=USER_NAME_REGEX, include_in_schema=False
+    ),
+    x_api_key: str | None = Header(None, regex=API_KEY_REGEX, include_in_schema=False),
     access_token: str | None = Depends(dep_access_token),
     api_key: str | None = Depends(dep_api_key),
 ) -> UserEntity:
@@ -148,8 +152,10 @@ async def dep_current_user_optional(
     request: Request,
     access_token: AccessToken,
     api_key: ApiKey,
-    x_as_user: str | None = Header(None, regex=USER_NAME_REGEX),
-    x_api_key: str | None = Header(None, regex=API_KEY_REGEX),
+    x_as_user: str | None = Header(
+        None, regex=USER_NAME_REGEX, include_in_schema=False
+    ),
+    x_api_key: str | None = Header(None, regex=API_KEY_REGEX, include_in_schema=False),
 ) -> UserEntity | None:
     try:
         user = await dep_current_user(

--- a/ayon_server/api/metadata.py
+++ b/ayon_server/api/metadata.py
@@ -26,8 +26,19 @@ tags_meta: list[dict[str, Any]] = [
         "name": "Authentication",
         "description": """
 Authentication endpoints. Most of the endpoints require authentication.
-This is done by passing `Authorization` header with `Bearer <token>` value.
-        """,
+
+There are two methods of authentication:
+
+- Clients, such as the web interface or Ayon launcher use
+  `Authorization` header with `Bearer <token>` value.
+  Token is obtained by calling the `/auth/login` endpoint.
+  When not in use, the token expires after one day.
+- Services use x-api-key header with the API key value.
+  API key is generated in the user settings and can be revoked at any time.
+
+Services can additionally use `x-as-user` header to impersonate another user.
+This is useful for services that need to create data on behalf of another user.
+""",
     },
     {
         "name": "Projects",

--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -332,6 +332,7 @@ def init_addon_endpoints(target_app: fastapi.FastAPI) -> None:
                 target_app.add_api_route(
                     path,
                     endpoint["handler"],
+                    include_in_schema=ayonconfig.openapi_include_addon_endpoints,
                     methods=[endpoint["method"]],
                     name=endpoint["name"],
                     tags=[f"{addon_definition.friendly_name} {version}"],

--- a/ayon_server/config.py
+++ b/ayon_server/config.py
@@ -155,6 +155,11 @@ class AyonConfig(BaseModel):
         description="Enable audit trail",
     )
 
+    openapi_include_addon_endpoints: bool = Field(
+        default=False,
+        description="Include addon endpoints in the OpenAPI schema",
+    )
+
     log_retention_days: int = Field(
         default=7,
         description="Number of days to keep logs in the event log",


### PR DESCRIPTION
This PR introduces changes to the way we use OpenAPI schema for generating TypeScript definitions.

## Key Changes

### Addon Endpoints Filtering

Addon endpoints, which are primarily relevant for addon developers, will now be excluded from the schema by default.
These endpoints can be included by setting the `ayon_openapi_include_addon_endpoints` environment variable.
This change reduces unnecessary noise in the schema and improves clarity for the majority of users.

### Authorization Options Streamlining

Shared authorization options, which are repeated across all endpoints, are now excluded from the schema.
Instead, authorization methods are comprehensively described in the Authorization section of the REST documentation. This avoids redundancy and centralizes authorization information for easier maintenance and reference.

### Security Considerations

Excluding addon endpoints by default enhances operational security as these endpoints could potentially expose sensitive information or vulnerabilities. Opting in to include these endpoints ensures they are only exposed when necessary.