### PR TITLE
Fix returned entity URIs for representation entity type

### DIFF
--- a/api/uris/queries.py
+++ b/api/uris/queries.py
@@ -109,7 +109,7 @@ async def representation_uris(
         version = row["version"]
         version_name = f"v{version:03d}"
         uri = f"ayon+entity://{project_name}/{path}"
-        uri += f"&product={row['product']}"
+        uri += f"?product={row['product']}"
         uri += f"&version={version_name}"
         uri += f"&representation={row['repre']}"
         result.append((id, uri))


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [ ] Referenced issue is linked

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Fixes the returned entity URIs for representation entity type.

### Technical details

When resolving the current URIs fail.

This fails:
```
ayon+entity://ayontest/asset/char_hero&product=usdMain&version=v032&representation=usd
```
This works:
```
ayon+entity://ayontest/asset/char_hero?product=usdMain&version=v032&representation=usd
```
It's the `&`. Lacking a question mark.

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

### Additional context

<!-- Add any other context or screenshots here. -->
