### PR TITLE
Disallow guest users creating guest admins and guest services

### DIFF
--- a/api/users/users.py
+++ b/api/users/users.py
@@ -147,6 +147,9 @@ async def create_user(
     else:
         raise ConflictException("User already exists")
 
+    if nuser.is_guest and (nuser.is_service or nuser.is_admin):
+        raise BadRequestException("Guests cannot be service or admin users")
+
     if put_data.password:
         if nuser.is_service:
             raise BadRequestException("Service users cannot have passwords")


### PR DESCRIPTION
This pull request includes a crucial change to the `create_user` function in the `api/users/users.py` file. The change adds a validation check to ensure that guest users cannot be service or admin users.