### PR TITLE
Skip inactive-projects clean-up

### DIFF
--- a/ayon_server/background/clean_up.py
+++ b/ayon_server/background/clean_up.py
@@ -266,6 +266,9 @@ class AyonCleanUp(BackgroundWorker):
         else:
             # For each project, clean up thumbnails and unused files
             for project in projects:
+                if not project.active:
+                    continue
+
                 for prj_func in (
                     clear_thumbnails,
                     clear_activities,


### PR DESCRIPTION
We could just assume project is marked as inactive when there's no ongoing activity that should be cleaned-up