### PR TITLE
Activity feed:  Reactions

### DIFF
--- a/api/activities/__init__.py
+++ b/api/activities/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["activity", "suggest", "router", "watchers"]
+__all__ = ["activity", "suggest", "reactions", "router", "watchers"]
 
-from . import activity, suggest, watchers
+from . import activity, reactions, suggest, watchers
 from .router import router

--- a/api/activities/activity.py
+++ b/api/activities/activity.py
@@ -11,6 +11,7 @@ from ayon_server.activities import (
 )
 from ayon_server.activities.watchers.set_watchers import ensure_watching
 from ayon_server.api.dependencies import (
+    ActivityID,
     CurrentUser,
     PathEntityID,
     PathProjectLevelEntityType,
@@ -91,7 +92,7 @@ async def post_project_activity(
 @router.delete("/activities/{activity_id}")
 async def delete_project_activity(
     project_name: ProjectName,
-    activity_id: str,
+    activity_id: ActivityID,
     user: CurrentUser,
     background_tasks: BackgroundTasks,
     x_sender: str | None = Header(default=None),
@@ -127,7 +128,7 @@ class ActivityPatchModel(OPModel):
 @router.patch("/activities/{activity_id}")
 async def patch_project_activity(
     project_name: ProjectName,
-    activity_id: str,
+    activity_id: ActivityID,
     user: CurrentUser,
     activity: ActivityPatchModel,
     background_tasks: BackgroundTasks,

--- a/api/activities/reactions.py
+++ b/api/activities/reactions.py
@@ -1,0 +1,145 @@
+from datetime import datetime
+from typing import Literal
+
+from fastapi import Header, Path
+
+from ayon_server.api.dependencies import (
+    ActivityID,
+    CurrentUser,
+    ProjectName,
+)
+from ayon_server.entities import UserEntity
+from ayon_server.events.eventstream import EventStream
+from ayon_server.exceptions import NotFoundException
+from ayon_server.lib.postgres import Postgres
+from ayon_server.types import NAME_REGEX, Field, OPModel
+
+from .router import router
+
+
+async def modify_reactions(
+    project_name: str,
+    activity_id: str,
+    user: UserEntity,
+    reaction: str,
+    action: Literal["add", "remove"],
+    sender: str | None = None,
+):
+    """
+
+    Reactions are stored in the activity data as a list of dicts
+    with the following structure:
+
+    {
+        "reaction": "like",
+        "userName": "user1",
+        "fullName": "User One",
+        "timestamp": "2024-10-01T12:00:00Z"
+    }
+
+
+    """
+    async with Postgres.acquire() as conn, conn.transaction():
+        res = await conn.fetch(
+            f"""
+            SELECT activity_type, data
+            FROM project_{project_name}.activities
+            WHERE id = $1
+            """,
+            activity_id,
+        )
+
+        if not res:
+            raise NotFoundException("Activity not found")
+        activity_type = res[0]["activity_type"]
+
+        # modify the reactions
+
+        activity_data = res[0]["data"]
+        reactions = activity_data.get("reactions", [])
+
+        if action == "add":
+            # check if the user has already reacted
+            for r in reactions:
+                if r["reaction"] == reaction and r["userName"] == user.name:
+                    return
+
+            reactions.append(
+                {
+                    "reaction": reaction,
+                    "userName": user.name,
+                    "fullName": user.attrib.fullName,
+                    "timestamp": datetime.now().isoformat(),
+                }
+            )
+        elif action == "remove":
+            reactions = [
+                r
+                for r in reactions
+                if r["reaction"] != reaction or r["userName"] != user.name
+            ]
+
+        # load activity references (used to generate the event summary)
+
+        references = await conn.fetch(
+            f"""
+            SELECT entity_id, entity_type, reference_type
+            FROM project_{project_name}.activity_references
+            WHERE activity_id = $1
+            """,
+            activity_id,
+        )
+
+        summary = {
+            "activity_id": activity_id,
+            "activity_type": activity_type,
+            "references": references,
+        }
+
+    await EventStream.dispatch(
+        "activity.updated",
+        project=project_name,
+        description="",
+        summary=summary,
+        store=False,
+        user=user.name,
+        sender=sender,
+    )
+
+
+#
+# REST API
+#
+
+
+class CreateReactionModel(OPModel):
+    reaction: str = Field(..., description="The reaction to be created", example="like")
+
+
+@router.post("/activities/{activity_id}/reactions", status_code=201)
+async def create_reaction_to_activity(
+    user: CurrentUser,
+    project_name: ProjectName,
+    activity_id: ActivityID,
+    request: CreateReactionModel,
+    x_sender: str | None = Header(None, description="The sender of the request"),
+):
+    await modify_reactions(
+        project_name, activity_id, user, request.reaction, "add", x_sender
+    )
+
+
+@router.delete("/activities/{activity_id}/reactions/{reaction}", status_code=204)
+async def delete_reaction_to_activity(
+    user: CurrentUser,
+    project_name: ProjectName,
+    activity_id: ActivityID,
+    reaction: str = Path(
+        ...,
+        description="The reaction to be deleted",
+        example="like",
+        regex=NAME_REGEX,
+    ),
+    x_sender: str | None = Header(None, description="The sender of the request"),
+):
+    await modify_reactions(project_name, activity_id, user, reaction, "add", x_sender)


### PR DESCRIPTION
## List of changes

### React to an activity

New endpoint `[POST] /api/projects/{project_name}/activities/{activity_id}/reactions` with the payload of:

```json
"reaction": "like"
```

### Remove previous reaction

New endpoint `[DELETE] /api/projects/{project_name}/activities/{activity_id}/reactions/{reaction}`

where {reaction} is a previously created reaction

### Retrieving reactions

Graphql sub-node on each activity `reactions` with the following structure:

![image](https://github.com/user-attachments/assets/0566ab1a-9b9c-4876-b558-68afed969d8c)


