### PR TITLE
Setup: Default access groups

### DIFF
--- a/setup/access_groups.py
+++ b/setup/access_groups.py
@@ -14,7 +14,16 @@ DEFAULT_ACCESS_GROUPS = [
             "delete": {"enabled": True},  # restrict folder deletion
         },
     },
-    {"name": "freelancer", "data": {}},
+    {
+        "name": "freelancer",
+        "data": {
+            "create": {"enabled": True},  # restrict folder creation
+            "delete": {"enabled": True},  # restrict folder deletion
+            "update": {"enabled": True},  # restrict folder update
+            "read": {"enabled": True, "access_list": [{"access_type": "assigned"}]},
+            "publish": {"enabled": True, "access_list": [{"access_type": "assigned"}]},
+        },
+    },
 ]
 
 

--- a/setup/access_groups.py
+++ b/setup/access_groups.py
@@ -2,10 +2,34 @@ from typing import Any
 
 from ayon_server.lib.postgres import Postgres
 
+DEFAULT_ACCESS_GROUPS = [
+    {
+        "name": "supervisor",
+        "data": {},  # no restrictions
+    },
+    {
+        "name": "artist",
+        "data": {
+            "create": {"enabled": True},  # restrict folder creation
+            "delete": {"enabled": True},  # restrict folder deletion
+        },
+    },
+    {"name": "freelancer", "data": {}},
+]
+
 
 async def deploy_access_groups(access_groups: list[dict[str, Any]]) -> None:
     if not access_groups:
-        return
+        res = await Postgres.fetch("SELECT name FROM access_groups LIMIT 1")
+        if res:
+            # there are already access groups in the database
+            # and no explicit access groups are provided,
+            # so we don't need to do anything
+            return
+
+        # there are no access groups in the database and there are no
+        # groups provided, so we need to create the default access groups
+        access_groups = DEFAULT_ACCESS_GROUPS
 
     for access_group in access_groups:
         name = access_group["name"]


### PR DESCRIPTION
Provide a sane default access groups when the server is started for the first time and there are no explicit groups set in template.json

### Default groups

#### supervisor

Has unrestricted access to the project

#### artist 

Has unrestricted read/publish access to the project, but cannot change the project hierarchy

#### freelancer

Can read/publish the parts of the hierarchy where they have tasks assigned