### PR TITLE
Added missing event to task/assign endpoint

### DIFF
--- a/api/tasks/tasks.py
+++ b/api/tasks/tasks.py
@@ -184,24 +184,38 @@ async def assign_users_to_task(
         raise ForbiddenException("Normal users can only assign themselves")
 
     task = await TaskEntity.load(project_name, task_id)
-    assignees = task.assignees
+    assignees = set(task.assignees)
+    original_assignees = set(task.assignees)
 
     if post_data.mode == "add":
-        assignees.extend(post_data.users)
-        # Remove duplicates
-        assignees = list(dict.fromkeys(assignees))
+        assignees.update(post_data.users)
     elif post_data.mode == "remove":
-        assignees = [
-            assignee for assignee in assignees if assignee not in post_data.users
-        ]
+        for uname in post_data.users:
+            assignees.discard(uname)
     elif post_data.mode == "set":
         assignees = post_data.users
     else:
         raise ValueError(f"Unknown mode: {post_data.mode}")
 
-    task.assignees = assignees
+    if assignees == original_assignees:
+        # nothing changed
+        return EmptyResponse()
+
+    task.assignees = list(assignees)
     await task.save()
 
-    # TODO: trigger event
+    event_payload = {
+        "description": f"Changed task {task.name} assignees",
+        "project": project_name,
+        "summary": {"entityId": task.id, "parentId": task.folder_id},
+        "user": user.name,
+    }
+    if ayonconfig.audit_trail:
+        event_payload["payload"] = {
+            "oldValue": list(original_assignees),
+            "newValue": list(assignees),
+        }
+
+    await EventStream.dispatch("entity.task.assignees_changed", **event_payload)
 
     return EmptyResponse()

--- a/ayon_server/events/patch.py
+++ b/ayon_server/events/patch.py
@@ -185,6 +185,7 @@ def build_pl_entity_change_events(
             continue
 
         description = f"Changed {entity_type} {original_entity.name} {column_name}"
+
         result.append(
             {
                 "topic": f"entity.{entity_type}.{topic_name}",


### PR DESCRIPTION
This pull request includes changes to improve the handling of task assignees and event dispatching in the `[POST] task/assign` endpoint.

* Ensured the `entity.task.assignees_changed` event is dispatched with the appropriate payload when assignees are changed
* Converted `assignees` to a set to avoid duplicates and improve performance. Added a check to return early if there are no changes to assignees.
* Added an audit trail to track changes in task assignees by including the old and new values in the event payload.
