### PR TITLE
Trigger event when entity parent changes

### DIFF
--- a/ayon_server/events/patch.py
+++ b/ayon_server/events/patch.py
@@ -19,6 +19,11 @@ ADDITIONAL_COLUMNS = {
     "product_type": "product_type_changed",
     "author": "author_changed",
     "files": "files_changed",
+    "parent_id": "parent_changed",  # for folders
+    "folder_id": "folder_changed",  # for tasks and products
+    "task_id": "task_changed",  # for workfiles and versions
+    "product_id": "product_changed",  # for versions
+    "version_id": "version_changed",  # for representations
 }
 
 


### PR DESCRIPTION
Additional events are triggered when a top-level field of an entity is changed:

```python
{
    "parent_id": "parent_changed",  # for folders
    "folder_id": "folder_changed",  # for tasks and products
    "task_id": "task_changed",  # for workfiles and versions
    "product_id": "product_changed",  # for versions
    "version_id": "version_changed",  # for representations
}
```

![image](https://github.com/user-attachments/assets/2c03657d-1792-4b3c-ba22-39bae331c317)

Keep in mind that there are constraints in the API, that for example forbids changing hierarchy of folders (e.g. changing parent_id of a folder) when there's a published version in that folder.
