### PR TITLE
REST: Use ProjectLevelOperations in create-update-delete endpoints

### DIFF
--- a/api/versions/versions.py
+++ b/api/versions/versions.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter
 
 from ayon_server.api.dependencies import (
     CurrentUser,
@@ -14,7 +14,7 @@ from ayon_server.operations.project_level import ProjectLevelOperations
 router = APIRouter(tags=["Versions"])
 
 #
-# l [GET]
+# [GET]
 #
 
 
@@ -100,7 +100,6 @@ async def update_version(
 
 @router.delete("/projects/{project_name}/versions/{version_id}", status_code=204)
 async def delete_version(
-    background_tasks: BackgroundTasks,
     user: CurrentUser,
     project_name: ProjectName,
     version_id: VersionID,

--- a/api/versions/versions.py
+++ b/api/versions/versions.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from fastapi import APIRouter, BackgroundTasks
 
 from ayon_server.api.dependencies import (
@@ -11,14 +9,12 @@ from ayon_server.api.dependencies import (
 )
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
 from ayon_server.entities import VersionEntity
-from ayon_server.events import EventStream
-from ayon_server.events.patch import build_pl_entity_change_events
-from ayon_server.exceptions import ForbiddenException
+from ayon_server.operations.project_level import ProjectLevelOperations
 
 router = APIRouter(tags=["Versions"])
 
 #
-# [GET]
+# l [GET]
 #
 
 
@@ -45,7 +41,6 @@ async def get_version(
 @router.post("/projects/{project_name}/versions", status_code=201)
 async def create_version(
     post_data: VersionEntity.model.post_model,  # type: ignore
-    background_tasks: BackgroundTasks,
     user: CurrentUser,
     project_name: ProjectName,
     sender: Sender,
@@ -57,32 +52,17 @@ async def create_version(
     """
 
     payload = post_data.dict(exclude_unset=True)
-    if "author" not in payload:
-        payload["author"] = user.name
-
-    if not user.is_admin:
-        if payload["author"] != user.name:
-            raise ForbiddenException(
-                "You can only create versions for yourself, unless you are an admin."
-            )
-
-    version = VersionEntity(project_name=project_name, payload=payload)
-    await version.ensure_create_access(user)
-    event = {
-        "topic": "entity.version.created",
-        "description": f"Version {version.name} created",
-        "summary": {"entityId": version.id, "parentId": version.parent_id},
-        "project": project_name,
-    }
-    await version.save()
-    background_tasks.add_task(
-        EventStream.dispatch,
+    ops = ProjectLevelOperations(
+        project_name,
+        user=user,
         sender=sender,
         sender_type=sender_type,
-        user=user.name,
-        **event,  # type: ignore
     )
-    return EntityIdResponse(id=version.id)
+
+    ops.create("version", **payload)
+    res = await ops.process(can_fail=False, raise_on_error=True)
+    version_id = res.operations[0].entity_id
+    return EntityIdResponse(id=version_id)
 
 
 #
@@ -93,7 +73,6 @@ async def create_version(
 @router.patch("/projects/{project_name}/versions/{version_id}", status_code=204)
 async def update_version(
     post_data: VersionEntity.model.patch_model,  # type: ignore
-    background_tasks: BackgroundTasks,
     user: CurrentUser,
     project_name: ProjectName,
     version_id: VersionID,
@@ -102,19 +81,15 @@ async def update_version(
 ) -> EmptyResponse:
     """Patch (partially update) a version."""
 
-    version = await VersionEntity.load(project_name, version_id)
-    await version.ensure_update_access(user)
-    events = build_pl_entity_change_events(version, post_data)
-    version.patch(post_data)
-    await version.save()
-    for event in events:
-        background_tasks.add_task(
-            EventStream.dispatch,
-            sender=sender,
-            sender_type=sender_type,
-            user=user.name,
-            **event,
-        )
+    ops = ProjectLevelOperations(
+        project_name,
+        user=user,
+        sender=sender,
+        sender_type=sender_type,
+    )
+
+    ops.update("version", version_id, **post_data.dict(exclude_unset=True))
+    await ops.process(can_fail=False, raise_on_error=True)
     return EmptyResponse()
 
 
@@ -137,20 +112,12 @@ async def delete_version(
     This will also delete all representations of the version.
     """
 
-    version = await VersionEntity.load(project_name, version_id)
-    await version.ensure_delete_access(user)
-    event: dict[str, Any] = {
-        "topic": "entity.version.deleted",
-        "description": f"Version {version.name} deleted",
-        "summary": {"entityId": version.id, "parentId": version.parent_id},
-        "project": project_name,
-    }
-    await version.delete()
-    background_tasks.add_task(
-        EventStream.dispatch,
+    ops = ProjectLevelOperations(
+        project_name,
+        user=user,
         sender=sender,
         sender_type=sender_type,
-        user=user.name,
-        **event,
     )
+    ops.delete("version", version_id)
+    await ops.process(can_fail=False, raise_on_error=True)
     return EmptyResponse()

--- a/ayon_server/operations/common.py
+++ b/ayon_server/operations/common.py
@@ -1,3 +1,5 @@
+__all__ = ["RollbackException", "OperationType"]
+
 from typing import Literal
 
 

--- a/ayon_server/operations/project_level/entity_create.py
+++ b/ayon_server/operations/project_level/entity_create.py
@@ -1,0 +1,59 @@
+from typing import Any
+
+from ayon_server.entities import UserEntity
+from ayon_server.entities.core import ProjectLevelEntity
+from ayon_server.exceptions import ForbiddenException
+from ayon_server.lib.postgres import Connection
+
+from .models import OperationModel
+
+
+async def create_project_level_entity(
+    entity_class: type[ProjectLevelEntity],
+    project_name: str,
+    operation: OperationModel,
+    user: UserEntity | None,
+    transaction: Connection | None = None,
+) -> tuple[ProjectLevelEntity, list[dict[str, Any]], int]:
+    assert operation.data is not None, "data is required for create"
+
+    payload = entity_class.model.post_model(**operation.data)
+    payload_dict = payload.dict()
+    if operation.entity_id is not None:
+        payload_dict["id"] = operation.entity_id
+
+    #
+    # Sanity checks
+    #
+
+    if operation.entity_type == "version":
+        if user and not payload_dict.get("author"):
+            payload_dict["author"] = user.name
+        if user and not user.is_admin and payload_dict["author"] != user.name:
+            raise ForbiddenException("Only admins can create versions for other users")
+
+    elif operation.entity_type == "workfile":
+        if user and not payload_dict.get("created_by"):
+            payload_dict["created_by"] = user.name
+        if not payload_dict.get("updated_by"):
+            payload_dict["updated_by"] = payload_dict["created_by"]
+
+    #
+    # Create the entity and events
+    #
+
+    entity = entity_class(project_name, payload_dict)
+    if user:
+        await entity.ensure_create_access(user)
+    description = f"{operation.entity_type.capitalize()} {entity.name} created"
+    events = [
+        {
+            "topic": f"entity.{operation.entity_type}.created",
+            "summary": {"entityId": entity.id, "parentId": entity.parent_id},
+            "description": description,
+            "project": project_name,
+            "user": user.name if user else None,
+        }
+    ]
+    await entity.save(transaction=transaction)
+    return entity, events, 201

--- a/ayon_server/operations/project_level/entity_delete.py
+++ b/ayon_server/operations/project_level/entity_delete.py
@@ -1,0 +1,49 @@
+from typing import Any
+
+from ayon_server.config import ayonconfig
+from ayon_server.entities import UserEntity
+from ayon_server.entities.core import ProjectLevelEntity
+from ayon_server.exceptions import ForbiddenException
+from ayon_server.lib.postgres import Connection
+
+from .models import OperationModel
+
+
+async def delete_project_level_entity(
+    entity_class: type[ProjectLevelEntity],
+    project_name: str,
+    operation: OperationModel,
+    user: UserEntity | None,
+    transaction: Connection | None = None,
+) -> tuple[ProjectLevelEntity, list[dict[str, Any]], int]:
+    assert operation.entity_id is not None, "entity_id is required for delete"
+    entity = await entity_class.load(project_name, operation.entity_id)
+
+    #
+    # Sanity checks
+    #
+
+    if user:
+        await entity.ensure_delete_access(user)
+
+    if operation.force and user and not user.is_manager:
+        raise ForbiddenException("Only managers can force delete")
+
+    #
+    # Create events and delete the entity
+    #
+
+    description = f"{operation.entity_type.capitalize()} {entity.name} deleted"
+    events = [
+        {
+            "topic": f"entity.{operation.entity_type}.deleted",
+            "summary": {"entityId": entity.id, "parentId": entity.parent_id},
+            "description": description,
+            "project": project_name,
+            "user": user.name if user else None,
+        }
+    ]
+    if ayonconfig.audit_trail:
+        events[0]["payload"] = {"entityData": entity.dict_simple()}
+    await entity.delete(transaction=transaction, force=operation.force)
+    return entity, events, 204

--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -1,0 +1,66 @@
+from typing import Any, cast
+
+from ayon_server.entities import FolderEntity, UserEntity
+from ayon_server.entities.core import ProjectLevelEntity
+from ayon_server.events.patch import build_pl_entity_change_events
+from ayon_server.exceptions import ForbiddenException
+from ayon_server.lib.postgres import Connection
+
+from .models import OperationModel
+
+
+async def update_project_level_entity(
+    entity_class: type[ProjectLevelEntity],
+    project_name: str,
+    operation: OperationModel,
+    user: UserEntity | None,
+    transaction: Connection | None = None,
+) -> tuple[ProjectLevelEntity, list[dict[str, Any]], int]:
+    assert operation.data is not None, "data is required for update"
+    assert operation.entity_id is not None, "entity_id is required for update"
+
+    payload = entity_class.model.patch_model(**operation.data)
+    entity = await entity_class.load(
+        project_name,
+        operation.entity_id,
+        for_update=True,
+        transaction=transaction,
+    )
+
+    #
+    # Sanity checks
+    #
+
+    thumbnail_only = len(operation.data) == 1 and "thumbnailId" in operation.data
+
+    if user:
+        await entity.ensure_update_access(user, thumbnail_only=thumbnail_only)
+
+    if operation.entity_type == "folder":
+        folder_entity = cast(FolderEntity, entity)
+        has_versions = bool(await folder_entity.get_versions(transaction))
+        for key in ("name", "folder_type", "parent_id"):
+            if key not in operation.data:
+                continue
+            old_value = entity.payload.dict(exclude_none=True).get(key)
+            new_value = operation.data[key]
+            if has_versions and old_value != new_value:
+                raise ForbiddenException(
+                    f"Cannot change {key} of a folder with published versions"
+                )
+
+    if operation.entity_type == "workfile":
+        if not payload.updated_by:  # type: ignore
+            payload.updated_by = user.name  # type: ignore
+
+    #
+    # Create events and update the entity
+    #
+
+    events = build_pl_entity_change_events(entity, payload)
+    if user:
+        for event in events:
+            event["user"] = user.name
+    entity.patch(payload)
+    await entity.save(transaction=transaction)
+    return entity, events, 204

--- a/ayon_server/operations/project_level/models.py
+++ b/ayon_server/operations/project_level/models.py
@@ -1,0 +1,51 @@
+from typing import Annotated, Any
+
+from ayon_server.types import Field, OPModel, ProjectLevelEntityType
+from ayon_server.utils import create_uuid
+
+from ..common import OperationType
+
+
+class OperationModel(OPModel):
+    """Model for a single project-level operation.
+
+    Operation type is one of create, update, delete.
+
+    Each operation has a unique ID, that may be used to match the result
+    in the response. The ID is automatically generated if not provided.
+
+    The entity ID is required for update and delete operations, optional for create.
+    The data field is required for create and update operations, ignored for delete.
+
+    Force flag may be used for delete operations to force
+    recursive deletion of the children entities (if applicable).
+    """
+
+    id: Annotated[str, Field(default_factory=create_uuid, title="Operation ID")]
+    type: Annotated[OperationType, Field(title="Operation type")]
+    entity_type: Annotated[ProjectLevelEntityType, Field(title="Entity type")]
+    entity_id: Annotated[str | None, Field(title="Entity ID")] = None
+    data: Annotated[dict[str, Any] | None, Field(title="Data")] = None
+    force: Annotated[bool, Field(title="Force recursive deletion")] = False
+    as_user: str | None = None
+
+
+class OperationResponseModel(OPModel):
+    """Response model for a single operation.
+
+    Entity ID is `None` if the operation is a create and the operation fails.
+    Status returns HTTP-like status code (201, 204, 404, etc.)
+    """
+
+    id: Annotated[str, Field(title="Operation ID")]
+    type: Annotated[OperationType, Field(title="Operation type")]
+    entity_type: Annotated[ProjectLevelEntityType, Field(title="Entity type")]
+    entity_id: Annotated[str | None, Field(title="Entity ID")] = None
+    success: Annotated[bool, Field(title="Operation success")]
+    status: Annotated[int, Field(title="HTTP-like status code")]
+    detail: Annotated[str | None, Field(title="Error message")] = None
+
+
+class OperationsResponseModel(OPModel):
+    operations: Annotated[list[OperationResponseModel], Field(default_factory=list)]
+    success: Annotated[bool, Field(title="Overall success")]


### PR DESCRIPTION
This pull request refactors the folder, product, representation, and task management operations by replacing direct entity manipulation with the `ProjectLevelOperations` class. This change aims to centralize and simplify the codebase, ensuring consistency and reducing redundancy.

- [x] Use ProjectLevelOperations for create-update-delete REST endpoints
- [x] Refactor ProjectLevelOperations (de-spaghettify)