### PR TITLE
Events: Unsubscribe from event stream

### DIFF
--- a/ayon_server/events/eventstream.py
+++ b/ayon_server/events/eventstream.py
@@ -15,15 +15,20 @@ HandlerType = Callable[[EventModel], Awaitable[None]]
 
 class EventStream:
     model: Type[EventModel] = EventModel
-    hooks: dict[str, list[HandlerType]] = {}
+    hooks: dict[str, dict[str, HandlerType]] = {}
 
     @classmethod
     def subscribe(cls, topic: str, handler: HandlerType) -> str:
         token = create_id()
         if topic not in cls.hooks:
-            cls.hooks[topic] = []
-        cls.hooks[topic].append(handler)
+            cls.hooks[topic] = {}
+        cls.hooks[topic][token] = handler
         return token
+
+    @classmethod
+    def unsubscribe(cls, token: str) -> None:
+        for topic in cls.hooks:
+            cls.hooks[topic].pop(token, None)
 
     @classmethod
     async def dispatch(
@@ -138,7 +143,7 @@ class EventStream:
             )
         )
 
-        handlers = cls.hooks.get(event.topic, [])
+        handlers = cls.hooks.get(event.topic, {}).values()
         for handler in handlers:
             try:
                 await handler(event)

--- a/ayon_server/events/eventstream.py
+++ b/ayon_server/events/eventstream.py
@@ -18,10 +18,12 @@ class EventStream:
     hooks: dict[str, list[HandlerType]] = {}
 
     @classmethod
-    def subscribe(cls, topic: str, handler: HandlerType) -> None:
+    def subscribe(cls, topic: str, handler: HandlerType) -> str:
+        token = create_id()
         if topic not in cls.hooks:
             cls.hooks[topic] = []
         cls.hooks[topic].append(handler)
+        return token
 
     @classmethod
     async def dispatch(

--- a/ayon_server/events/eventstream.py
+++ b/ayon_server/events/eventstream.py
@@ -29,6 +29,8 @@ class EventStream:
     def unsubscribe(cls, token: str) -> None:
         for topic in cls.hooks:
             cls.hooks[topic].pop(token, None)
+            if not cls.hooks[topic]:
+                cls.hooks.pop(topic)
 
     @classmethod
     async def dispatch(

--- a/ayon_server/events/eventstream.py
+++ b/ayon_server/events/eventstream.py
@@ -27,10 +27,13 @@ class EventStream:
 
     @classmethod
     def unsubscribe(cls, token: str) -> None:
+        topics_to_remove = []
         for topic in cls.hooks:
             cls.hooks[topic].pop(token, None)
             if not cls.hooks[topic]:
-                cls.hooks.pop(topic)
+                topics_to_remove.append(topic)
+        for topic in topics_to_remove:
+            cls.hooks.pop(topic)
 
     @classmethod
     async def dispatch(


### PR DESCRIPTION
`EventStream.subscribe()` now returns a string token, that could be used for unsubscribing later on.

This is useful in the cases an addon needs to listen for events only if it is in production for example:

```python

    async def setup(self):
        self.event_tokens = []
        await self.on_bundle_updated() 
        EventStream.subscribe("bundle.updated", self.on_bundle_updated)


    async def on_bundle_updated(self, _: EventModel | None = None) -> None:

        if await self.is_production():
            if not self.event_tokens:
                logging.debug(f"{self} is in production mode, subscribing to events")
                self.event_tokens = [
                    EventStream.subscribe("entity.folder.status_changed", self.on_status_changed),
                    EventStream.subscribe("entity.task.status_changed", self.on_status_changed),
                ]

        else:
            if self.event_tokens:
                logging.debug(f"{self} is not in production mode, unsubscribing from events")
                for token in self.event_tokens:
                    EventStream.unsubscribe(token)
                self.event_tokens = []


    async def on_status_changed(self, event: EventModel):
        logging.debug(f"Status changed event received: {event}")

        # Do something with the event
```
