### PR TITLE
Inbox: Truncate message body

### DIFF
--- a/ayon_server/graphql/nodes/activity.py
+++ b/ayon_server/graphql/nodes/activity.py
@@ -205,6 +205,13 @@ def activity_from_record(
     else:
         parents = []
 
+    body = record.pop("body")
+    if context.get("inbox"):
+        body = body.replace("\n", " ")
+        if len(body) == 200:
+            # 200 characters is the inbox limit defined in the database
+            body += "..."
+
     reactions: list[ActivityReactionNode] = []
     if reactions_data := activity_data.get("reactions"):
         for reaction in reactions_data:
@@ -227,6 +234,7 @@ def activity_from_record(
         category=category,
         read=reference_data.pop("read", False),
         reactions=reactions,
+        body=body,
         **record,
     )
     # probably won't be used

--- a/ayon_server/graphql/resolvers/inbox.py
+++ b/ayon_server/graphql/resolvers/inbox.py
@@ -86,6 +86,7 @@ async def get_inbox(
     #
 
     # start_time = time.monotonic()
+    info.context["inbox"] = True
     res = await resolve(
         ActivitiesConnection,
         ActivityEdge,

--- a/schemas/schema.public.sql
+++ b/schemas/schema.public.sql
@@ -317,9 +317,9 @@ BEGIN
                 t.creation_order as creation_order,
 
                 t.activity_type as activity_type,
-                t.body as body,
+                substring(t.body from 1 for 200) as body,
                 t.tags as tags,
-      
+
                 t.activity_data as activity_data,
                 t.reference_data as reference_data,
                 t.active as active


### PR DESCRIPTION
This PR should reduces the amount of data pulled from the database while resolving user's inbox

- Updated the `get_inbox` resolver to set a context flag indicating that the inbox is being accessed.
- Changed the SQL schema to enforce a 200-character limit on the `body` field in get_user_inbox