### PR TITLE
Helpers: get_used_project_tags helper

### DIFF
--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -18,6 +18,7 @@ from ayon_server.graphql.resolvers.tasks import get_task, get_tasks
 from ayon_server.graphql.resolvers.versions import get_version, get_versions
 from ayon_server.graphql.resolvers.workfiles import get_workfile, get_workfiles
 from ayon_server.graphql.utils import parse_attrib_data
+from ayon_server.helpers.tags import get_used_project_tags
 from ayon_server.lib.postgres import Postgres
 from ayon_server.utils import json_dumps
 
@@ -202,6 +203,10 @@ class ProjectNode:
             """
             )
         ]
+
+    @strawberry.field(description="List of tags used in the project")
+    async def used_tags(self) -> list[str]:
+        return await get_used_project_tags(self.project_name)
 
 
 def project_from_record(

--- a/ayon_server/helpers/tags.py
+++ b/ayon_server/helpers/tags.py
@@ -9,27 +9,22 @@ async def get_used_project_tags(project_name: str) -> list[str]:
     contain tags defined in the project anatomy.
     """
     result = []
-    async with Postgres.acquire() as conn, conn.transaction():
-        project_schema = f"project_{project_name}"
-        await conn.execute(f"SET LOCAL search_path TO '{project_schema}'")
-
-        query = """
-        SELECT DISTINCT tag FROM (
-            SELECT unnest(tags) AS tag FROM folders
-            UNION ALL
-            SELECT unnest(tags) FROM products
-            UNION ALL
-            SELECT unnest(tags) FROM tasks
-            UNION ALL
-            SELECT unnest(tags) FROM versions
-            UNION ALL
-            SELECT unnest(tags) FROM representations
-            UNION ALL
-            SELECT unnest(tags) FROM workfiles
-        ) t
-        """
-
-        async for record in conn.cursor(query):
-            result.append(record["tag"])
-
+    project_schema = f"project_{project_name.lower()}"
+    query = f"""
+    SELECT DISTINCT tag FROM (
+        SELECT unnest(tags) AS tag FROM {project_schema}.folders
+        UNION ALL
+        SELECT unnest(tags) FROM {project_schema}.products
+        UNION ALL
+        SELECT unnest(tags) FROM {project_schema}.tasks
+        UNION ALL
+        SELECT unnest(tags) FROM {project_schema}.versions
+        UNION ALL
+        SELECT unnest(tags) FROM {project_schema}.representations
+        UNION ALL
+        SELECT unnest(tags) FROM {project_schema}.workfiles
+    ) t
+    """
+    async for row in Postgres.iterate(query):
+        result.append(row["tag"])
     return result

--- a/ayon_server/helpers/tags.py
+++ b/ayon_server/helpers/tags.py
@@ -1,0 +1,35 @@
+from ayon_server.lib.postgres import Postgres
+
+
+async def get_used_project_tags(project_name: str) -> list[str]:
+    """Returns a list of tags that are used in the project.
+
+    This function is used to get all the tags that are used in the project.
+    The tags are collected from all the entities, but don't necessarily
+    contain tags defined in the project anatomy.
+    """
+    result = []
+    async with Postgres.acquire() as conn, conn.transaction():
+        project_schema = f"project_{project_name}"
+        await conn.execute(f"SET LOCAL search_path TO '{project_schema}'")
+
+        query = """
+        SELECT DISTINCT tag FROM (
+            SELECT unnest(tags) AS tag FROM folders
+            UNION ALL
+            SELECT unnest(tags) FROM products
+            UNION ALL
+            SELECT unnest(tags) FROM tasks
+            UNION ALL
+            SELECT unnest(tags) FROM versions
+            UNION ALL
+            SELECT unnest(tags) FROM representations
+            UNION ALL
+            SELECT unnest(tags) FROM workfiles
+        ) t
+        """
+
+        async for record in conn.cursor(query):
+            result.append(record["tag"])
+
+    return result


### PR DESCRIPTION
This pull request introduces a new helper function to the `ayon_server` project, specifically for retrieving project tags from various entities within a project. 

```python

from ayon_server.helpers.tags import get_used_project_tags

all_tags: list[str] = await get_used_project_tags("my-project")
```