### PR TITLE
GraphQL: Querying tasks in nested folders

### DIFF
--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -63,6 +63,9 @@ async def get_tasks(
     assignees_any: Annotated[
         list[str] | None, argdesc("List tasks with any of the selected assignees")
     ] = None,
+    includeFolderChildren: Annotated[
+        bool, argdesc("Include tasks in child folders when folderIds is used")
+    ] = False,
 ) -> TasksConnection:
     """Return a list of tasks."""
 
@@ -74,6 +77,8 @@ async def get_tasks(
 
     project_name = root.project_name
     fields = FieldInfo(info, ["tasks.edges.node", "task"])
+
+    use_folder_query = False
 
     #
     # SQL
@@ -129,7 +134,41 @@ async def get_tasks(
     if folder_ids is not None:
         if not folder_ids:
             return TasksConnection()
-        sql_conditions.append(f"tasks.folder_id IN {SQLTool.id_array(folder_ids)}")
+
+        if includeFolderChildren:
+            use_folder_query = True
+            sql_cte.append(
+                f"""
+                top_folder_paths AS (
+                    SELECT path FROM project_{project_name}.hierarchy
+                    WHERE id IN {SQLTool.id_array(folder_ids)}
+                )
+                """
+            )
+
+            sql_cte.append(
+                f"""
+                child_folder_ids AS (
+                    SELECT id FROM project_{project_name}.hierarchy
+                    WHERE EXISTS (
+                        SELECT 1
+                        FROM top_folder_paths
+                        WHERE project_{project_name}.hierarchy.path
+                        LIKE top_folder_paths.path || '/%'
+                    )
+                    OR project_{project_name}.hierarchy.path = ANY (
+                        SELECT path FROM top_folder_paths
+                    )
+                )
+                """
+            )
+            sql_conditions.append(
+                "tasks.folder_id IN (SELECT id FROM child_folder_ids)"
+            )
+
+        else:
+            sql_conditions.append(f"tasks.folder_id IN {SQLTool.id_array(folder_ids)}")
+
     elif root.__class__.__name__ == "FolderNode":
         # cannot use isinstance here because of circular imports
         sql_conditions.append(f"tasks.folder_id = '{root.id}'")
@@ -210,7 +249,7 @@ async def get_tasks(
     else:
         sql_columns.append("'{}'::JSONB as parent_folder_attrib")
 
-    if "folder" in fields or (access_list is not None):
+    if "folder" in fields or (access_list is not None) or use_folder_query:
         sql_columns.extend(
             [
                 "folders.id AS _folder_id",
@@ -235,10 +274,14 @@ async def get_tasks(
             """
         )
 
-        if any(
-            field.endswith("folder.path") or field.endswith("folder.parents")
-            for field in fields
-        ) or (access_list is not None):
+        if (
+            any(
+                field.endswith("folder.path") or field.endswith("folder.parents")
+                for field in fields
+            )
+            or (access_list is not None)
+            or use_folder_query
+        ):
             sql_columns.append("hierarchy.path AS _folder_path")
             sql_joins.append(
                 f"""


### PR DESCRIPTION
added `includeFolderChildren` to the tasks resolver, that expands the resultset with tasks under all children folders when `folderIds` list argument is used