### PR TITLE
Events: allow specifying source topics in list in enroll + batch event delete

### DIFF
--- a/api/events/__init__.py
+++ b/api/events/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["router", "enroll", "events"]
+__all__ = ["router", "enroll", "events", "operations"]
 
-from . import enroll, events
+from . import enroll, events, operations
 from .router import router

--- a/api/events/enroll.py
+++ b/api/events/enroll.py
@@ -1,7 +1,13 @@
+import re
+
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.events.enroll import EnrollResponseModel, enroll_job
-from ayon_server.exceptions import ForbiddenException, ServiceUnavailableException
+from ayon_server.exceptions import (
+    BadRequestException,
+    ForbiddenException,
+    ServiceUnavailableException,
+)
 from ayon_server.lib.postgres import Postgres
 from ayon_server.sqlfilter import Filter
 from ayon_server.types import TOPIC_REGEX, Field, OPModel
@@ -14,11 +20,10 @@ from .router import router
 
 
 class EnrollRequestModel(OPModel):
-    source_topic: str = Field(
+    source_topic: str | list[str] = Field(
         ...,
-        title="Source topic",
+        title="Source topic(s)",
         example="ftrack.update",
-        regex=TOPIC_REGEX,
     )
     target_topic: str = Field(
         ...,
@@ -50,6 +55,12 @@ class EnrollRequestModel(OPModel):
     debug: bool = False
 
 
+def validate_source_topic(value: str) -> str:
+    if not re.match(TOPIC_REGEX, value):
+        raise BadRequestException(f"Invalid topic: {value}")
+    return value.replace("*", "%")
+
+
 # response model must be here
 @router.post("/enroll", response_model=EnrollResponseModel)
 async def enroll(
@@ -62,20 +73,34 @@ async def enroll(
     Used by workers to get a new job to process. If there is no job
     available, request returns 204 (no content).
 
+    Returns 503 (service unavailable) if the database pool is almost full.
+    Processing jobs should never block user requests.
+
     Non-error response is returned because having nothing to do is not an error
     and we don't want to spam the logs.
     """
+
+    if not current_user.is_service:
+        raise ForbiddenException("Only services can enroll for jobs")
+
+    # source_topic
+    source_topic: str | list[str]
+
+    if isinstance(payload.source_topic, str):
+        source_topic = validate_source_topic(payload.source_topic)
+    else:
+        source_topic = [validate_source_topic(t) for t in payload.source_topic]
+
+    # target_topic
+    if "*" in payload.target_topic:
+        raise BadRequestException("Target topic must not contain wildcards")
+
+    # Keep DB pool size above 3
 
     if Postgres.get_available_connections() < 3:
         raise ServiceUnavailableException(
             f"Postgres remaining pool size: {Postgres.get_available_connections()}"
         )
-
-    assert "*" not in payload.target_topic, "Target topic must not contain wildcards"
-    source_topic = payload.source_topic.replace("*", "%")
-
-    if not current_user.is_service:
-        raise ForbiddenException("Only services can enroll for jobs")
 
     user_name = current_user.name
 

--- a/api/events/operations.py
+++ b/api/events/operations.py
@@ -1,0 +1,31 @@
+from typing import Literal
+
+from ayon_server.api.dependencies import CurrentUser
+from ayon_server.exceptions import ForbiddenException, NotImplementedException
+from ayon_server.lib.postgres import Postgres
+from ayon_server.sqlfilter import Filter, build_filter
+from ayon_server.types import Field, OPModel
+
+from .router import router
+
+OperationType = Literal["delete", "restart", "abort"]
+
+
+class EventOperationModel(OPModel):
+    type: OperationType = Field(..., title="Operation type")
+    filter: Filter = Field(..., title="Filter", description="Filter source events")
+
+
+@router.post("/eventops")
+async def event_operations(user: CurrentUser, request: EventOperationModel) -> None:
+    if not user.is_admin:
+        raise ForbiddenException("Only admins can perform event operations")
+
+    filter_query = build_filter(request.filter) or "TRUE"
+
+    if request.type == "delete":
+        query = f"DELETE FROM events WHERE {filter_query}"
+    else:
+        raise NotImplementedException("Not implemented")
+
+    await Postgres.execute(query)

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -34,6 +34,7 @@ class Condition(OPModel):
         "notin",
         "contains",
         "excludes",
+        "like",
     ] = Field("eq")
 
     @validator("operator", pre=True, always=True)
@@ -155,6 +156,8 @@ def build_condition(c: Condition, **kwargs) -> str:
         return f"{key} @> {value}"
     elif operator == "excludes":
         return f"NOT ({key} @> {value})"
+    elif operator == "like":
+        return f"{key} LIKE {value}"
     else:
         raise ValueError(f"Unsupported operator: {operator}")
 


### PR DESCRIPTION
Enroll now accepts source topics both as strings with `*` wildcard or a list of strings. 

![image](https://github.com/user-attachments/assets/5b1c8239-93b9-4c29-a0a8-57d1657337e2)

That maintains 100% backwards compatibility while allowing multiple topics selection without using expensive wildcards.

### Additional context

Additionally, this PR adds a new endpoint for batch updates of events. It was implemented in order to make the API testable, so it is just a minimal implementation only supporting event deletion, but it will be expanded later. 

![image](https://github.com/user-attachments/assets/1bd465fd-ef0b-4fbc-97f7-5c4cb8af9155)

