### PR TITLE
Handle empty response when returning cached 'nothing to do' from enroll

### DIFF
--- a/api/events/enroll.py
+++ b/api/events/enroll.py
@@ -149,7 +149,7 @@ async def enroll(
 
         sloth("Request is already completed. Returning the cached result.")
         await Redis.delete("enroll", request_hash)
-        return cached_result.get("result")
+        return cached_result.get("result") or EmptyResponse()
 
     else:
         if cached_result:

--- a/api/events/enroll.py
+++ b/api/events/enroll.py
@@ -149,7 +149,9 @@ async def enroll(
 
         sloth("Request is already completed. Returning the cached result.")
         await Redis.delete("enroll", request_hash)
-        return cached_result.get("result") or EmptyResponse()
+        if result := cached_result.get("result"):
+            return EnrollResponseModel(**result)
+        return EmptyResponse()  # return empty response if there is no result
 
     else:
         if cached_result:


### PR DESCRIPTION
This pull request includes a small but important change to the enroll endpoint. The change ensures that an `EmptyResponse` is returned if the cached result is not available.
