### PR TITLE
REST: tasksFolders endpoint

### DIFF
--- a/api/events/enroll.py
+++ b/api/events/enroll.py
@@ -14,7 +14,7 @@ from ayon_server.exceptions import (
 )
 from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
-from ayon_server.sqlfilter import Filter
+from ayon_server.sqlfilter import QueryFilter
 from ayon_server.types import TOPIC_REGEX, Field, OPModel
 from ayon_server.utils import hash_data
 
@@ -59,7 +59,7 @@ class EnrollRequestModel(OPModel):
         description="Ensure events are processed in sequential order",
         example=True,
     )
-    filter: Filter | None = Field(
+    filter: QueryFilter | None = Field(
         None, title="Filter", description="Filter source events"
     )
     max_retries: int = Field(3, title="Max retries", example=3)

--- a/api/events/operations.py
+++ b/api/events/operations.py
@@ -3,7 +3,7 @@ from typing import Literal
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.exceptions import ForbiddenException, NotImplementedException
 from ayon_server.lib.postgres import Postgres
-from ayon_server.sqlfilter import Filter, build_filter
+from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import Field, OPModel
 
 from .router import router
@@ -13,7 +13,7 @@ OperationType = Literal["delete", "restart", "abort"]
 
 class EventOperationModel(OPModel):
     type: OperationType = Field(..., title="Operation type")
-    filter: Filter = Field(..., title="Filter", description="Filter source events")
+    filter: QueryFilter = Field(..., title="Filter", description="Filter source events")
 
 
 @router.post("/eventops")

--- a/api/query/query.py
+++ b/api/query/query.py
@@ -6,7 +6,7 @@ from ayon_server.api.dependencies import CurrentUser
 from ayon_server.events import EventModel
 from ayon_server.exceptions import ForbiddenException
 from ayon_server.lib.postgres import Postgres
-from ayon_server.sqlfilter import Filter, build_filter
+from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import Field, OPModel
 
 router = APIRouter(prefix="", tags=["Events"])
@@ -24,7 +24,9 @@ class QueryRequestModel(OPModel):
         "representation",
         "workfile",
     ] = Field(...)
-    filter: Filter | None = Field(None, title="Filter", description="Filter events")
+    filter: QueryFilter | None = Field(
+        None, title="Filter", description="Filter events"
+    )
     limit: int = Field(
         100, title="Limit", description="Maximum number of events to return"
     )
@@ -63,6 +65,7 @@ async def query(
                 project=record["project_name"],
                 user=record["user_name"],
                 sender=record["sender"],
+                sender_type=record["sender_type"],
                 depends_on=record["depends_on"],
                 status=record["status"],
                 retries=record["retries"],

--- a/api/tasks_folders/__init__.py
+++ b/api/tasks_folders/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["router"]
+
+from .tasks_folders import router

--- a/api/tasks_folders/tasks_folders.py
+++ b/api/tasks_folders/tasks_folders.py
@@ -1,15 +1,19 @@
 from typing import Annotated
 
 from fastapi import APIRouter
+from nxtools import logging
 
+from ayon_server.access.utils import folder_access_list
 from ayon_server.api.dependencies import CurrentUser, ProjectName
+from ayon_server.lib.postgres import Postgres
+from ayon_server.sqlfilter import Filter, build_filter
 from ayon_server.types import Field, OPModel
 
 router = APIRouter(tags=["Tasks"])
 
 
 class TasksFoldersQuery(OPModel):
-    pass
+    filter: Annotated[Filter | None, Field(description="")] = None
 
 
 class TasksFoldersResponse(OPModel):
@@ -26,12 +30,42 @@ class TasksFoldersResponse(OPModel):
     ]
 
 
+ALLOWED_KEYS = [
+    "id",
+    "name",
+    "label",
+    "status",
+    "task_type",
+    "assignees",
+    "attrib",
+    "active",
+    "tags",
+]
+
+
 @router.post("/projects/{project_name}/tasksFolders")
 async def query_tasks_folders(
     user: CurrentUser,
     project_name: ProjectName,
-    query: TasksFoldersQuery,
+    request: TasksFoldersQuery,
 ) -> TasksFoldersResponse:
     result = []
