### PR TITLE
Auth: fixed session invalidation logic

### DIFF
--- a/ayon_server/auth/session.py
+++ b/ayon_server/auth/session.py
@@ -85,13 +85,9 @@ class Session:
         # extend normal tokens validity, but not service tokens.
         # they should be validated against db forcefully every 10 minutes or so
 
-        # Extend the session lifetime only if it's in its second half
-        # (save update requests).
-        # So it doesn't make sense to call the parameter last_used is it?
-        # Whatever. Fix later.
-
         if not session.is_service:
-            if time.time() - session.created > ayonconfig.session_ttl / 2:
+            remaining_ttl = ayonconfig.session_ttl - (time.time() - session.last_used)
+            if remaining_ttl < ayonconfig.session_ttl - 120:
                 session.last_used = time.time()
                 await Redis.set(cls.ns, token, json_dumps(session.dict()))
 

--- a/ayon_server/config/ayonconfig.py
+++ b/ayon_server/config/ayonconfig.py
@@ -108,7 +108,7 @@ class AyonConfig(BaseModel):
     )
 
     session_ttl: int = Field(
-        default=24 * 3600,
+        default=72 * 3600,
         description="Session lifetime in seconds",
     )
 


### PR DESCRIPTION
This pull request includes changes to the session management and configuration in the `ayon_server` module. The most important changes involve updating the session lifetime logic and modifying the default session TTL configuration.

- Updated the logic to extend the session lifetime only if the remaining TTL is less than the TTL minus 120 seconds. This change ensures that the session is updated more efficiently.
- Changed the default session TTL from 24 hours to 72 hours to provide a longer session lifetime by default (hold session over the weekend)