### PR TITLE
Added folder reference to task activities

### DIFF
--- a/ayon_server/activities/references.py
+++ b/ayon_server/activities/references.py
@@ -90,6 +90,15 @@ async def get_references_from_task(task: TaskEntity) -> set[ActivityReferenceMod
             )
         )
 
+    references.add(
+        ActivityReferenceModel(
+            entity_type="folder",
+            entity_name=None,
+            entity_id=task.folder_id,
+            reference_type="relation",
+        )
+    )
+
     return references
 
 


### PR DESCRIPTION
When creating an activity on a task, create an additional reference to the task folder

![image](https://github.com/user-attachments/assets/eccd194b-3cff-4ced-b614-bcd3a1c4fc7c)
