### PR TITLE
Remove download.ynput.cloud links from launcher and dependency packages sources

### DIFF
--- a/api/desktop/deps.py
+++ b/api/desktop/deps.py
@@ -68,6 +68,13 @@ def get_manifest(filename: str) -> DependencyPackage:
     if manifest.has_local_file:
         if "server" not in [s.type for s in manifest.sources]:
             manifest.sources.insert(0, SourceModel(type="server"))
+
+    manifest.sources = [
+        m
+        for m in manifest.sources
+        if not (m.url and m.url.startswith("https://download.ynput.cloud"))
+    ]
+
     return manifest
 
 

--- a/api/desktop/installers.py
+++ b/api/desktop/installers.py
@@ -73,6 +73,15 @@ def get_manifest(filename: str) -> Installer:
     if manifest.has_local_file:
         if "server" not in [s.type for s in manifest.sources]:
             manifest.sources.insert(0, SourceModel(type="server"))
+
+    print("pre sources", manifest.sources)
+    manifest.sources = [
+        m
+        for m in manifest.sources
+        if not (m.url and m.url.startswith("https://download.ynput.cloud"))
+    ]
+    print("post sources", manifest.sources)
+
     return manifest
 
 

--- a/api/desktop/installers.py
+++ b/api/desktop/installers.py
@@ -74,13 +74,11 @@ def get_manifest(filename: str) -> Installer:
         if "server" not in [s.type for s in manifest.sources]:
             manifest.sources.insert(0, SourceModel(type="server"))
 
-    print("pre sources", manifest.sources)
     manifest.sources = [
         m
         for m in manifest.sources
         if not (m.url and m.url.startswith("https://download.ynput.cloud"))
     ]
-    print("post sources", manifest.sources)
 
     return manifest
 


### PR DESCRIPTION
Original download link is stored in dependency packages and launcher manifests. Since these links expire, we need to filter them out to prevent downloading from dead links. 

This is a hot fix and eventually, the links should also be removed when the manifest is stored.