### PR TITLE
Inbox: API enhancements

### DIFF
--- a/api/inbox/inbox.py
+++ b/api/inbox/inbox.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.lib.postgres import Postgres
@@ -10,10 +10,18 @@ from .router import router
 class ManageInboxItemRequest(OPModel):
     project_name: str = Field(...)
 
-    ids: list[str] = Field(
-        default_factory=list,
-        title="List of items",
-        description="List of reference_ids of items to be managed",
+    ids: Annotated[
+        list[str] | None,
+        Field(
+            title="List of items",
+            description="List of reference_ids of items to be managed",
+        ),
+    ] = None
+
+    all: bool = Field(
+        False,
+        title="All",
+        description="If true, all items will be managed",
     )
 
     status: Literal["unread", "read", "inactive"] = Field(
@@ -31,6 +39,9 @@ async def manage_inbox_item(user: CurrentUser, request: ManageInboxItemRequest):
     # read: sets refence_data->>'read' to true
     # unread: sets active to true and deletes refence_data->>'read'
 
+    if not request.ids and not request.all:
+        raise ValueError("Either ids or all should be provided")
+
     if request.status == "unread":
         body = "active = true, data = data - 'read'"
     elif request.status == "read":
@@ -40,15 +51,20 @@ async def manage_inbox_item(user: CurrentUser, request: ManageInboxItemRequest):
     else:
         raise ValueError("Invalid status. This should not happen.")
 
+    if request.all:
+        base_query = f"""
+            UPDATE project_{request.project_name}.activity_references
+            SET {body} WHERE entity_type = 'user' entity_name = $2
+        """
+        await Postgres.execute(base_query, request.ids, user.name)
+        return None
+
     base_query = f"""
         UPDATE project_{request.project_name}.activity_references
         SET {body}
-        WHERE
-            id = ANY($1)
+        WHERE id = ANY($1)
         AND entity_type = 'user'
         AND entity_name = $2
     """
-
     await Postgres.execute(base_query, request.ids, user.name)
-
     return None

--- a/api/inbox/inbox.py
+++ b/api/inbox/inbox.py
@@ -54,7 +54,7 @@ async def manage_inbox_item(user: CurrentUser, request: ManageInboxItemRequest):
     if request.all:
         base_query = f"""
             UPDATE project_{request.project_name}.activity_references
-            SET {body} WHERE entity_type = 'user' entity_name = $2
+            SET {body} WHERE entity_type = 'user' AND entity_name = $2
         """
         await Postgres.execute(base_query, request.ids, user.name)
         return None

--- a/api/inbox/inbox.py
+++ b/api/inbox/inbox.py
@@ -54,9 +54,9 @@ async def manage_inbox_item(user: CurrentUser, request: ManageInboxItemRequest):
     if request.all:
         base_query = f"""
             UPDATE project_{request.project_name}.activity_references
-            SET {body} WHERE entity_type = 'user' AND entity_name = $2
+            SET {body} WHERE entity_type = 'user' AND entity_name = $1
         """
-        await Postgres.execute(base_query, request.ids, user.name)
+        await Postgres.execute(base_query, user.name)
         return None
 
     base_query = f"""


### PR DESCRIPTION
This PR enhances the existing `manage_inbox_item` endpoint with `all` argument. Originally, it was necessary to provide a list of ids to manage, now, this list is optional if `all` is set to true - that allows marking the entire inbox as `read` or `inactive` using a single request.