### PR TITLE
Events: emit granular events when project is updated

### DIFF
--- a/api/projects/anatomy.py
+++ b/api/projects/anatomy.py
@@ -2,6 +2,7 @@ from ayon_server.api.dependencies import CurrentUser, ProjectName, Sender, Sende
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.entities import ProjectEntity
 from ayon_server.events import EventStream
+from ayon_server.events.patch import build_project_change_events
 from ayon_server.helpers.deploy_project import anatomy_to_project_data
 from ayon_server.helpers.extract_anatomy import extract_project_anatomy
 from ayon_server.settings.anatomy import Anatomy
@@ -34,17 +35,17 @@ async def set_project_anatomy(
 
     patch_data = anatomy_to_project_data(payload)
     patch = ProjectEntity.model.patch_model(**patch_data)
+    events = build_project_change_events(project, patch)
     project.patch(patch)
 
     await project.save()
 
-    await EventStream.dispatch(
-        "entity.project.changed",
-        sender=sender,
-        sender_type=sender_type,
-        project=project_name,
-        user=user.name,
-        description=f"Project {project_name} anatomy has been changed",
-    )
+    for event in events:
+        await EventStream.dispatch(
+            **event,
+            sender=sender,
+            sender_type=sender_type,
+            user=user.name,
+        )
 
     return EmptyResponse()

--- a/ayon_server/events/patch.py
+++ b/ayon_server/events/patch.py
@@ -20,6 +20,7 @@ ADDITIONAL_COLUMNS = {
     "product_type": "product_type_changed",
     "author": "author_changed",
     "files": "files_changed",
+    "config": "config_changed",  # for projects
     "parent_id": "parent_changed",  # for folders
     "folder_id": "folder_changed",  # for tasks and products
     "task_id": "task_changed",  # for workfiles and versions
@@ -240,6 +241,32 @@ def build_project_change_events(
             payload = {
                 "oldValue": oval,
                 "newValue": nval,
+            }
+            result[-1]["payload"] = payload
+
+    for column_name, topic_name in ADDITIONAL_COLUMNS.items():
+        if not hasattr(original_entity, column_name):
+            continue
+
+        if column_name not in patch_data:
+            continue
+
+        if getattr(original_entity, column_name) == patch_data.get(column_name):
+            continue
+
+        description = f"Changed project {column_name}"
+
+        result.append(
+            {
+                "topic": f"entity.project.{topic_name}",
+                "description": description,
+                **common_data,
+            }
+        )
+        if ayonconfig.audit_trail:
+            payload = {
+                "oldValue": getattr(original_entity, column_name),
+                "newValue": patch_data[column_name],
             }
             result[-1]["payload"] = payload
 

--- a/ayon_server/events/patch.py
+++ b/ayon_server/events/patch.py
@@ -48,13 +48,13 @@ def get_tags_description(entity_desc: str, list1: list[str], list2: list[str]) -
     description = ""
     if added:
         what = entity_desc + (" tag " if len(added) == 1 else " tags ")
-        description += f"Added {what}" + ", ".join(added) + ". "
+        description += f"Added {what}" + ", ".join(added)
     if removed:
         if added:
             what = ""
         else:
             what = entity_desc + (" tag " if len(removed) == 1 else " tags ")
-        description += f"Removed {what} " + ", ".join(removed) + ". "
+        description += f"Removed {what} " + ", ".join(removed)
 
     return description.strip()
 
@@ -187,6 +187,15 @@ def build_pl_entity_change_events(
             continue
 
         description = f"Changed {entity_type} {original_entity.name} {column_name}"
+        if column_name == "active":
+            if patch_data.get("active"):
+                description = (
+                    f"{entity_type.capitalize()} {original_entity.name} activated"
+                )
+            else:
+                description = (
+                    f"{entity_type.capitalize()} {original_entity.name} deactivated"
+                )
 
         result.append(
             {
@@ -255,6 +264,11 @@ def build_project_change_events(
             continue
 
         description = f"Changed project {column_name}"
+        if column_name == "active":
+            if patch_data.get("active"):
+                description = "Project activated"
+            else:
+                description = "Project deactivated"
 
         result.append(
             {


### PR DESCRIPTION
This pull request introduces a new function to build project change events and integrates it into the existing project update and anatomy setting functionalities. The main goal of these changes is to enhance the event dispatching mechanism when project data is modified.

The following new events are introduced. All of them support audit trail (`oldValue` and `newValue` stored in the event payload)

- [x] Emit `entity.project.attrib_changed` event when project attribute is changed using patch request or setting its anatomy
- [x] Emit `entity.project.config_changed`
- [x] Emit `entity.project.active_changed`
- [x] Emit `entity.project.data_changed`

The original `entity.project.changed` is still being emited to maintain the backwards compatibility (it does not contain the audit trail)