### PR TITLE
Auth: Infinite loop when accessing unassigned project

### DIFF
--- a/ayon_server/api/dependencies.py
+++ b/ayon_server/api/dependencies.py
@@ -10,6 +10,7 @@ from ayon_server.auth.utils import hash_password
 from ayon_server.entities import UserEntity
 from ayon_server.exceptions import (
     BadRequestException,
+    ForbiddenException,
     NotFoundException,
     UnauthorizedException,
     UnsupportedMediaException,
@@ -140,7 +141,7 @@ async def dep_current_user(
         perms = user.permissions(project_name)
         if (perms is not None) and perms.endpoints.enabled:
             if endpoint not in perms.endpoints.endpoints:
-                raise UnauthorizedException(f"{endpoint} is not accessible")
+                raise ForbiddenException(f"{endpoint} is not accessible")
     return user
 
 


### PR DESCRIPTION
`CurrentUser` dependency returned 401 error when user tried to access a project without permission. 401 error triggers redirection to the login page in the frontend without clearing the stored access token, which leaded to infinite loop of pare reloads. The dependency now returns 403, that makes more sense (as it it a permission error, not authorization) and fixes this issue.