### PR TITLE
Authentication: create_session endpoint

### DIFF
--- a/api/auth/sessions.py
+++ b/api/auth/sessions.py
@@ -1,6 +1,10 @@
+from fastapi import Request
+
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.auth.session import Session, SessionModel
+from ayon_server.entities import UserEntity
 from ayon_server.exceptions import ForbiddenException
+from ayon_server.types import Field, OPModel
 
 from .router import router
 
@@ -15,3 +19,41 @@ async def list_active_sessions(user: CurrentUser) -> list[SessionModel]:
         result.append(row)
 
     return result
+
+
+class CreateSessionRequest(OPModel):
+    user_name: str | None = Field(None, description="User name to create session for")
+    message: str | None = Field(None, description="Message to log in event stream")
+
+
+@router.post("/sessions")
+async def create_session(
+    user: CurrentUser,
+    request: Request,
+    payload: CreateSessionRequest,
+) -> SessionModel:
+    """Create user session
+
+    - services can use this endpoint to create a session for a user
+    - users can use this endpoint to create additional sessions for themselves
+      (e.g. to authenticate Ayon Launcher)
+    """
+
+    if payload.user_name and payload.user_name != user.name:
+        if not user.is_service:
+            raise ForbiddenException(
+                "Only services can create sessions for other users"
+            )
+        target_user = await UserEntity.load(payload.user_name)
+    else:
+        target_user = user
+
+    message = payload.message or f"Session created for {target_user.name}"
+    if payload.user_name:
+        message = f"{message} by {user.name}"
+
+    return await Session.create(
+        user=target_user,
+        request=request,
+        message=message,
+    )


### PR DESCRIPTION
Allow creating additional sessions for users using `[POST] /api/auth/sessions`

- services can create sessions for any users
- normal users can create sessions only for themselves