### PR TITLE
Relabel `motd` customization "Message of the Day" to "Login Page Message"

### DIFF
--- a/api/system/info.py
+++ b/api/system/info.py
@@ -28,7 +28,7 @@ from .sites import SiteInfo
 class InfoResponseModel(OPModel):
     motd: str | None = Field(
         None,
-        title="Message of the day",
+        title="Login Page Message",
         description="Instance specific message to be displayed in the login page",
         example="Hello and welcome to Ayon!",
     )
@@ -286,8 +286,8 @@ async def get_site_info(
     This is the initial endpoint that is called when the user opens the page.
     It returns information about the site, the current user and the configuration.
 
-    If the user is not logged in, only the message of the day and the API version
-    are returned.
+    If the user is not logged in, only the login page message (motd) and the
+    API version are returned.
     """
 
     additional_info = {}

--- a/ayon_server/config/serverconfig.py
+++ b/ayon_server/config/serverconfig.py
@@ -19,10 +19,9 @@ class CustomizationModel(BaseSettingsModel):
 
     motd: str = SettingsField(
         "",
-        title="Message of the Day",
-        description="The message of the day that "
-        "is displayed to users on the login page. "
-        "Markdown syntax is supported.",
+        title="Login Page Message",
+        description="The message that is displayed to users on the login "
+        "page. Markdown syntax is supported.",
         example="Welcome to Ayon!",
         widget="textarea",
     )


### PR DESCRIPTION
## PR Checklist

Relabel `motd` customization "Message of the Day" to "Login Page Message".

## Description of changes

They now live in 2025 instead of the 70s.

### Technical details

The server still lives in the 70s, representing its love for `motd` because the internal key is maintained. 

### Additional context

Upon each login, bold display,
Behold—**Message of the Day!**

From Unix roots, a sysadmin’s lore,
Warnings, jokes, and stats galore.

Before the tweet or status feed,
The `motd` met every need.

But now they brand it, cold and vague,
As "Login Page Message"—what a plague!

A name so lifeless, bland, and grey,
They'll never take **MOTD** away!