### PR TITLE
Optimize entity thumbnail storage

### DIFF
--- a/api/thumbnails/thumbnails.py
+++ b/api/thumbnails/thumbnails.py
@@ -116,6 +116,7 @@ async def retrieve_thumbnail(
     project_name: str,
     thumbnail_id: str | None,
     placeholder: PlaceholderOption = "none",
+    original: bool = False,
 ) -> Response:
     query = f"SELECT * FROM project_{project_name}.thumbnails WHERE id = $1"
     if thumbnail_id is not None:
@@ -216,7 +217,9 @@ async def get_thumbnail(
     if not user.is_manager:
         raise ForbiddenException("Only managers can access arbitrary thumbnails")
 
-    return await retrieve_thumbnail(project_name, thumbnail_id, placeholder)
+    return await retrieve_thumbnail(
+        project_name, thumbnail_id, placeholder=placeholder, original=original
+    )
 
 
 #
@@ -259,6 +262,7 @@ async def get_folder_thumbnail(
     project_name: ProjectName,
     folder_id: FolderID,
     placeholder: PlaceholderOption = Query("empty"),
+    original: bool = Query(False),
 ) -> Response:
     try:
         folder = await FolderEntity.load(project_name, folder_id)
@@ -268,7 +272,9 @@ async def get_folder_thumbnail(
             return get_fake_thumbnail_response()
         raise e
 
-    return await retrieve_thumbnail(project_name, folder.thumbnail_id, placeholder)
+    return await retrieve_thumbnail(
+        project_name, folder.thumbnail_id, placeholder=placeholder, original=original
+    )
 
 
 #
@@ -308,6 +314,7 @@ async def get_version_thumbnail(
     project_name: ProjectName,
     version_id: VersionID,
     placeholder: PlaceholderOption = Query("empty"),
+    original: bool = Query(False),
 ) -> Response:
     try:
         version = await VersionEntity.load(project_name, version_id)
@@ -316,7 +323,9 @@ async def get_version_thumbnail(
         if placeholder == "empty":
             return get_fake_thumbnail_response()
         raise e
-    return await retrieve_thumbnail(project_name, version.thumbnail_id, placeholder)
+    return await retrieve_thumbnail(
+        project_name, version.thumbnail_id, placeholder=placeholder, original=original
+    )
 
 
 #
@@ -358,6 +367,7 @@ async def get_workfile_thumbnail(
     project_name: ProjectName,
     workfile_id: WorkfileID,
     placeholder: PlaceholderOption = Query("empty"),
+    original: bool = Query(False),
 ) -> Response:
     try:
         workfile = await WorkfileEntity.load(project_name, workfile_id)
@@ -367,7 +377,9 @@ async def get_workfile_thumbnail(
             return get_fake_thumbnail_response()
         else:
             raise NotFoundException("Workfile not found")
-    return await retrieve_thumbnail(project_name, workfile.thumbnail_id, placeholder)
+    return await retrieve_thumbnail(
+        project_name, workfile.thumbnail_id, placeholder=placeholder, original=original
+    )
 
 
 #
@@ -427,6 +439,7 @@ async def get_task_thumbnail(
     project_name: ProjectName,
     task_id: TaskID,
     placeholder: PlaceholderOption = Query("empty"),
+    original: bool = Query(False),
 ) -> Response:
     try:
         task = await TaskEntity.load(project_name, task_id)
@@ -446,4 +459,6 @@ async def get_task_thumbnail(
     else:
         thumbnail_id = task.thumbnail_id
 
-    return await retrieve_thumbnail(project_name, thumbnail_id, placeholder)
+    return await retrieve_thumbnail(
+        project_name, thumbnail_id, placeholder=placeholder, original=original
+    )

--- a/api/thumbnails/thumbnails.py
+++ b/api/thumbnails/thumbnails.py
@@ -92,7 +92,7 @@ async def store_thumbnail(
         thumbnail = payload
     else:
         storage = await Storages.project(project_name)
-        await storage.store_thumbnail(thumbnail_id, thumbnail)
+        await storage.store_thumbnail(thumbnail_id, payload)
 
     query = f"""
         INSERT INTO project_{project_name}.thumbnails (id, mime, data)
@@ -128,7 +128,6 @@ async def retrieve_thumbnail(
             if res:
                 payload = None
                 if original:
-                    logging.debug("fetching original thumbnail")
                     storage = await Storages.project(project_name)
                     payload = await storage.get_thumbnail(thumbnail_id)
 

--- a/api/thumbnails/thumbnails.py
+++ b/api/thumbnails/thumbnails.py
@@ -129,7 +129,10 @@ async def retrieve_thumbnail(
                 payload = None
                 if original:
                     storage = await Storages.project(project_name)
-                    payload = await storage.get_thumbnail(thumbnail_id)
+                    try:
+                        payload = await storage.get_thumbnail(thumbnail_id)
+                    except FileNotFoundError:
+                        pass
 
                 record = res[0]
                 payload = payload or record["data"]

--- a/api/thumbnails/thumbnails.py
+++ b/api/thumbnails/thumbnails.py
@@ -54,6 +54,11 @@ async def body_from_request(request: Request) -> bytes:
 
 
 def get_fake_thumbnail_response() -> Response:
+    """Generate a "fake thumbnail" response.
+
+    This function creates a FastAPI Response object containing an
+    1x1 transparent png and appropriate headers.
+    """
     response = Response(status_code=203, content=get_fake_thumbnail())
     response.headers["Content-Type"] = "image/png"
     response.headers["Cache-Control"] = f"max-age={30}"
@@ -180,6 +185,7 @@ async def get_thumbnail(
     project_name: ProjectName,
     thumbnail_id: ThumbnailID,
     placeholder: PlaceholderOption = Query("empty"),
+    original: bool = Query(False),
 ) -> Response:
     """Get a thumbnail by its ID.
 

--- a/api/thumbnails/thumbnails.py
+++ b/api/thumbnails/thumbnails.py
@@ -126,11 +126,18 @@ async def retrieve_thumbnail(
             pass  # project does not exist
         else:
             if res:
+                payload = None
+                if original:
+                    logging.debug("fetching original thumbnail")
+                    storage = await Storages.project(project_name)
+                    payload = await storage.get_thumbnail(thumbnail_id)
+
                 record = res[0]
+                payload = payload or record["data"]
                 return Response(
                     media_type=record["mime"],
                     status_code=200,
-                    content=record["data"],
+                    content=payload,
                     headers={
                         "X-Thumbnail-Id": thumbnail_id,
                         "X-Thumbnail-Time": str(record.get("created_at", 0)),

--- a/ayon_server/background/clean_up.py
+++ b/ayon_server/background/clean_up.py
@@ -19,10 +19,14 @@ async def clear_thumbnails(project_name: str) -> None:
 
     Delete only thumbnails older than 24 hours.
     """
+
+    # keep this outside the query - it's easier to debug this way
+    older_cond = "created_at < 'yesterday'::timestamp AND"
+    # older_cond = ""
+
     query = f"""
         DELETE FROM project_{project_name}.thumbnails
-        WHERE created_at < 'yesterday'::timestamp
-        AND id NOT IN (
+        WHERE {older_cond} id NOT IN (
             SELECT thumbnail_id id FROM project_{project_name}.folders
             WHERE thumbnail_id IS NOT NULL
             UNION

--- a/ayon_server/files/project_storage.py
+++ b/ayon_server/files/project_storage.py
@@ -296,6 +296,16 @@ class ProjectStorage:
         Raises `FileNotFoundError` if the thumbnail is not found.
         """
         path = await self.get_path(thumbnail_id, file_group="thumbnails")
+        if self.storage_type == "local":
+            try:
+                async with aiofiles.open(path, "rb") as f:
+                    return await f.read()
+            except FileNotFoundError as e:
+                raise FileNotFoundError(
+                    f"Thumbnail {thumbnail_id} not found on {self}"
+                ) from e
+            except Exception as e:
+                raise AyonException(f"Failed to read file: {e}") from e
         return await retrieve_s3_file(self, path)
 
     async def delete_thumbnail(self, thumbnail_id: str) -> None:

--- a/ayon_server/files/project_storage.py
+++ b/ayon_server/files/project_storage.py
@@ -82,6 +82,12 @@ class ProjectStorage:
         file_id: str,
         file_group: FileGroup = "uploads",
     ) -> str:
+        """Return the full path to the file on the storage
+
+        In the case of S3, the resulting path is used as the key (relative
+        path from the bucket), while in the case of local storage, it's
+        the full path to the file on the disk.
+        """
         root = await self.get_root()
         assert file_group in ["uploads", "thumbnails"], "Invalid file group"
         _file_id = file_id.replace("-", "")
@@ -104,9 +110,9 @@ class ProjectStorage:
         file_group: FileGroup = "uploads",
         ttl: int = 3600,
     ) -> str:
-        """Return a signed URL for the file
+        """Return a signed URL to access the file on the storage over HTTP
 
-        This is only supported for S3 storages
+        This method is only supported for S3 storages.
         """
         if self.storage_type == "s3":
             path = await self.get_path(file_id, file_group=file_group)

--- a/ayon_server/files/project_storage.py
+++ b/ayon_server/files/project_storage.py
@@ -161,7 +161,6 @@ class ProjectStorage:
         """
 
         path = await self.get_path(file_id, file_group=file_group)
-        logging.debug(f"Unlinking file {file_id} from {self} ({file_group})")
         if self.storage_type == "local":
             try:
                 os.remove(path)
@@ -179,15 +178,16 @@ class ProjectStorage:
                     logging.error(f"Failed to delete directory on {self}: {e}")
             return True
 
-        if self.storage_type == "s3":
+        elif self.storage_type == "s3":
             assert self.bucket_name  # mypy
             try:
                 await delete_s3_file(self, path)
             except Exception as e:
                 logging.error(f"Failed to delete file: {e}")
                 return False
-
-        raise Exception("Unknown storage type")
+            return True
+        else:
+            raise Exception("Unknown storage type")
 
     # Project files (uploads) methods
     # for comment attachment and reviewables
@@ -301,4 +301,5 @@ class ProjectStorage:
 
         Fail silently if the thumbnail is not found.
         """
-        return None
+        logging.debug(f"Deleting thumbnail {thumbnail_id} from {self}")
+        await self.unlink(thumbnail_id, file_group="thumbnails")

--- a/ayon_server/files/project_storage.py
+++ b/ayon_server/files/project_storage.py
@@ -14,6 +14,7 @@ from ayon_server.files.s3 import (
     delete_s3_file,
     get_signed_url,
     handle_s3_upload,
+    retrieve_s3_file,
     store_s3_file,
 )
 from ayon_server.helpers.cloud import get_instance_id
@@ -294,7 +295,8 @@ class ProjectStorage:
 
         Raises `FileNotFoundError` if the thumbnail is not found.
         """
-        return b""
+        path = await self.get_path(thumbnail_id, file_group="thumbnails")
+        return await retrieve_s3_file(self, path)
 
     async def delete_thumbnail(self, thumbnail_id: str) -> None:
         """Delete the thumbnail image from the storage.

--- a/ayon_server/files/s3.py
+++ b/ayon_server/files/s3.py
@@ -77,7 +77,10 @@ async def store_s3_file(storage: "ProjectStorage", key: str, data: bytes) -> Non
 
 def _retrieve_s3_file(storage: "ProjectStorage", key: str) -> bytes:
     client = _get_s3_client(storage)
-    response = client.get_object(Bucket=storage.bucket_name, Key=key)
+    try:
+        response = client.get_object(Bucket=storage.bucket_name, Key=key)
+    except client.exceptions.NoSuchKey as e:
+        raise FileNotFoundError() from e
     return response["Body"].read()
 
 
@@ -87,7 +90,10 @@ async def retrieve_s3_file(storage: "ProjectStorage", key: str) -> bytes:
 
 def _delete_s3_file(storage: "ProjectStorage", key: str):
     client = _get_s3_client(storage)
-    client.delete_object(Bucket=storage.bucket_name, Key=key)
+    try:
+        client.delete_object(Bucket=storage.bucket_name, Key=key)
+    except client.exceptions.NoSuchKey:
+        pass  # fail silently
 
 
 async def delete_s3_file(storage: "ProjectStorage", key: str):

--- a/ayon_server/files/s3.py
+++ b/ayon_server/files/s3.py
@@ -110,8 +110,8 @@ class S3Uploader:
         self.bucket_name = bucket_name
 
         # Limited-size async queue for chunk uploads to prevent over-filling
-        self._queue: asyncio.Queue[bytes | None] = asyncio.Queue(maxsize=max_queue_size)
-        self._worker_task: asyncio.Task[Any] | None = None
+        self._queue = asyncio.Queue(maxsize=max_queue_size)
+        self._worker_task = None
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
 
     def _init_file_upload(self, key: str):

--- a/ayon_server/helpers/thumbnails.py
+++ b/ayon_server/helpers/thumbnails.py
@@ -2,14 +2,71 @@ import base64
 import functools
 import io
 
+from nxtools import logging
 from PIL import Image
 from starlette.concurrency import run_in_threadpool
+
+
+class ThumbnailProcessNoop(Exception):
+    pass
+
+
+def calculate_scaled_size(
+    source_width: int,
+    source_height: int,
+    max_width: int | None,
+    max_height: int | None,
+) -> tuple[int, int]:
+    """
+    Calculate the scaled size for an image while maintaining the aspect ratio.
+
+    Parameters:
+    source_width (int): The width of the original image.
+    source_height (int): The height of the original image.
+    max_width (int | None): The maximum allowed width for the scaled image.
+    max_height (int | None): The maximum allowed height for the scaled image.
+
+    Returns:
+    tuple[int, int]: A tuple containing the scaled width and height.
+    """
+    aspect_ratio = source_width / source_height
+
+    if max_width is None and max_height is None:
+        raise ValueError("At least one of max_width or max_height must be specified")
+
+    if not (max_width or max_height):
+        raise ValueError("At least one of max_width or max_height must be specified")
+
+    if max_width is None:
+        assert max_height
+        max_width = int(max_height * aspect_ratio)
+    elif max_height is None:
+        assert max_width
+        max_height = int(max_width / aspect_ratio)
+
+    if source_width <= max_width and source_height <= max_height:
+        return source_width, source_height
+
+    if (max_width / aspect_ratio) <= max_height:
+        target_width = max_width
+        target_height = int(max_width / aspect_ratio)
+    else:
+        target_height = max_height
+        target_width = int(max_height * aspect_ratio)
+
+    if target_width % 2 != 0:
+        target_width -= 1
+    if target_height % 2 != 0:
+        target_height -= 1
+
+    return target_width, target_height
 
 
 async def process_thumbnail(
     image_bytes: bytes,
     size: tuple[int | None, int | None] = (150, None),
     format: str | None = None,
+    raise_on_noop: bool = False,
 ) -> bytes:
     """
     Resize an image to the specified dimensions and format asynchronously.
@@ -37,21 +94,22 @@ async def process_thumbnail(
             if size == (None, None):
                 raise ValueError("Both width and height cannot be None")
 
-            new_width, new_height = size
             original_width, original_height = img.size
 
-            if new_width is None:
-                assert new_height is not None  # keeps pyright happy
-                new_width = int(new_height * original_width / original_height)
-            elif new_height is None:
-                assert new_width is not None  # keeps pyright happy
-                new_height = int(new_width * original_height / original_width)
+            new_width, new_height = calculate_scaled_size(
+                original_width, original_height, *size
+            )
 
-            if new_width > original_width or new_height > original_height:
+            if new_width >= original_width or new_height >= original_height:
                 # If the requested size is larger than the original image,
                 # return the original image
+                if raise_on_noop:
+                    raise ThumbnailProcessNoop()
                 return image_bytes
 
+            logging.debug(
+                f"Resizing image from {img.size} to {(new_width, new_height)}"
+            )
             img = img.resize((new_width, new_height), Image.LANCZOS)  # type: ignore
             img_byte_arr = io.BytesIO()
 

--- a/ayon_server/helpers/thumbnails.py
+++ b/ayon_server/helpers/thumbnails.py
@@ -72,5 +72,9 @@ async def process_thumbnail(
 
 @functools.cache
 def get_fake_thumbnail() -> bytes:
+    """Returns a fake thumbnail image as a byte stream.
+
+    The image is a 1x1 pixel PNG encoded in base64.
+    """
     base64_string = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="  # noqa
     return base64.b64decode(base64_string)


### PR DESCRIPTION
This pull request introduces several enhancements and new functionalities to the thumbnail storage and retrieval system. The most important changes include adding support for original thumbnails, refactoring storage methods, and improving the cleanup process for unused thumbnails.

When an uploaded thumbnail is larger than a defined value (currently hardcoded 600px both width and height) the original is stored in the project storage (server/projects/{project_name}/thumbnails) and a scaled down version is saved to the DB for quick retrieval.

### Tasks

- [x] save scaled down version of the image to the database, and the original to the project storage
- [x] support `?original=true` in `[GET] ..../thumbnail` endpoints to retrieve the original image
- [x] implement file deletion in thumbnails cleaner process
- [ ] implement "optimize thumbnails" background process that will be executed once (rest?) and handle older "large" thumbnails (separate PR?)

### Description of changes

  - Added an `original` parameter to various thumbnail retrieval functions to fetch the original image from storage if available. 
  - Introduced new methods in `ProjectStorage` for handling thumbnails, including storing, retrieving, and deleting thumbnail images. 
  - Updated the `clear_thumbnails` function to improve the deletion process of old thumbnails, ensuring that only those not referenced in the database are removed.
  - Included detailed docstrings and comments for better code readability and maintenance.

These changes collectively enhance the robustness and functionality of the thumbnail management system, making it more efficient and easier to maintain.
