### PR TITLE
Include thumbnails in storage usage metrics

### DIFF
--- a/ayon_server/metrics/projects.py
+++ b/ayon_server/metrics/projects.py
@@ -129,9 +129,7 @@ async def get_project_metrics(
             ),
             None,
         )
-        if db_size is None:
-            print("DB size is None for project", project.name)
-        result["db_size"] = db_size
+        result["db_size"] = db_size or 0  # 0 should never happen
 
         storage_utilizations = await system_metrics.get_upload_sizes()
         storage_utilization = next(
@@ -142,9 +140,7 @@ async def get_project_metrics(
             ),
             None,
         )
-        if storage_utilization is None:
-            print("Storage utilization is None for project", project.name)
-        result["storage_utilization"] = storage_utilization
+        result["storage_utilization"] = storage_utilization or 0
 
     if saturated:
         result["folder_types"] = [f["name"] for f in project.folder_types]

--- a/ayon_server/metrics/system.py
+++ b/ayon_server/metrics/system.py
@@ -145,12 +145,18 @@ class SystemMetrics:
 
             res = await Postgres.fetch(
                 f"""
-                SELECT SUM((meta->'originalSize)::BIGINT)
+                SELECT SUM((meta->'originalSize')::BIGINT)
                 FROM project_{project_name}.thumbnails
                 WHERE meta->'originalSize' IS NOT NULL  -- Ayon <1.5.0
                 AND meta->'originalSize' != meta->'thumbnailSize'
                 """
             )
+
+            thumbnails_size = res[0]["sum"] or 0
+            project_size += thumbnails_size
+
+            if not project_size:
+                continue
 
             m = Metric(
                 "storage_utilization_project",


### PR DESCRIPTION
Include original thumbnails off-loaded to the project storage in storage utilization metrics