### PR TITLE
Settings: Update default hero publish template to include frame and udim

### DIFF
--- a/ayon_server/settings/anatomy/templates.py
+++ b/ayon_server/settings/anatomy/templates.py
@@ -132,7 +132,7 @@ class Templates(BaseSettingsModel):
             HeroTemplate(
                 name="default",
                 directory="{root[work]}/{project[name]}/{hierarchy}/{folder[name]}/publish/{product[type]}/{product[name]}/hero",  # noqa: E501
-                file="{project[code]}_{folder[name]}_{task[name]}_hero<_{comment}>.{ext}",  # noqa: E501
+                file="{project[code]}_{folder[name]}_{product[name]}_hero<_{output}><.{@frame}><_{udim}>.{ext}",  # noqa: E501
             )
         ],
     )


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [ ] Referenced issue is linked

## Description of changes

Update default hero template to contain match default publish template but with version swapped to `hero`

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

It's good to be aware that this may introduce more complexities because with hero version publishes it may be the case that previous hero versions had different frames and as such, it may occur that 'frames' that _should not_ be there anymore do not actually belong to the new version - same goes for UDIMs.

What becomes worse then is if e.g. a path set inside a DCC just happens to be referring to e.g. a start frame of the hero that's not supposed to be there in the new version. Which means you're basically potentially losing the 'static' nature of what a hero version tries to be? **This is why I'm creating this as DRAFT since that may need to be taken seriously.**

**NOTE:** This PR also replaces **task name** in the filename to **product name** to align with default regular publish template because it seemed odd that those differed - but maybe there were reasons to have that task name instead of product name for hero files?

### Additional context

This has come up before as an issue here:

- [Ynput Community forum: Hero Publishing UDIMs](https://community.ynput.io/t/hero-publishing-udims)
- [Ynput Community forum: Houdini Hero Publishing Per Frame geo pointcache](https://community.ynput.io/t/creating-hero-versions-of-per-frame-houdini-geo-caches/1358/8)

A potential error that would be hit, is e.g. this:
```
DEBUG: --- Integration of Hero version for product `pointcacheGeo` begins.
DEBUG: Looking for matching profile for: hosts: "houdini" | product_types: "pointcache" | task_names: "modeling" | task_types: "Modeling"
DEBUG: "houdini" not found in "hosts": ['standalonepublisher']
DEBUG: None of profiles match your setup. hosts: "houdini" | product_types: "pointcache" | task_names: "modeling" | task_types: "Modeling"
DEBUG: `hero` template check was successful. `{root[work]}/{project[name]}/{hierarchy}/{folder[name]}/publish/{product[type]}/{product[name]}/hero/{project[code]}_{folder[name]}_{task[name]}_hero<_{comment}>.{ext}`
DEBUG: hero publish dir: "C:\projects\ayontest\asset\char_hero\publish\pointcache\pointcacheGeo\hero"
DEBUG: http://localhost:5000 "POST /graphql HTTP/1.1" 200 105
DEBUG: Response <RestApiResponse [200]>
DEBUG: Creating first hero version.
ERROR: !!! Creating of hero version failed. Previous hero version maybe lost some data!
Traceback (most recent call last):
  File "C:\Users\User\AppData\Local\Ynput\AYON\dependency_packages\ayon_2403061937_windows.zip\dependencies\pyblish\plugin.py", line 527, in __explicit_process
    runner(*args)
  File "E:\dev\ayon-core\client\ayon_core\plugins\publish\integrate_hero_version.py", line 127, in process
    self.integrate_instance(
  File "E:\dev\ayon-core\client\ayon_core\plugins\publish\integrate_hero_version.py", line 390, in integrate_instance
    head, tail = _template_filled.split(frame_splitter)
ValueError: not enough values to unpack (expected 2, got 1)
```
