### PR TITLE
Activity feed: notify clients when an activity is created, updated or deleted

### DIFF
--- a/api/activities/activity.py
+++ b/api/activities/activity.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from fastapi import BackgroundTasks
+from fastapi import BackgroundTasks, Header
 
 from ayon_server.activities import (
     ActivityType,
@@ -42,6 +42,7 @@ async def post_project_activity(
     entity_id: PathEntityID,
     user: CurrentUser,
     activity: ProjectActivityPostModel,
+    x_sender: str | None = Header(default=None),
 ) -> CreateActivityResponseModel:
     """Create an activity.
 
@@ -67,6 +68,7 @@ async def post_project_activity(
         files=activity.files,
         user_name=user.name,
         timestamp=activity.timestamp,
+        sender=x_sender,
     )
 
     return CreateActivityResponseModel(id=id)

--- a/api/activities/activity.py
+++ b/api/activities/activity.py
@@ -79,6 +79,7 @@ async def delete_project_activity(
     project_name: ProjectName,
     activity_id: str,
     user: CurrentUser,
+    x_sender: str | None = Header(default=None),
 ) -> EmptyResponse:
     """Delete an activity.
 
@@ -91,7 +92,12 @@ async def delete_project_activity(
     else:
         user_name = user.name
 
-    await delete_activity(project_name, activity_id, user_name=user_name)
+    await delete_activity(
+        project_name,
+        activity_id,
+        user_name=user_name,
+        sender=x_sender,
+    )
 
     return EmptyResponse()
 
@@ -108,6 +114,7 @@ async def patch_project_activity(
     user: CurrentUser,
     activity: ActivityPatchModel,
     background_tasks: BackgroundTasks,
+    x_sender: str | None = Header(default=None),
 ) -> EmptyResponse:
     """Edit an activity.
 
@@ -126,6 +133,7 @@ async def patch_project_activity(
         body=activity.body,
         files=activity.files,
         user_name=user_name,
+        sender=x_sender,
     )
 
     background_tasks.add_task(delete_unused_files, project_name)

--- a/ayon_server/activities/update_activity.py
+++ b/ayon_server/activities/update_activity.py
@@ -25,6 +25,7 @@ async def update_activity(
     user_name: str | None = None,
     extra_references: list[ActivityReferenceModel] | None = None,
     data: dict[str, Any] | None = None,
+    sender: str | None = None,
 ) -> None:
     """Update an activity."""
 


### PR DESCRIPTION
When an activity is created RT `activity.created` event is dispatched with a list of all affected entities. that should trigger cache invalidation of the activity feed.

![image](https://github.com/ynput/ayon-backend/assets/5007200/6713d2b2-ce4d-48d5-a0eb-7dfdf3db3953)


Keep in mind, that sender matching will prevent originating browser tab receiving the message, so whoever creates the activity is responsible to invalidate their own cache. 

Don't forget subscribing to `activity.created` topic.


(the same structure is used for `activity.updated` and `activity.deleted` topics