### PR TITLE
Settings: Improved SettingsField

### DIFF
--- a/ayon_server/settings/__init__.py
+++ b/ayon_server/settings/__init__.py
@@ -2,8 +2,8 @@
 
 __all__ = [
     "BaseSettingsModel",
-    "Field",
     "SettingsField",
+    "Field",
     "MultiplatformPathModel",
     "MultiplatformPathListModel",
     "TemplateWorkfileBaseOptions",
@@ -19,7 +19,7 @@ __all__ = [
     "normalize_name",
 ]
 
-from pydantic import Field
+from pydantic import Field  # This is deprecated and will be removed in the future
 
 from ayon_server.settings.common import BaseSettingsModel
 from ayon_server.settings.enum import folder_types_enum, task_types_enum
@@ -36,6 +36,5 @@ from ayon_server.settings.overrides import (
     extract_overrides,
     list_overrides,
 )
+from ayon_server.settings.settings_field import SettingsField
 from ayon_server.settings.validators import ensure_unique_names, normalize_name
-
-SettingsField = Field

--- a/ayon_server/settings/anatomy/__init__.py
+++ b/ayon_server/settings/anatomy/__init__.py
@@ -1,4 +1,4 @@
-from pydantic import Field, validator
+from pydantic import validator
 
 from ayon_server.entities import ProjectEntity
 from ayon_server.settings.anatomy.folder_types import FolderType, default_folder_types
@@ -9,6 +9,7 @@ from ayon_server.settings.anatomy.tags import Tag
 from ayon_server.settings.anatomy.task_types import TaskType, default_task_types
 from ayon_server.settings.anatomy.templates import Templates
 from ayon_server.settings.common import BaseSettingsModel
+from ayon_server.settings.settings_field import SettingsField
 from ayon_server.settings.validators import ensure_unique_names
 
 
@@ -21,49 +22,49 @@ class ProjectAttribModel(
 
 class Anatomy(BaseSettingsModel):
     _layout: str = "root"
-    roots: list[Root] = Field(
+    roots: list[Root] = SettingsField(
         default=default_roots,
         title="Roots",
         description="Setup root paths for the project",
     )
 
-    templates: Templates = Field(
+    templates: Templates = SettingsField(
         default_factory=Templates,
         title="Templates",
         description="Path templates configuration",
     )
 
-    attributes: ProjectAttribModel = Field(
+    attributes: ProjectAttribModel = SettingsField(
         default_factory=ProjectAttribModel,
         title="Attributes",
         description="Attributes configuration",
     )
 
-    folder_types: list[FolderType] = Field(
+    folder_types: list[FolderType] = SettingsField(
         default_factory=lambda: default_folder_types,
         title="Folder types",
         description="Folder types configuration",
     )
 
-    task_types: list[TaskType] = Field(
+    task_types: list[TaskType] = SettingsField(
         default_factory=lambda: default_task_types,
         title="Task types",
         description="Task types configuration",
     )
 
-    link_types: list[LinkType] = Field(
+    link_types: list[LinkType] = SettingsField(
         default_factory=lambda: default_link_types,
         title="Link types",
         description="Link types configuration",
     )
 
-    statuses: list[Status] = Field(
+    statuses: list[Status] = SettingsField(
         default_factory=lambda: default_statuses,
         title="Statuses",
         description="Statuses configuration",
     )
 
-    tags: list[Tag] = Field(
+    tags: list[Tag] = SettingsField(
         default_factory=list,
         title="Tags",
         description="Tags configuration",

--- a/ayon_server/settings/anatomy/folder_types.py
+++ b/ayon_server/settings/anatomy/folder_types.py
@@ -1,16 +1,17 @@
-from pydantic import Field, validator
+from pydantic import validator
 
 from ayon_server.settings.common import BaseSettingsModel
+from ayon_server.settings.settings_field import SettingsField
 
 
 class FolderType(BaseSettingsModel):
     _layout: str = "compact"
-    name: str = Field(..., title="Name", min_length=1, max_length=100)
-    shortName: str = Field("", title="Short name")
-    icon: str = Field("folder", title="Icon", widget="icon")
+    name: str = SettingsField(..., title="Name", min_length=1, max_length=100)
+    shortName: str = SettingsField("", title="Short name")
+    icon: str = SettingsField("folder", title="Icon", widget="icon")
 
     # Set to old name when renaming
-    original_name: str | None = Field(None, title="Original name", scope=[])
+    original_name: str | None = SettingsField(None, title="Original name", scope=[])
 
     def __hash__(self):
         return hash(self.name)

--- a/ayon_server/settings/anatomy/link_types.py
+++ b/ayon_server/settings/anatomy/link_types.py
@@ -1,18 +1,17 @@
 from typing import Literal
 
-from pydantic import Field
-
 from ayon_server.settings.common import BaseSettingsModel
+from ayon_server.settings.settings_field import SettingsField
 from ayon_server.types import ProjectLevelEntityType
 
 
 class LinkType(BaseSettingsModel):
     _layout: str = "compact"
-    link_type: str = Field(..., title="Link type", min_length=1, max_length=100)
-    input_type: ProjectLevelEntityType = Field(..., title="Input type")
-    output_type: ProjectLevelEntityType = Field(..., title="Output type")
-    color: str | None = Field(None, title="Color", widget="color")
-    style: Literal["solid", "dashed"] = Field("solid", title="Style")
+    link_type: str = SettingsField(..., title="Link type", min_length=1, max_length=100)
+    input_type: ProjectLevelEntityType = SettingsField(..., title="Input type")
+    output_type: ProjectLevelEntityType = SettingsField(..., title="Output type")
+    color: str | None = SettingsField(None, title="Color", widget="color")
+    style: Literal["solid", "dashed"] = SettingsField("solid", title="Style")
 
     def __hash__(self):
         return hash((self.link_type, self.input_type, self.output_type))

--- a/ayon_server/settings/anatomy/roots.py
+++ b/ayon_server/settings/anatomy/roots.py
@@ -1,6 +1,5 @@
-from pydantic import Field
-
 from ayon_server.settings.common import BaseSettingsModel
+from ayon_server.settings.settings_field import SettingsField
 
 
 class Root(BaseSettingsModel):
@@ -8,25 +7,29 @@ class Root(BaseSettingsModel):
 
     _layout: str = "expanded"
 
-    name: str = Field(
+    name: str = SettingsField(
         ...,
         title="Root name",
         regex="^[a-zA-Z0-9_]{1,}$",
+        example="work",
     )
 
-    windows: str = Field(
+    windows: str = SettingsField(
         "",
         title="Windows",
+        example="C:/projects",
     )
 
-    linux: str = Field(
+    linux: str = SettingsField(
         "",
         title="Linux",
+        example="/mnt/share/projects",
     )
 
-    darwin: str = Field(
+    darwin: str = SettingsField(
         "",
         title="Darwin",
+        example="/Volumes/projects",
     )
 
 

--- a/ayon_server/settings/anatomy/statuses.py
+++ b/ayon_server/settings/anatomy/statuses.py
@@ -1,8 +1,9 @@
 from typing import Literal
 
-from pydantic import Field, validator
+from pydantic import validator
 
 from ayon_server.settings.common import BaseSettingsModel
+from ayon_server.settings.settings_field import SettingsField
 
 State = Literal["not_started", "in_progress", "done", "blocked"]
 
@@ -18,12 +19,21 @@ def get_state_enum():
 
 class Status(BaseSettingsModel):
     _layout: str = "compact"
-    name: str = Field(..., title="Name", min_length=1, max_length=100)
-    shortName: str = Field("", title="Short name")
-    state: State = Field("not_started", title="State", enum_resolver=get_state_enum)
-    icon: str = Field("", title="Icon", widget="icon")
-    color: str = Field("#cacaca", title="Color", widget="color")
-    original_name: str | None = Field(None, scope=[])  # Used for renaming
+    name: str = SettingsField(
+        ..., title="Name", min_length=1, max_length=100, example="In progress"
+    )
+    shortName: str = SettingsField("", title="Short name", example="PRG")
+    state: State = SettingsField(
+        "not_started",
+        title="State",
+        enum_resolver=get_state_enum,
+        example="in_progress",
+    )
+    icon: str = SettingsField("", title="Icon", widget="icon", example="play_arrow")
+    color: str = SettingsField(
+        "#cacaca", title="Color", widget="color", example="#3498db"
+    )
+    original_name: str | None = SettingsField(None, scope=[])  # Used for renaming
 
     @validator("original_name")
     def validate_original_name(cls, v, values):

--- a/ayon_server/settings/anatomy/tags.py
+++ b/ayon_server/settings/anatomy/tags.py
@@ -1,13 +1,18 @@
-from pydantic import Field, validator
+from pydantic import validator
 
 from ayon_server.settings.common import BaseSettingsModel
+from ayon_server.settings.settings_field import SettingsField
 
 
 class Tag(BaseSettingsModel):
     _layout: str = "compact"
-    name: str = Field(..., title="Name", min_length=1, max_length=100)
-    color: str = Field("#cacaca", title="Color", widget="color")
-    original_name: str | None = Field(None, scope=[])  # Used for renaming
+    name: str = SettingsField(
+        ..., title="Name", min_length=1, max_length=100, example="fluffy"
+    )
+    color: str = SettingsField(
+        "#cacaca", title="Color", widget="color", example="#3498db"
+    )
+    original_name: str | None = SettingsField(None, scope=[])  # Used for renaming
 
     @validator("original_name")
     def validate_original_name(cls, v, values):

--- a/ayon_server/settings/anatomy/task_types.py
+++ b/ayon_server/settings/anatomy/task_types.py
@@ -1,16 +1,17 @@
-from pydantic import Field, validator
+from pydantic import validator
 
 from ayon_server.settings.common import BaseSettingsModel
+from ayon_server.settings.settings_field import SettingsField
 
 
 class TaskType(BaseSettingsModel):
     _layout: str = "compact"
-    name: str = Field(..., title="Name", min_length=1, max_length=100)
-    shortName: str = Field("", title="Short name")
-    icon: str = Field("task_alt", title="Icon", widget="icon")
+    name: str = SettingsField(..., title="Name", min_length=1, max_length=100)
+    shortName: str = SettingsField("", title="Short name")
+    icon: str = SettingsField("task_alt", title="Icon", widget="icon")
 
     # Set to old name when renaming
-    original_name: str | None = Field(None, title="Original name", scope=[])
+    original_name: str | None = SettingsField(None, title="Original name", scope=[])
 
     def __hash__(self):
         return hash(self.name)

--- a/ayon_server/settings/anatomy/templates.py
+++ b/ayon_server/settings/anatomy/templates.py
@@ -1,11 +1,12 @@
-from pydantic import Field, validator
+from pydantic import validator
 
 from ayon_server.settings.common import BaseSettingsModel
+from ayon_server.settings.settings_field import SettingsField
 from ayon_server.settings.validators import ensure_unique_names, normalize_name
 
 
 class BaseTemplate(BaseSettingsModel):
-    name: str = Field(..., title="Name")
+    name: str = SettingsField(..., title="Name")
 
     @validator("name")
     def validate_name(cls, value):
@@ -13,33 +14,33 @@ class BaseTemplate(BaseSettingsModel):
 
 
 class WorkTemplate(BaseTemplate):
-    directory: str = Field(..., title="Directory template")
-    file: str = Field(..., title="File name template")
+    directory: str = SettingsField(..., title="Directory template")
+    file: str = SettingsField(..., title="File name template")
 
 
 class PublishTemplate(BaseTemplate):
-    directory: str = Field(..., title="Directory template")
-    file: str = Field(..., title="File name template")
+    directory: str = SettingsField(..., title="Directory template")
+    file: str = SettingsField(..., title="File name template")
 
 
 class HeroTemplate(BaseTemplate):
-    directory: str = Field(..., title="Directory template")
-    file: str = Field(..., title="File name template")
+    directory: str = SettingsField(..., title="Directory template")
+    file: str = SettingsField(..., title="File name template")
 
 
 class DeliveryTemplate(BaseTemplate):
-    directory: str = Field(..., title="Directory template")
-    file: str = Field(..., title="File name template")
+    directory: str = SettingsField(..., title="Directory template")
+    file: str = SettingsField(..., title="File name template")
 
 
 class CustomTemplate(BaseTemplate):
     _layout: str = "compact"
-    value: str = Field("", title="Template value")
+    value: str = SettingsField("", title="Template value")
 
 
 class StagingDirectory(BaseTemplate):
     _layout: str = "compact"
-    directory: str = Field("")
+    directory: str = SettingsField("")
 
 
 # TODO: Custom templates are not supported yet
@@ -47,29 +48,29 @@ class StagingDirectory(BaseTemplate):
 
 
 class Templates(BaseSettingsModel):
-    version_padding: int = Field(
+    version_padding: int = SettingsField(
         default=3,
         title="Version padding",
         gt=0,
     )
 
-    version: str = Field(
+    version: str = SettingsField(
         default="v{version:0>{@version_padding}}",
         title="Version template",
     )
 
-    frame_padding: int = Field(
+    frame_padding: int = SettingsField(
         default=4,
         title="Frame padding",
         gt=0,
     )
 
-    frame: str = Field(
+    frame: str = SettingsField(
         default="{frame:0>{@frame_padding}}",
         title="Frame template",
     )
 
-    work: list[WorkTemplate] = Field(
+    work: list[WorkTemplate] = SettingsField(
         default_factory=lambda: [
             WorkTemplate(
                 name="default",
@@ -85,7 +86,7 @@ class Templates(BaseSettingsModel):
         title="Work",
     )
 
-    publish: list[PublishTemplate] = Field(
+    publish: list[PublishTemplate] = SettingsField(
         title="Publish",
         default_factory=lambda: [
             PublishTemplate(
@@ -126,7 +127,7 @@ class Templates(BaseSettingsModel):
         ],
     )
 
-    hero: list[HeroTemplate] = Field(
+    hero: list[HeroTemplate] = SettingsField(
         title="Hero",
         default_factory=lambda: [
             HeroTemplate(
@@ -137,17 +138,17 @@ class Templates(BaseSettingsModel):
         ],
     )
 
-    delivery: list[DeliveryTemplate] = Field(
+    delivery: list[DeliveryTemplate] = SettingsField(
         default_factory=list,
         title="Delivery",
     )
 
-    staging: list[StagingDirectory] = Field(
+    staging: list[StagingDirectory] = SettingsField(
         default_factory=list,
         title="Staging directories",
     )
 
-    others: list[CustomTemplate] = Field(
+    others: list[CustomTemplate] = SettingsField(
         default_factory=list,
         title="Others",
     )

--- a/ayon_server/settings/models.py
+++ b/ayon_server/settings/models.py
@@ -1,44 +1,44 @@
 from pydantic import validator
 
-from ayon_server.settings import Field
 from ayon_server.settings.common import BaseSettingsModel
 from ayon_server.settings.enum import task_types_enum
+from ayon_server.settings.settings_field import SettingsField
 from ayon_server.settings.validators import ensure_unique_names
 
 
 class MultiplatformPathModel(BaseSettingsModel):
-    windows: str = Field("", title="Windows")
-    linux: str = Field("", title="Linux")
-    darwin: str = Field("", title="MacOS")
+    windows: str = SettingsField("", title="Windows")
+    linux: str = SettingsField("", title="Linux")
+    darwin: str = SettingsField("", title="MacOS")
 
 
 class MultiplatformPathListModel(BaseSettingsModel):
-    windows: list[str] = Field(default_factory=list, title="Windows")
-    linux: list[str] = Field(default_factory=list, title="Linux")
-    darwin: list[str] = Field(default_factory=list, title="MacOS")
+    windows: list[str] = SettingsField(default_factory=list, title="Windows")
+    linux: list[str] = SettingsField(default_factory=list, title="Linux")
+    darwin: list[str] = SettingsField(default_factory=list, title="MacOS")
 
 
 class CustomTemplateModel(BaseSettingsModel):
     _layout = "expanded"
     _isGroup = True
-    task_types: list[str] = Field(
+    task_types: list[str] = SettingsField(
         default_factory=list, title="Task types", enum_resolver=task_types_enum
     )
 
     # label:
     # Absolute path to workfile template or Ayon Anatomy text is accepted.
 
-    path: MultiplatformPathModel = Field(
+    path: MultiplatformPathModel = SettingsField(
         default_factory=MultiplatformPathModel, title="Path"
     )
 
 
 class TemplateWorkfileBaseOptions(BaseSettingsModel):
-    create_first_version: bool = Field(
+    create_first_version: bool = SettingsField(
         False,
         title="Create first workfile",
     )
-    custom_templates: list[CustomTemplateModel] = Field(
+    custom_templates: list[CustomTemplateModel] = SettingsField(
         default_factory=list,
         title="Custom templates",
     )
@@ -46,20 +46,22 @@ class TemplateWorkfileBaseOptions(BaseSettingsModel):
 
 # --- Host 'imageio' models ---
 class ImageIOConfigModel(BaseSettingsModel):
-    enabled: bool = Field(False)
-    filepath: list[str] = Field(default_factory=list, title="Config path")
+    enabled: bool = SettingsField(False)
+    filepath: list[str] = SettingsField(default_factory=list, title="Config path")
 
 
 class ImageIOFileRuleModel(BaseSettingsModel):
-    name: str = Field("", title="Rule name")
-    pattern: str = Field("", title="Regex pattern")
-    colorspace: str = Field("", title="Colorspace name")
-    ext: str = Field("", title="File extension")
+    name: str = SettingsField("", title="Rule name")
+    pattern: str = SettingsField("", title="Regex pattern")
+    colorspace: str = SettingsField("", title="Colorspace name")
+    ext: str = SettingsField("", title="File extension")
 
 
 class ImageIOFileRulesModel(BaseSettingsModel):
-    enabled: bool = Field(False)
-    rules: list[ImageIOFileRuleModel] = Field(default_factory=list, title="Rules")
+    enabled: bool = SettingsField(False)
+    rules: list[ImageIOFileRuleModel] = SettingsField(
+        default_factory=list, title="Rules"
+    )
 
     @validator("rules")
     def validate_unique_outputs(cls, value):
@@ -69,9 +71,9 @@ class ImageIOFileRulesModel(BaseSettingsModel):
 
 # Base model that can be used as is if host does not need any custom fields
 class ImageIOBaseModel(BaseSettingsModel):
-    ocio_config: ImageIOConfigModel = Field(
+    ocio_config: ImageIOConfigModel = SettingsField(
         default_factory=ImageIOConfigModel, title="OCIO config"
     )
-    file_rules: ImageIOFileRulesModel = Field(
+    file_rules: ImageIOFileRulesModel = SettingsField(
         default_factory=ImageIOFileRulesModel, title="File Rules"
     )

--- a/ayon_server/settings/settings_field.py
+++ b/ayon_server/settings/settings_field.py
@@ -36,7 +36,7 @@ def SettingsField(
     regex: str | None = None,
     discriminator: str | None = None,
     repr: bool = True,
-    # Ayon settings specifics
+    # AYON settings specifics
     example: Any = None,
     enum_resolver: AnyCallable | None = None,
     required_items: list[str] | None = None,

--- a/ayon_server/settings/settings_field.py
+++ b/ayon_server/settings/settings_field.py
@@ -1,0 +1,125 @@
+from typing import Any
+
+from nxtools import logging
+from pydantic.fields import FieldInfo, Undefined
+from pydantic.typing import AnyCallable, NoArgAnyCallable
+
+"""
+Unused pydantic fields
+    exclude: Optional[Union['AbstractSetIntStr', 'MappingIntStrAny', Any]] = None,
+    include: Optional[Union['AbstractSetIntStr', 'MappingIntStrAny', Any]] = None,
+    const: Optional[bool] = None,
+"""
+
+
+def SettingsField(
+    default: Any = Undefined,
+    *,
+    default_factory: NoArgAnyCallable | None = None,
+    alias: str | None = None,
+    title: str | None = None,
+    description: str | None = None,
+    gt: float | None = None,
+    ge: float | None = None,
+    lt: float | None = None,
+    le: float | None = None,
+    multiple_of: float | None = None,
+    allow_inf_nan: bool | None = None,
+    max_digits: int | None = None,
+    decimal_places: int | None = None,
+    min_items: int | None = None,
+    max_items: int | None = None,
+    unique_items: bool | None = None,
+    min_length: int | None = None,
+    max_length: int | None = None,
+    allow_mutation: bool = True,
+    regex: str | None = None,
+    discriminator: str | None = None,
+    repr: bool = True,
+    # Ayon settings specifics
+    example: Any = None,
+    enum_resolver: AnyCallable | None = None,
+    required_items: list[str] | None = None,
+    section: str | None = None,
+    widget: str | None = None,
+    layout: str | None = None,
+    tags: list[str] | None = None,
+    scope: list[str] | None = None,
+    placeholder: str | None = None,
+    conditional_enum: dict[str, list[str]] | None = None,
+    disabled: bool = False,
+    # compatibility
+    conditionalEnum: dict[str, list[str]] | None = None,  # backward compatibility
+    examples: list[Any] | None = None,
+    # everything else
+    **kwargs: Any,
+) -> Any:
+    # sanity checks
+
+    conditional_enum = conditional_enum or conditionalEnum
+    if kwargs:
+        logging.debug(f"SettingsField: unsupported argument: {kwargs}")
+
+    examples = examples or []
+    if example is not None:
+        examples.append(example)
+    if not examples:
+        examples = None
+
+    # extras
+
+    extra: dict[str, Any] = {}
+
+    if example is not None:
+        extra["example"] = example
+    if enum_resolver is not None:
+        extra["enum_resolver"] = enum_resolver
+    if required_items is not None:
+        extra["required_items"] = required_items
+    if section is not None:
+        extra["section"] = section
+    if widget is not None:
+        extra["widget"] = widget
+    if layout is not None:
+        extra["layout"] = layout
+    if tags is not None:
+        extra["tags"] = tags
+    if placeholder is not None:
+        extra["placeholder"] = placeholder
+    if conditional_enum is not None:
+        extra["conditional_enum"] = conditional_enum
+    if scope is not None:
+        extra["scope"] = scope
+    if disabled is not None:
+        extra["disabled"] = disabled
+
+    # construct FieldInfo
+
+    field_info = FieldInfo(
+        default,
+        default_factory=default_factory,
+        alias=alias,
+        title=title,
+        description=description,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        multiple_of=multiple_of,
+        allow_inf_nan=allow_inf_nan,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        min_items=min_items,
+        max_items=max_items,
+        unique_items=unique_items,
+        min_length=min_length,
+        max_length=max_length,
+        allow_mutation=allow_mutation,
+        regex=regex,
+        discriminator=discriminator,
+        repr=repr,
+        **extra,
+    )
+
+    field_info._validate()
+    return field_info


### PR DESCRIPTION
`SettingsField` is no longer just an alias to `pydantic.Field` but reimplements it and provides type checking for all additional types used in settings. **kwargs is now used just for backward compatibility (preventing raising errors, instead it logs a message about unsupported argument passed)

![image](https://github.com/user-attachments/assets/f3f73b7f-c71a-4a12-9c82-bc36c13792c8)
