### PR TITLE
Project files: Trashing project files directories upon deletion

### DIFF
--- a/api/projects/projects.py
+++ b/api/projects/projects.py
@@ -10,6 +10,7 @@ from ayon_server.exceptions import (
     ForbiddenException,
     NotFoundException,
 )
+from ayon_server.files import Storages
 from ayon_server.helpers.project_list import get_project_list
 from ayon_server.lib.postgres import Postgres
 
@@ -194,6 +195,10 @@ async def delete_project(user: CurrentUser, project_name: ProjectName) -> EmptyR
         raise ForbiddenException("You need to be a manager in order to delete projects")
 
     await project.delete()
+
+    storage = await Storages.project(project_name)
+    await storage.trash()
+
     await unassign_users_from_deleted_projects()
     logging.info(f"[DELETE] Deleted project {project.name}", user=user.name)
 

--- a/ayon_server/files/project_storage.py
+++ b/ayon_server/files/project_storage.py
@@ -348,7 +348,8 @@ class ProjectStorage:
 
         if self.storage_type == "local":
             logging.debug(f"Trashing project {self.project_name} storage")
-            project_dir = await self.get_root()
+            projects_root = await self.get_root()
+            project_dir = os.path.join(projects_root, self.project_name)
             if not os.path.isdir(project_dir):
                 return
             timestamp = int(time.time())

--- a/ayon_server/helpers/download.py
+++ b/ayon_server/helpers/download.py
@@ -47,6 +47,7 @@ async def download_file(
     target_path: str,
     filename: str | None = None,
     progress_handler: Callable[[int], Awaitable[None]] | None = None,
+    timeout: int | None = None,
 ) -> None:
     """Downloads a file from a url to a target path"""
 
@@ -100,7 +101,7 @@ async def download_file(
     temp_file_path = target_path + f".{uuid.uuid1().hex}.part"
     i = 0
     async with httpx.AsyncClient(
-        timeout=ayonconfig.http_timeout, follow_redirects=True
+        timeout=timeout or ayonconfig.http_timeout, follow_redirects=True
     ) as client:
         async with client.stream("GET", url) as response:
             if response.status_code != 200:

--- a/ayon_server/helpers/project_list.py
+++ b/ayon_server/helpers/project_list.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Any
 
+from ayon_server.exceptions import NotFoundException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.types import OPModel
@@ -44,3 +45,12 @@ async def get_project_list() -> list[ProjectListItem]:
     else:
         project_list = json_loads(project_list)
         return [ProjectListItem(**item) for item in project_list]
+
+
+async def get_project_info(project_name: str) -> ProjectListItem:
+    """Return a single project info"""
+    project_list = await get_project_list()
+    for project in project_list:
+        if project.name == project_name:
+            return project
+    raise NotFoundException(f"Project {project_name} not found")


### PR DESCRIPTION
https://github.com/ynput/ayon-backend/issues/380

### Local filesystem

Upon project deletion, the project directory is renamed to `{project_name}.{timestamp}.trash` 

Since project names cannot contain `.` character, dot-delimination is non ambiguous, using a timestamp ( `int(time.time()`) allows multiple versions of the same project and restore the snapshot. 

Sufffixing the projectname with `.trash` makes it easy to filter & delete.

> [!IMPORTANT] 
> This approach ensures 100% backward compatibility with existing projects

![image](https://github.com/user-attachments/assets/6b838f83-23ea-4f2a-9875-11a4e464f5e1)


### S3

S3 does not support "directory" renaming so we need a different approach here:

- every project storage from now uses `{project_name}.{timestamp}` as the project root. where the timestamp is the project `created_at`, so it's deterministic, can be paired with the current version of the project and the list can be sorted by versions/periods
- when a project is deleted and recreated,  a new unique project root will be created
- The clean-up process will delete project directories not attached to any project after a grace period.

> [!WARNING]
> This is a breaking change that requires changing the project roots in S3 storages, 
> but as far as we know, S3 is not used anywhere in production yet.

![image](https://github.com/user-attachments/assets/ae3a270e-919e-406c-9994-6398b7d04152)
