### PR TITLE
API: Routers defined by addons

### DIFF
--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -23,6 +23,8 @@ from ayon_server.settings import BaseSettingsModel, apply_overrides
 from ayon_server.settings.common import migrate_settings_overrides
 
 if TYPE_CHECKING:
+    from fastapi import APIRouter
+
     from ayon_server.addons.definition import ServerAddonDefinition
 
 METADATA_KEYS = [
@@ -69,6 +71,7 @@ class BaseServerAddon:
     definition: "ServerAddonDefinition"
     legacy: bool = False  # auto-set to true if it is the old style addon
     endpoints: list[dict[str, Any]]
+    routers: list["APIRouter"]
 
     def __init__(self, definition: "ServerAddonDefinition", addon_dir: str, **kwargs):
         # populate metadata from package.py
@@ -95,6 +98,7 @@ class BaseServerAddon:
         self.definition = definition
         self.addon_dir = addon_dir
         self.endpoints = []
+        self.routers = []
         self.restart_requested = False
         logging.debug(f"Initializing addon {self.name} v{self.version}")
         self.initialize()
@@ -169,6 +173,9 @@ class BaseServerAddon:
         """
         logging.info(f"Addon {self.name}:{self.version} requested server restart")
         self.restart_requested = True
+
+    def add_router(self, router: "APIRouter") -> None:
+        self.routers.append(router)
 
     def add_endpoint(
         self,

--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -328,6 +328,17 @@ def init_addon_endpoints(target_app: fastapi.FastAPI) -> None:
                     name=f"{addon_name}_{version}_ws",
                 )
 
+            for router in addon.routers:
+                target_app.include_router(
+                    router,
+                    prefix=f"/api/addons/{addon_name}/{version}",
+                    tags=[f"{addon_definition.friendly_name} {version}"],
+                    include_in_schema=ayonconfig.openapi_include_addon_endpoints,
+                    generate_unique_id_function=lambda x: slugify(
+                        f"{addon_name}_{version}_{x.name}", separator="_"
+                    ),
+                )
+
             for endpoint in addon.endpoints:
                 path = endpoint["path"].lstrip("/")
                 first_element = path.split("/")[0]


### PR DESCRIPTION
The key changes include adding support for registering routers in the `BaseServerAddon` class and updating the server initialization to include these routers.

* Introduced a new method `add_router` to the `BaseServerAddon` class for adding `APIRouter` 
* Introduced `CurrentAddon` dependency to get the instance of the addon from the endpoint

This adds a way to include multiple addon endpoints in one step and declutter the initialization.

```python

from fastapi import APIRouter
from ayon_server.api.dependencies import CurrentAddon

router = APIRouter()

@router.get("/my-route")
def my_route(addon: CurrentAddon):
    return {"message": f"Hello from {addon.name} {addon.version}"}


class MyAddon(BaseServerAddon):
    def initialize(self):
        self.add_router(router)
```


![image](https://github.com/user-attachments/assets/62aa324f-751f-4961-aff3-c37351f05716)

Route names are created dynamically based on the addon name and version (similarly to endpoints added by add_endpoint method)
