### PR TITLE
Frontend index caching

### DIFF
--- a/ayon_server/api/frontend.py
+++ b/ayon_server/api/frontend.py
@@ -1,0 +1,67 @@
+import os
+from functools import cache
+
+import fastapi
+from starlette.exceptions import HTTPException
+from starlette.staticfiles import StaticFiles
+from starlette.types import Scope
+
+from ayon_server.config import ayonconfig
+
+
+@cache
+def get_index() -> fastapi.responses.HTMLResponse:
+    # Index.html file is read from the server cache
+    # to avoid reading it from the disk on every request
+    # It is very small and shouldn't change during runtime
+    # But we don't want to cache it in the browser,
+    # because of the hashes of js and css files
+    # - when they change, the browser should reload the index.html
+
+    frontend_dir = ayonconfig.frontend_dir
+    index_path = os.path.join(frontend_dir, "index.html")
+    if not os.path.isfile(index_path):
+        content = "frontend not found"
+    with open(index_path) as file:
+        content = file.read()
+    return fastapi.responses.HTMLResponse(
+        content, headers={"Cache-Control": "no-cache"}
+    )
+
+
+class FrontendFiles(StaticFiles):
+    async def get_response(self, path: str, scope: Scope) -> fastapi.responses.Response:
+        # For the root path, return the index.html file
+        # from the server cache (it shouldn't change during runtime)
+        if path in [".", "", "/", "index.html"]:
+            return get_index()
+        try:
+            # For other paths, return the file from the static files directory
+            return await super().get_response(path, scope)
+        except HTTPException as exc:
+            if exc.status_code != 404:
+                # Propagate non-404 errors
+                raise exc
+
+            # Frontend is mounted to /, so we need to handle 404 errors
+            # for the /api/ and /addons/ paths (in order to trigger the
+            # correct 404 handler instead of falling back to the index.html)
+
+            if path.startswith("api/"):
+                # Propagate 404 errors for the /api/ path
+                raise exc
+            if path.startswith("addons/"):
+                # Propagate 404 errors for the /addons/ path
+                raise exc
+
+            # For 404 errors, return the index.html file from the server cache
+            # that handles the routing on the client side
+            return get_index()
+
+
+def init_frontend(target_app: fastapi.FastAPI) -> None:
+    """Initialize frontend endpoints."""
+    frontend_dir = os.path.abspath(ayonconfig.frontend_dir)
+    if not os.path.isdir(frontend_dir):
+        return
+    target_app.mount("/", FrontendFiles(directory=frontend_dir, html=True))


### PR DESCRIPTION
Introduces a custom frontend staticfiles handler, that does not use cache-control for index.html, instead it keeps the content of index.html in memory cache. 

Index file is small so we can safely keep it in memory and serve it every time user reloads the page. Contents is loaded from the disk every time server is restarted, which should cover changes in imports.