### PR TITLE
Disable enroll when db pool is getting full

### DIFF
--- a/api/resolve/__init__.py
+++ b/api/resolve/__init__.py
@@ -272,11 +272,6 @@ async def resolve_entities(
     # if not req.path:
     #     return [ResolvedEntityModel(project_name=req.project_name)]
 
-    if Postgres.get_available_connections() < 3:
-        raise ServiceUnavailableException(
-            f"Postgres remaining pool size: {Postgres.get_available_connections()}"
-        )
-
     target_entity_type: ProjectLevelEntityType | None = None
 
     platform = None
@@ -432,6 +427,12 @@ async def resolve_uris(
     the server will resolve the file path to the actual absolute path.
 
     """
+
+    if Postgres.get_available_connections() < 3:
+        raise ServiceUnavailableException(
+            f"Postgres remaining pool size: {Postgres.get_available_connections()}"
+        )
+
     roots = {}
     if request.resolve_roots and site_id:
         projects = [parse_uri(uri).project_name for uri in request.uris]


### PR DESCRIPTION
Similarly to the check in `/api/resolve` enpoint, `/api/enroll` now returns `503` status when the database pool is overloaded. 
This signals connected services, that enroll is not available at the moment and they should try it later. 

Since evaluating this status has no overhead, it can be handled the same way as "no response" / "nothing to do". 

Reason: In the case DB is overloaded, `enroll` endpoint is the one that "can wait" and let a few connection in the pool available for UI. 