### PR TITLE
Allow QuickTime files as proxies

### DIFF
--- a/api/files/files.py
+++ b/api/files/files.py
@@ -186,7 +186,7 @@ async def get_project_file(
     headers = await get_file_headers(project_name, file_id)
 
     if headers["Content-Type"].startswith("video"):
-        return await serve_video(request, path)
+        return await serve_video(request, path, content_type=headers["Content-Type"])
 
     return FileResponse(path, headers=headers)
 

--- a/api/files/video.py
+++ b/api/files/video.py
@@ -13,7 +13,7 @@ MAX_CHUNK_SIZE = 1024 * 1024 * 2
 
 
 class VideoResponse(Response):
-    content_type = "video/mp4"
+    pass
 
 
 def get_file_size(file_name: str) -> int:
@@ -43,22 +43,6 @@ def _get_range_header(range_header: str, file_size: int) -> tuple[int, int]:
     if start > end or start < 0 or end > file_size - 1:
         raise RangeNotSatisfiableException(f"Invalid range: {start}-{end}")
     return start, end
-
-
-def get_reviewable_head(request: Request, file_path: str) -> VideoResponse:
-    """Get the headers for a video file."""
-    file_size = get_file_size(file_path)
-    headers = {
-        "content-type": "video/mp4",
-        "content-length": str(file_size),
-        "access-control-expose-headers": (
-            "content-type, accept-ranges, content-length, "
-            "content-range, content-encoding"
-        ),
-    }
-    if file_size <= MAX_200_SIZE:
-        headers["accept-ranges"] = "bytes"
-    return VideoResponse(headers=headers)
 
 
 async def range_requests_response(
@@ -126,8 +110,10 @@ async def range_requests_response(
     )
 
 
-async def serve_video(request: Request, video_path: str) -> VideoResponse:
+async def serve_video(
+    request: Request, video_path: str, content_type: str
+) -> VideoResponse:
     if not os.path.exists(video_path):
         raise NotFoundException("Video not found")
 
-    return await range_requests_response(request, video_path, "video/mp4")
+    return await range_requests_response(request, video_path, content_type)

--- a/ayon_server/helpers/ffprobe.py
+++ b/ayon_server/helpers/ffprobe.py
@@ -40,7 +40,10 @@ async def extract_media_info(file_path: str) -> dict[str, Any]:
 
     result: dict[str, Any] = {
         "probeVersion": 1,
-        "majorBrand": probe_data.get("format", {}).get("tags", {}).get("major_brand"),
+        "majorBrand": probe_data.get("format", {})
+        .get("tags", {})
+        .get("major_brand", "")
+        .strip(),
     }
 
     for stream in probe_data.get("streams", []):
@@ -83,7 +86,7 @@ async def extract_media_info(file_path: str) -> dict[str, Any]:
 def availability_from_media_info(mediainfo: dict[str, Any]) -> ReviewableAvailability:
     duration = mediainfo.get("duration", 0)
     codec = mediainfo.get("codec", "unknown")
-    major_brand = mediainfo.get("majorBrand", "unknown")
+    major_brand = mediainfo.get("majorBrand", "unknown").strip()
 
     if mediainfo.get("videoTrackIndex") is None:
         # no video track. weird.
@@ -98,10 +101,12 @@ def availability_from_media_info(mediainfo: dict[str, Any]) -> ReviewableAvailab
 
     # video files
 
-    if major_brand not in ["mp42", "isom"]:
+    if codec not in ["h264", "vp9"]:
         return "conversionRequired"
 
-    if codec not in ["h264", "vp9"]:
+    if major_brand not in ["mp42", "isom"]:
+        if major_brand == "qt":
+            return "conversionRecommended"
         return "conversionRequired"
 
     # apart from firefox, all browsers support almost all pixel formats


### PR DESCRIPTION
A majority of browsers can playback QuickTime files directly, so this PR allows the playback of QT reviewables without transcoding. Transcoding is still recommended and supported as QT flavors may vary and playback may be unsupported on some platforms. 