### PR TITLE
Fix attribute model for enums

### DIFF
--- a/ayon_server/entities/models/generator.py
+++ b/ayon_server/entities/models/generator.py
@@ -153,6 +153,8 @@ def generate_model(
 
         if field.get("enum"):
             field["_attrib_enum"] = True
+            if isinstance(field["enum"][0], AttributeEnumItem):
+                field["enum"] = [e.value for e in field["enum"]]
         #
         # Default value
         #


### PR DESCRIPTION
This pull request includes a small but important change to the `generate_model` method in the `ayon_server/entities/models/generator.py` file. The change ensures that if the `enum` field contains instances of `AttributeEnumItem`, their values are extracted correctly.