### PR TITLE
Add unrealuasset as the publish template

### DIFF
--- a/ayon_server/settings/anatomy/templates.py
+++ b/ayon_server/settings/anatomy/templates.py
@@ -124,6 +124,11 @@ class Templates(BaseSettingsModel):
                 directory="{root[work]}/{project[name]}/{hierarchy}/{folder[name]}/publish/{product[type]}/{@version}",
                 file="{originalBasename}_{@version}.{ext}",
             ),
+            PublishTemplate(
+                name="unrealuasset",
+                directory="{root[work]}/{project[name]}/{hierarchy}/{folder[name]}/publish/{product[type]}/{product[name]}/{@version}",
+                file="{originalBasename}.{ext}",
+            ),
         ],
     )
 


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [ ] This comment contains a description of changes
-   [ ] Referenced issue is linked : https://github.com/ynput/ayon-unreal/issues/64 and  https://github.com/ynput/ayon-unreal/issues/66

## Description of changes
Added the published template setting for unreal uasset/umap publishing 
Related to this PR: https://github.com/ynput/ayon-core/pull/859


### Technical details
The current uasset/umap publisher is using default template name as the published path, but the default one would change the filename of the uasset/umap, which would corrupt the uasset/umap, and u sers cannot load the uasset/umap. There is some custom publish template needs to be added to make sure the uasset is published with original filename so that the file itself would not be corrupted.

### Additional context
The related ayon-core PR: https://github.com/ynput/ayon-core/pull/859
The related issues: https://github.com/ynput/ayon-unreal/issues/64 and  https://github.com/ynput/ayon-unreal/issues/66
