### PR TITLE
Watching and inbox rules improvements

### DIFF
--- a/ayon_server/graphql/resolvers/inbox.py
+++ b/ayon_server/graphql/resolvers/inbox.py
@@ -43,8 +43,12 @@ async def get_inbox(
         # that is passed as an argument to funcition, which uses
         # it to format a string... i am so sorry
         operator = "IN" if show_important_messages else "NOT IN"
+        if show_important_messages:
+            not_important = "AND t.activity_type != ''status.change''"
+        else:
+            not_important = "OR t.activity_type = ''status.change''"
         subquery_conds.append(
-            f"t.reference_type {operator} (''mention'', ''watching'')"
+            f"(t.reference_type {operator} (''mention'', ''watching'') {not_important})"
         )
 
     subquery_add_arg = ""


### PR DESCRIPTION
## Watching/unwatching a task

When watching a task:

- User gets added as a watcher to all versions of that task automatically.
- User gets added to any new versions of that tasks automatically.

When unwatching a task:

- User gets removed from watching all task versions.
- User does not get automatically added to new task versions.


### Note

Setting/unsetting a watcher should invalidate client cache as now the new state is only visible after page reload

## Status changes

Status changes are no loner considered important in the inbox, regardless user watching the entity or not

## get_inbox query

`get_user_inbox` query now takes in account whether the user has access to the project. If they're unassigned from the project, related items will disappear from the inbox (that also improves the performance).