### PR TITLE
Setup: Increased query timeout for DB migration

### DIFF
--- a/setup/__main__.py
+++ b/setup/__main__.py
@@ -62,7 +62,7 @@ async def db_migration(has_schema: bool) -> int:
             #    continue
             # logging.info(f"Applying migration {migration_version}")
 
-            await Postgres.execute(migration.read_text())
+            await Postgres.execute(migration.read_text(), timeout=600)
         return migration_version
 
     return int(available_migrations[-1].stem)


### PR DESCRIPTION
Added a `timeout` parameter with a value of 600 seconds to the `Postgres.execute` method call in the `db_migration` function.