+
+    filter = build_filter(request.filter, key_whitelist=ALLOWED_KEYS)
+
+    query = f"""
+        SELECT DISTINCT folder_id
+        FROM project_{project_name}.tasks
+        WHERE
+            {filter}
+    """
+
+    facl = await folder_access_list(user, project_name, "read")
+
+    logging.debug("query", query)
+    async for row in Postgres.iterate(query):
+        if facl is not None and row["folder_id"] not in facl:
+            continue
+        result.append(row["folder_id"])
 
     return TasksFoldersResponse(folder_ids=result)

--- a/api/tasks_folders/tasks_folders.py
+++ b/api/tasks_folders/tasks_folders.py
@@ -51,7 +51,7 @@ async def query_tasks_folders(
 ) -> TasksFoldersResponse:
     result = []
 
-    filter = build_filter(request.filter, key_whitelist=ALLOWED_KEYS)
+    filter = build_filter(request.filter, column_whitelist=ALLOWED_KEYS)
 
     query = f"""
         SELECT DISTINCT folder_id

--- a/api/tasks_folders/tasks_folders.py
+++ b/api/tasks_folders/tasks_folders.py
@@ -1,0 +1,37 @@
+from typing import Annotated
+
+from fastapi import APIRouter
+
+from ayon_server.api.dependencies import CurrentUser, ProjectName
+from ayon_server.types import Field, OPModel
+
+router = APIRouter(tags=["Tasks"])
+
+
+class TasksFoldersQuery(OPModel):
+    pass
+
+
+class TasksFoldersResponse(OPModel):
+    folder_ids: Annotated[
+        list[str],
+        Field(
+            default_factory=list,
+            description="List of folder ids containing tasks matching the query",
+            example=[
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222",
+            ],
+        ),
+    ]
+
+
+@router.post("/projects/{project_name}/tasksFolders")
+async def query_tasks_folders(
+    user: CurrentUser,
+    project_name: ProjectName,
+    query: TasksFoldersQuery,
+) -> TasksFoldersResponse:
+    result = []
+
+    return TasksFoldersResponse(folder_ids=result)

--- a/api/tasks_folders/tasks_folders.py
+++ b/api/tasks_folders/tasks_folders.py
@@ -6,14 +6,14 @@ from nxtools import logging
 from ayon_server.access.utils import folder_access_list
 from ayon_server.api.dependencies import CurrentUser, ProjectName
 from ayon_server.lib.postgres import Postgres
-from ayon_server.sqlfilter import Filter, build_filter
+from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import Field, OPModel
 
 router = APIRouter(tags=["Tasks"])
 
 
 class TasksFoldersQuery(OPModel):
-    filter: Annotated[Filter | None, Field(description="")] = None
+    filter: Annotated[QueryFilter | None, Field(description="")] = None
 
 
 class TasksFoldersResponse(OPModel):

--- a/ayon_server/events/enroll.py
+++ b/ayon_server/events/enroll.py
@@ -1,7 +1,7 @@
 from ayon_server.events.eventstream import EventStream
 from ayon_server.exceptions import ConstraintViolationException
 from ayon_server.lib.postgres import Postgres
-from ayon_server.sqlfilter import Filter, build_filter
+from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import Field, OPModel
 from ayon_server.utils import SQLTool, hash_data
 
@@ -24,7 +24,7 @@ async def enroll_job(
     user_name: str | None = None,
     description: str | None = None,
     sequential: bool = False,
-    filter: Filter | None = None,
+    filter: QueryFilter | None = None,
     max_retries: int = 3,
     ignore_sender_types: list[str] | None = None,
     ignore_older_than: int | None = None,

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -296,12 +296,12 @@ async def get_tasks(
             "thumbnail_id",
         ]
         fq = QueryFilter(**json.loads(filter))
-        fcond = build_filter(
+        if fcond := build_filter(
             fq,
             column_whitelist=column_whitelist,
             table_prefix="tasks",
-        )
-        sql_conditions.append(fcond)
+        ):
+            sql_conditions.append(fcond)
 
     #
     # Joins

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -185,6 +185,12 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
         column = f"{table_prefix}.{column}"
 
     if isinstance(value, list):
+        if len(value) == 0:
+            if operator == "eq":
+                return f"array_length({column}, 1) IS NULL"
+            if operator == "ne":
+                return f"array_length({column}, 1) IS NOT NULL"
+
         if all(isinstance(v, str) for v in value):
             escaped_list = [v.replace("'", "''") for v in value]  # type: ignore
             arr_value = "array[" + ", ".join([f"'{v}'" for v in escaped_list]) + "]"
@@ -209,6 +215,7 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
                 return f"{column}::{cast_type} != ALL({arr_value})"
         elif operator == "any":
             return f"{column}::{cast_type}[] && {arr_value}"
+
         else:
             raise ValueError(f"Invalid list operator: {operator}")
 

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -137,7 +137,7 @@ def create_path_from_key(
     column = camel_to_snake(path[0])
     if column_whitelist is not None and column not in column_whitelist:
         raise ValueError(f"Invalid key: {column}")
-    path[0]
+    path[0] = column
     return path
 
 


### PR DESCRIPTION
This new endpoint returns a list of folder ids containing tasks matching the given query. This is also a prototype of the proposed query structure that may be adopted for more entity types.

The query supports multiple nested conditions. The `filter` object accepts two parameters:

- **`operator`**: Either `"and"` or `"or"` (defaults to `"and"` if not provided).
- **`conditions`**: A list of conditions, which can either be:
  - Another `filter` object (allowing for nested queries).
  - A condition object containing `key`, `operator`, and `value`.

### Condition Format

Each condition consists of:
- **`key`**: The name of the field (e.g., `status`, `tags`, `assignees`, etc.).
- **`operator`**: A comparison method.
- **`value`**: The value to compare against (if applicable).

### Supported Operators

| Operator  | Description |
|-----------|------------|
| `eq`      | Stored value must match the queried value. |
| `lt`      | Match records with value lower than the requested value  |
| `gt`      | Match records that are greater than the requested value. |
| `lte`     | Match records with value lower or equal the requested value |
| `gte`     | Match records with value greater or equal the requested value |
| `ne`      | Queried value must not match the stored value. |
| `isnull`  | Stored value must be `null` (`value` field is ignored). |
| `notnull` | Stored value must not be `null` (`value` field is ignored). |
| `in`      | Stored value must match at least one item in the array provided in `value`. |
| `notin`   | Stored value must not be present in the array provided in `value`. |
| `contains`| Stored value (array) must contain the provided `value`. |
| `excludes`| Stored value (array) must not contain the provided `value`. |
| `any`     | Both queried and stored values are arrays, and they must have at least one common element. |
| `like`    | Performs an SQL-like partial string match. |

This structure provides flexibility in querying tasks while maintaining consistency across different entity types.



`[POST] /api/projects/myproject/tasksFolders`

```json
{
    "filter": {
        "operator": "and",
        "conditions": [
            {
                "key": "tags",
                "operator": "any",
                "value": ["fluffy", "cute"],
            },
            {
                "operator": "or",
                "conditions": [
                    {
                        "key": "status",
                        "operator": "eq",
                        "value": "In progress"
                    },
                    {
                        "key": "status",
                        "operator": "eq",
                        "value": "Pending review"
                    },

                ]
            }
        ]
    }
}
```

Translates to SQL condition:

```sql
SELECT DISTINCT(folder_id) FROM project_myproject.tags 
WHERE
    tags::text[] && array['fluffy'] 
AND (status = 'In progress' OR status = 'Pending review'))
```

So the result will contain a list of ids of folders, that contain tasks with tag "fluffy" or "cute" and simultaneously have status `In progress` or `Pending review`