### PR TITLE
Always return dict for entity.data

### DIFF
--- a/ayon_server/graphql/nodes/event.py
+++ b/ayon_server/graphql/nodes/event.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import strawberry
 
+from ayon_server.graphql.utils import parse_data
 from ayon_server.utils import get_nickname, json_dumps, obscure
 
 
@@ -37,7 +38,6 @@ def event_from_record(
             record["user_name"] = get_nickname(record["user_name"])
         if record["topic"].startswith("log") and record["description"]:
             record["description"] = obscure(record["description"])
-    data = record.get("data", {})
 
     return EventNode(
         id=record["id"],
@@ -53,7 +53,7 @@ def event_from_record(
         summary=json_dumps(record["summary"]),
         created_at=record["created_at"],
         updated_at=record["updated_at"],
-        data=json_dumps(data) if data else None,
+        data=parse_data(record.get("data")),
     )
 
 

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -8,8 +8,7 @@ from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.resolvers.products import get_products
 from ayon_server.graphql.resolvers.tasks import get_tasks
 from ayon_server.graphql.types import Info
-from ayon_server.graphql.utils import parse_attrib_data
-from ayon_server.utils import json_dumps
+from ayon_server.graphql.utils import parse_attrib_data, parse_data
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import ProductsConnection, TasksConnection
@@ -102,7 +101,6 @@ def folder_from_record(
     """Construct a folder node from a DB row."""
 
     own_attrib = list(record["attrib"].keys())
-    data = record.get("data")
 
     return FolderNode(
         project_name=project_name,
@@ -123,7 +121,7 @@ def folder_from_record(
             project_attrib=record["project_attributes"],
             inherited_attrib=record["inherited_attributes"],
         ),
-        data=json_dumps(data) if data else None,
+        data=parse_data(record.get("data")),
         created_at=record["created_at"],
         updated_at=record["updated_at"],
         child_count=record.get("child_count", 0),

--- a/ayon_server/graphql/nodes/product.py
+++ b/ayon_server/graphql/nodes/product.py
@@ -7,8 +7,7 @@ from ayon_server.entities import ProductEntity
 from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.resolvers.versions import get_versions
 from ayon_server.graphql.types import Info
-from ayon_server.graphql.utils import parse_attrib_data
-from ayon_server.utils import json_dumps
+from ayon_server.graphql.utils import parse_attrib_data, parse_data
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import VersionsConnection
@@ -121,8 +120,6 @@ def product_from_record(
         for id, vers in zip(version_ids, version_list):
             vlist.append(VersionListItem(id=id, version=vers))
 
-    data = record.get("data", {})
-
     return ProductNode(
         project_name=project_name,
         id=record["id"],
@@ -137,7 +134,7 @@ def product_from_record(
             user=context["user"],
             project_name=project_name,
         ),
-        data=json_dumps(data) if data else None,
+        data=parse_data(record.get("data")),
         active=record["active"],
         created_at=record["created_at"],
         updated_at=record["updated_at"],

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -17,9 +17,8 @@ from ayon_server.graphql.resolvers.representations import (
 from ayon_server.graphql.resolvers.tasks import get_task, get_tasks
 from ayon_server.graphql.resolvers.versions import get_version, get_versions
 from ayon_server.graphql.resolvers.workfiles import get_workfile, get_workfiles
-from ayon_server.graphql.utils import parse_attrib_data
+from ayon_server.graphql.utils import parse_attrib_data, parse_data
 from ayon_server.lib.postgres import Postgres
-from ayon_server.utils import json_dumps
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import (
@@ -220,7 +219,7 @@ def project_from_record(
             user=context["user"],
             project_name=record["name"],
         ),
-        data=json_dumps(data) if data else None,
+        data=parse_data(data),
         created_at=record["created_at"],
         updated_at=record["updated_at"],
     )

--- a/ayon_server/graphql/nodes/representation.py
+++ b/ayon_server/graphql/nodes/representation.py
@@ -7,8 +7,7 @@ from strawberry import LazyType
 from ayon_server.entities import RepresentationEntity
 from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.types import Info
-from ayon_server.graphql.utils import parse_attrib_data
-from ayon_server.utils import json_dumps
+from ayon_server.graphql.utils import parse_attrib_data, parse_data
 
 if TYPE_CHECKING:
     from ayon_server.graphql.nodes.version import VersionNode
@@ -100,11 +99,11 @@ def representation_from_record(
             user=context["user"],
             project_name=project_name,
         ),
-        data=json_dumps(data) if data else None,
+        data=parse_data(data),
         active=record["active"],
         created_at=record["created_at"],
         updated_at=record["updated_at"],
-        context=json_dumps(data.get("context", {})),
+        context=parse_data(data.get("context", {})),
         files=parse_files(record.get("files", [])),
     )
 

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -8,8 +8,8 @@ from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.resolvers.versions import get_versions
 from ayon_server.graphql.resolvers.workfiles import get_workfiles
 from ayon_server.graphql.types import Info
-from ayon_server.graphql.utils import parse_attrib_data
-from ayon_server.utils import get_nickname, json_dumps
+from ayon_server.graphql.utils import parse_attrib_data, parse_data
+from ayon_server.utils import get_nickname
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import VersionsConnection, WorkfilesConnection
@@ -101,7 +101,6 @@ def task_from_record(
         assignees = record["assignees"]
 
     own_attrib = list(record["attrib"].keys())
-    data = record.get("data", {})
 
     return TaskNode(
         project_name=project_name,
@@ -121,7 +120,7 @@ def task_from_record(
             project_name=project_name,
             inherited_attrib=record["parent_folder_attrib"],
         ),
-        data=json_dumps(data) if data else None,
+        data=parse_data(record.get("data", {})),
         active=record["active"],
         created_at=record["created_at"],
         updated_at=record["updated_at"],

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -7,8 +7,8 @@ from ayon_server.entities import VersionEntity
 from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.resolvers.representations import get_representations
 from ayon_server.graphql.types import Info
-from ayon_server.graphql.utils import parse_attrib_data
-from ayon_server.utils import get_nickname, json_dumps
+from ayon_server.graphql.utils import parse_attrib_data, parse_data
+from ayon_server.utils import get_nickname
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import RepresentationsConnection
@@ -103,7 +103,7 @@ def version_from_record(
             user=context["user"],
             project_name=project_name,
         ),
-        data=json_dumps(data) if data else None,
+        data=parse_data(data),
         created_at=record["created_at"],
         updated_at=record["updated_at"],
     )

--- a/ayon_server/graphql/nodes/workfile.py
+++ b/ayon_server/graphql/nodes/workfile.py
@@ -7,8 +7,7 @@ from strawberry import LazyType
 from ayon_server.entities import WorkfileEntity
 from ayon_server.graphql.nodes.common import BaseNode
 from ayon_server.graphql.types import Info
-from ayon_server.graphql.utils import parse_attrib_data
-from ayon_server.utils import json_dumps
+from ayon_server.graphql.utils import parse_attrib_data, parse_data
 
 if TYPE_CHECKING:
     from ayon_server.graphql.nodes.task import TaskNode
@@ -51,7 +50,6 @@ def workfile_from_record(
 ) -> WorkfileNode:
     """Construct a version node from a DB row."""
 
-    data = record.get("data", {})
     name = os.path.basename(record["path"])
 
     return WorkfileNode(
@@ -72,7 +70,7 @@ def workfile_from_record(
             user=context["user"],
             project_name=project_name,
         ),
-        data=json_dumps(data) if data else None,
+        data=parse_data(record.get("data")),
         created_at=record["created_at"],
         updated_at=record["updated_at"],
     )

--- a/ayon_server/graphql/utils.py
+++ b/ayon_server/graphql/utils.py
@@ -1,8 +1,11 @@
 from datetime import datetime
 from typing import Any, Literal
 
+from nxtools import logging
+
 from ayon_server.entities.core import attribute_library
 from ayon_server.entities.user import UserEntity
+from ayon_server.utils import json_dumps
 
 
 def parse_json_data(target_type, data):
@@ -74,3 +77,17 @@ def parse_attrib_data(
                     value = datetime.fromisoformat(value)
                 result[key] = value
     return target_type(**result)
+
+
+def parse_data(data: Any) -> str:
+    """Normalize entity.data field to a JSON string
+
+    Ensure data is a dictionary.
+    """
+    if not data:
+        return "{}"
+    if isinstance(data, dict):
+        return json_dumps(data)
+    else:
+        logging.warning(f"Invalid data type: {type(data)}")
+        return "{}"


### PR DESCRIPTION
Return `"{}"` instead of null for empty entity.data fields in graphql.

![image](https://github.com/user-attachments/assets/0de5506c-04c5-40ec-ac6e-3c130c38c44a)

In REST, it seems it already wored fine:

![image](https://github.com/user-attachments/assets/c87952aa-819c-4a77-b58e-2b60331b52b6)



Please consider if this is a desired behavior - since in graphql it is necessary to json.loads the data field, using "null" would allow skip this and gain a little performance (it is much easier to validate `is None` than parsing the json string)