### PR TITLE
Events: Horizontal scaling support in EventStream.subscribe

### DIFF
--- a/ayon_server/addons/library.py
+++ b/ayon_server/addons/library.py
@@ -29,7 +29,7 @@ class AddonLibrary:
             logging.error(f"Addons directory does not exist: {addons_dir}")
             return None
 
-        for addon_name in os.listdir(addons_dir):
+        for addon_name in sorted(os.listdir(addons_dir)):
             # ignore hidden directories (such as .git)
             if addon_name.startswith("."):
                 continue


### PR DESCRIPTION
This pull request introduces several key improvements to the handling of event subscribers and the organization of hooks in the EventStream class.

### Event Behavior: Single Instance vs. All Instances

####  Single Instance Handling

When an event is created and a subscriber is attached to the topic, the function is triggered only on the current server instance.

Use Case: Situations where the event should be processed once, e.g., "Entity status change sends a notification."

#### All Instances Handling:
In scaled deployments of Ayon (multiple server instances), some events need to trigger functions on all instances.

Use Case: "Addon settings change requires all addon instances to reload their cache."

### Implementation

Added a new parameter, `all_nodes: bool`, to the `EventStream.subscribe method` (Default: False)
When set to True, the subscribed function will be triggered on all server instances.

Hooks are now split into two groups:
- `local_hooks`: Implementation remains unchanged.
- `global_hooks`: Implementation added in ayon_server.api.messaging.

### Testing Notes

Use multiple replicas in a Docker Compose environment.

```yaml
server:
    image: ynput/ayon:dev
    restart: unless-stopped
    deploy:
      replicas: 3
    ports: 
      -"5000-5002:5000"
```

Subscribe to an event topic from an addon using:

```python
EventStream.subscribe(topic_name, handler, all_nodes=True)
```

Verify correct behavior for both single-instance and all-instance event handling.

Keep in mind Ayon server is still not fully horizontally scalable, so other functionality may break when the server runs with multiple replicas.