### PR TITLE
GraphQL: New pagination, filtering and sorting by inherited attributes and allAttrib field

### DIFF
--- a/api/tasks_folders/tasks_folders.py
+++ b/api/tasks_folders/tasks_folders.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 
 from ayon_server.access.utils import folder_access_list
 from ayon_server.api.dependencies import CurrentUser, ProjectName
+from ayon_server.exceptions import BadRequestException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import Field, OPModel
@@ -56,6 +57,9 @@ async def query_tasks_folders(
         column_whitelist=ALLOWED_KEYS,
         column_map={"attrib": "(coalesce(f.attrib, '{}'::jsonb ) || tasks.attrib)"},
     )
+
+    if not filter:
+        raise BadRequestException("No filter provided")
 
     query = f"""
         SELECT DISTINCT tasks.folder_id

--- a/api/tasks_folders/tasks_folders.py
+++ b/api/tasks_folders/tasks_folders.py
@@ -52,15 +52,15 @@ async def query_tasks_folders(
 
     filter = build_filter(
         request.filter,
+        table_prefix="tasks",
         column_whitelist=ALLOWED_KEYS,
-        column_prefix="tasks",
         column_map={"attrib": "(coalesce(f.attrib, '{}'::jsonb ) || tasks.attrib)"},
     )
 
     query = f"""
-        SELECT DISTINCT folder_id
+        SELECT DISTINCT tasks.folder_id
         FROM project_{project_name}.tasks tasks
-        INNER JOIN project_{project_name}.exported attributes AS f
+        INNER JOIN project_{project_name}.exported_attributes AS f
         ON tasks.folder_id = f.folder_id
         WHERE {filter}
     """

--- a/ayon_server/graphql/__init__.py
+++ b/ayon_server/graphql/__init__.py
@@ -45,6 +45,7 @@ from ayon_server.graphql.resolvers.users import get_user, get_users
 from ayon_server.graphql.types import Info
 from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import logger
+from ayon_server.utils import json_dumps
 
 
 async def graphql_get_context(user: CurrentUser) -> dict[str, Any]:
@@ -128,6 +129,7 @@ class Query:
             updated_at=user.updated_at,
             created_at=user.created_at,
             attrib=UserAttribType(**user.attrib.dict()),
+            all_attrib=json_dumps(user.attrib.dict()),
             access_groups=user.data.get("accessGroups", {}),
             is_admin=user.is_admin,
             is_manager=user.is_manager,

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -36,6 +36,7 @@ class FolderNode(BaseNode):
     tags: list[str]
     attrib: FolderAttribType
     own_attrib: list[str]
+    all_attrib: str
     data: str | None
 
     # GraphQL specifics
@@ -121,6 +122,15 @@ def folder_from_record(
             relation=thumb_data.get("relation"),
         )
 
+    attrib = parse_attrib_data(
+        FolderAttribType,
+        record["attrib"],
+        user=context["user"],
+        project_name=project_name,
+        project_attrib=record["project_attributes"],
+        inherited_attrib=record["inherited_attributes"],
+    )
+
     return FolderNode(
         project_name=project_name,
         id=record["id"],
@@ -133,14 +143,7 @@ def folder_from_record(
         thumbnail=thumbnail,
         status=record["status"],
         tags=record["tags"],
-        attrib=parse_attrib_data(
-            FolderAttribType,
-            record["attrib"],
-            user=context["user"],
-            project_name=project_name,
-            project_attrib=record["project_attributes"],
-            inherited_attrib=record["inherited_attributes"],
-        ),
+        attrib=FolderAttribType(**attrib),
         data=json_dumps(data) if data else None,
         created_at=record["created_at"],
         updated_at=record["updated_at"],
@@ -150,6 +153,7 @@ def folder_from_record(
         has_reviewables=has_reviewables,
         path="/" + record.get("path", "").strip("/"),
         own_attrib=own_attrib,
+        all_attrib=json_dumps(attrib),
     )
 
 

--- a/ayon_server/graphql/nodes/product.py
+++ b/ayon_server/graphql/nodes/product.py
@@ -47,6 +47,7 @@ class ProductNode(BaseNode):
     status: str
     tags: list[str]
     attrib: ProductAttribType
+    all_attrib: str
     data: str | None
 
     # GraphQL specifics
@@ -122,6 +123,12 @@ def product_from_record(
             vlist.append(VersionListItem(id=id, version=vers))
 
     data = record.get("data", {})
+    attrib = parse_attrib_data(
+        ProductAttribType,
+        record["attrib"],
+        user=context["user"],
+        project_name=project_name,
+    )
 
     return ProductNode(
         project_name=project_name,
@@ -131,17 +138,13 @@ def product_from_record(
         product_type=record["product_type"],
         status=record["status"],
         tags=record["tags"],
-        attrib=parse_attrib_data(
-            ProductAttribType,
-            record["attrib"],
-            user=context["user"],
-            project_name=project_name,
-        ),
+        attrib=ProductAttribType(**attrib),
         data=json_dumps(data) if data else None,
         active=record["active"],
         created_at=record["created_at"],
         updated_at=record["updated_at"],
         version_list=vlist,
+        all_attrib=json_dumps(attrib),
         _folder=folder,
     )
 

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -78,6 +78,7 @@ class ProjectNode:
     project_name: str = strawberry.field()
     code: str = strawberry.field()
     attrib: ProjectAttribType
+    all_attrib: str
     data: str | None
     active: bool
     library: bool
@@ -217,18 +218,21 @@ def project_from_record(
     thumbnail = None
 
     data = record.get("data", {})
+    attrib = parse_attrib_data(
+        ProjectAttribType,
+        record["attrib"],
+        user=context["user"],
+        project_name=record["name"],
+    )
+
     return ProjectNode(
         name=record["name"],
         code=record["code"],
         project_name=record["name"],
         active=record["active"],
         library=record["library"],
-        attrib=parse_attrib_data(
-            ProjectAttribType,
-            record["attrib"],
-            user=context["user"],
-            project_name=record["name"],
-        ),
+        attrib=ProjectAttribType(**attrib),
+        all_attrib=json_dumps(attrib),
         thumbnail=thumbnail,
         data=json_dumps(data) if data else None,
         created_at=record["created_at"],

--- a/ayon_server/graphql/nodes/representation.py
+++ b/ayon_server/graphql/nodes/representation.py
@@ -37,6 +37,7 @@ class RepresentationNode(BaseNode):
     status: str
     tags: list[str]
     attrib: RepresentationAttribType
+    all_attrib: str
     data: str | None
 
     # GraphQL specifics
@@ -85,6 +86,12 @@ def representation_from_record(
     """Construct a representation node from a DB row."""
 
     data = record.get("data") or {}
+    attrib = parse_attrib_data(
+        RepresentationAttribType,
+        record["attrib"],
+        user=context["user"],
+        project_name=project_name,
+    )
 
     return RepresentationNode(
         project_name=project_name,
@@ -93,12 +100,8 @@ def representation_from_record(
         version_id=record["version_id"],
         status=record["status"],
         tags=record["tags"],
-        attrib=parse_attrib_data(
-            RepresentationAttribType,
-            record["attrib"],
-            user=context["user"],
-            project_name=project_name,
-        ),
+        attrib=RepresentationAttribType(**attrib),
+        all_attrib=json_dumps(attrib),
         data=json_dumps(data) if data else None,
         active=record["active"],
         created_at=record["created_at"],

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -40,6 +40,7 @@ class TaskNode(BaseNode):
     attrib: TaskAttribType
     data: str | None
     own_attrib: list[str]
+    all_attrib: str
 
     # GraphQL specifics
 
@@ -120,6 +121,14 @@ def task_from_record(
             relation=thumb_data.get("relation"),
         )
 
+    attrib = parse_attrib_data(
+        TaskAttribType,
+        record["attrib"],
+        user=context["user"],
+        project_name=project_name,
+        inherited_attrib=record["parent_folder_attrib"],
+    )
+
     return TaskNode(
         project_name=project_name,
         id=record["id"],
@@ -133,18 +142,13 @@ def task_from_record(
         status=record["status"],
         has_reviewables=has_reviewables,
         tags=record["tags"],
-        attrib=parse_attrib_data(
-            TaskAttribType,
-            record["attrib"],
-            user=context["user"],
-            project_name=project_name,
-            inherited_attrib=record["parent_folder_attrib"],
-        ),
+        attrib=TaskAttribType(**attrib),
         data=json_dumps(data) if data else None,
         active=record["active"],
         created_at=record["created_at"],
         updated_at=record["updated_at"],
         own_attrib=own_attrib,
+        all_attrib=json_dumps(attrib),
         _folder=folder,
     )
 

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -27,7 +27,7 @@ class TaskAttribType:
 
 @strawberry.type
 class TaskNode(BaseNode):
-    name: str
+    # name: str (inherited from BaseNode)
     label: str | None
     task_type: str
     thumbnail_id: str | None = None

--- a/ayon_server/graphql/nodes/user.py
+++ b/ayon_server/graphql/nodes/user.py
@@ -35,6 +35,7 @@ class UserNode:
     created_at: datetime
     updated_at: datetime
     attrib: UserAttribType
+    all_attrib: str
     access_groups: str
     default_access_groups: list[str]
     is_admin: bool
@@ -75,16 +76,17 @@ def user_from_record(
         and current_user.name != data.get("createdBy")
     ):
         name = get_nickname(name)
-        if attrib.email:
-            attrib.email = obscure(attrib.email)
-        if attrib.fullName:
-            attrib.fullName = name
-        attrib.avatarUrl = None
+        if email := attrib.get("email"):
+            attrib["email"] = obscure(email)
+        if attrib.get("fullName"):
+            attrib["fullName"] = name
+        attrib["avatarUrl"] = None
 
     return UserNode(
         name=name,
         active=record["active"],
-        attrib=attrib,
+        attrib=UserAttribType(**attrib),
+        all_attrib=json_dumps(attrib),
         created_at=record["created_at"],
         updated_at=record["updated_at"],
         access_groups=json_dumps(access_groups),

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -31,6 +31,7 @@ class VersionNode(BaseNode):
     product_id: str
     status: str
     attrib: VersionAttribType
+    all_attrib: str
     tags: list[str]
     task_id: str | None = None
     thumbnail_id: str | None = None
@@ -102,6 +103,13 @@ def version_from_record(
             relation=thumb_data.get("relation"),
         )
 
+    attrib = parse_attrib_data(
+        VersionAttribType,
+        record["attrib"],
+        user=context["user"],
+        project_name=project_name,
+    )
+
     return VersionNode(
         project_name=project_name,
         id=record["id"],
@@ -116,12 +124,8 @@ def version_from_record(
         author=author,
         status=record["status"],
         tags=record["tags"],
-        attrib=parse_attrib_data(
-            VersionAttribType,
-            record["attrib"],
-            user=context["user"],
-            project_name=project_name,
-        ),
+        attrib=VersionAttribType(**attrib),
+        all_attrib=json_dumps(attrib),
         data=json_dumps(data) if data else None,
         created_at=record["created_at"],
         updated_at=record["updated_at"],

--- a/ayon_server/graphql/nodes/workfile.py
+++ b/ayon_server/graphql/nodes/workfile.py
@@ -31,6 +31,7 @@ class WorkfileNode(BaseNode):
     updated_by: str | None
     status: str
     attrib: WorkfileAttribType
+    all_attrib: str
     data: str | None
     tags: list[str]
 
@@ -64,6 +65,12 @@ def workfile_from_record(
             source_entity_id=thumb_data.get("sourceEntityId"),
             relation=thumb_data.get("relation"),
         )
+    attrib = parse_attrib_data(
+        WorkfileAttribType,
+        record["attrib"],
+        user=context["user"],
+        project_name=project_name,
+    )
 
     return WorkfileNode(
         project_name=project_name,
@@ -78,12 +85,8 @@ def workfile_from_record(
         active=record["active"],
         status=record["status"],
         tags=record["tags"],
-        attrib=parse_attrib_data(
-            WorkfileAttribType,
-            record["attrib"],
-            user=context["user"],
-            project_name=project_name,
-        ),
+        attrib=WorkfileAttribType(**attrib),
+        all_attrib=json_dumps(attrib),
         data=json_dumps(data) if data else None,
         created_at=record["created_at"],
         updated_at=record["updated_at"],

--- a/ayon_server/graphql/resolvers/activities.py
+++ b/ayon_server/graphql/resolvers/activities.py
@@ -8,7 +8,6 @@ from ayon_server.graphql.resolvers.common import (
     ARGBefore,
     ARGFirst,
     ARGLast,
-    FieldInfo,
     create_pagination,
     resolve,
 )
@@ -131,20 +130,12 @@ async def get_activities(
     #
 
     order_by = ["created_at", "creation_order"]
-    paging_fields = FieldInfo(info, ["activities"])
-    need_cursor = paging_fields.has_any(
-        "activities.pageInfo.startCursor",
-        "activities.pageInfo.endCursor",
-        "activities.edges.cursor",
-    )
-
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by,
         first,
         after,
         last,
         before,
-        need_cursor=need_cursor,
     )
     sql_conditions.append(paging_conds)
 
@@ -156,14 +147,8 @@ async def get_activities(
         SELECT {cursor}, *
         FROM project_{project_name}.activity_feed
         {SQLTool.conditions(sql_conditions)}
-        {pagination}
+        {ordering}
     """
-
-    # print(query)
-
-    #
-    # Execute the query
-    #
 
     return await resolve(
         ActivitiesConnection,

--- a/ayon_server/graphql/resolvers/activities.py
+++ b/ayon_server/graphql/resolvers/activities.py
@@ -146,7 +146,7 @@ async def get_activities(
         before,
         need_cursor=need_cursor,
     )
-    sql_conditions.extend(paging_conds)
+    sql_conditions.append(paging_conds)
 
     #
     # Build the query
@@ -169,9 +169,10 @@ async def get_activities(
         ActivitiesConnection,
         ActivityEdge,
         ActivityNode,
-        project_name,
         query,
-        first,
-        last,
+        project_name=project_name,
+        first=first,
+        last=last,
         context=info.context,
+        order_by=order_by,
     )

--- a/ayon_server/graphql/resolvers/activities.py
+++ b/ayon_server/graphql/resolvers/activities.py
@@ -8,9 +8,9 @@ from ayon_server.graphql.resolvers.common import (
     ARGBefore,
     ARGFirst,
     ARGLast,
-    create_pagination,
     resolve,
 )
+from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.types import validate_name_list
 from ayon_server.utils import SQLTool

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -153,7 +153,6 @@ def create_pagination(
     after: str | None = None,
     last: int | None = None,
     before: str | None = None,
-    **kwargs,
 ) -> tuple[str, str, str]:
     """
     Generates a pagination SQL query for a GraphQL resolver.

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -118,57 +118,12 @@ async def create_folder_access_list(root, info) -> list[str] | None:
     return await folder_access_list(user, project_name)
 
 
-# def create_pagination2(
-#     order_by: list[str],
-#     first: int | None = None,
-#     after: str | None = None,
-#     last: int | None = None,
-#     before: str | None = None,
-#     need_cursor: bool = True,
-# ) -> tuple[str, list[str], str]:
-#     """
-#     Create pagination query and arguments.
-#     returns a tuple of
-#       - pagination query (ORDER BY... part of the query)
-#       - additional conditions (WHERE... part of the query)
-#       - cursor (to add to SELECT... part of the query)
-#     """
-#     pagination = ""
-#     sql_conditions = []
-
-#     assert order_by, "Order by must not be empty"
-
-#     cursor: str  # put to SELECT clause (should be 'SOMETHING as cursor')
-
-#     if len(order_by) == 1 or not need_cursor:
-#         cursor = f"{order_by[0]}"
-#     else:
-#         ccols = [f"{col}::text" for col in order_by]
-#         cursor = f"({'||'.join(ccols)})"
-
-#     if not (last or first):
-#         first = 100
-
-#     curval: str = "0"  # just to keep pyright happy
-
-#     if after:
-#         curval = after
-
-#     elif before:
-#         curval = before
-
-#     if first:
-#         pagination += f"ORDER BY cursor ASC LIMIT {first}"
-#         if after:
-#             sql_conditions.append(f"{cursor} > '{curval}'")
-#     elif last:
-#         pagination += f"ORDER BY cursor DESC LIMIT {last}"
-#         if before:
-#             sql_conditions.append(f"{cursor} < '{curval}'")
-#     return pagination, sql_conditions, f"{cursor} AS cursor"
+#
+# Pagination and sorting
+#
 
 
-def _decode_cursor(cursor: str | None) -> list:
+def _decode_cursor(cursor: str | None) -> list[Any]:
     if not cursor:
         return []
     try:
@@ -178,7 +133,11 @@ def _decode_cursor(cursor: str | None) -> list:
         return []
 
 
-def _get_casts(decoded_cursor: list) -> list[str]:
+def _encode_cursor(decoded_cursor: list[Any]) -> str:
+    return b64encode(json_dumps(decoded_cursor).encode()).decode()
+
+
+def _get_casts(decoded_cursor: list[Any]) -> list[str]:
     casts = []
     for dval in decoded_cursor:
         if isinstance(dval, str):
@@ -194,51 +153,69 @@ def create_pagination(
     after: str | None = None,
     last: int | None = None,
     before: str | None = None,
-    need_cursor: bool = True,
-) -> tuple[str, list[str], str]:
-    cursor_arr = []
-    pagination_arr = []
+    **kwargs,
+) -> tuple[str, str, str]:
+    """
+    Generates a pagination SQL query for a GraphQL resolver.
 
-    logger.debug(f"Pagination from {order_by}")
+    Accepts a list of columns to sort by and GraphQL pagination
+    parameters (`after`, `before`, `first`, `last`).
+
+    Returns a tuple of three strings: `ordering`, `conditions`, and `cursor`.
+
+    - `ordering`: The "ORDER BY" clause of the query,
+        including the `ORDER BY` statement itself.
+    - `conditions`: Conditions for the `WHERE` clause,
+        meant to be combined with other conditions using `AND`.
+    - `cursor`: A set of virtual columns in the `SELECT` section,
+        which the resolver uses to construct the actual cursor.
+    """
 
     if len(order_by) > 2:
         raise ValueError("Order by can have only two fields")
 
+    cursor_arr = []
+    ordering_arr = []
     decoded_cursor = _decode_cursor(before or after)
     casts = _get_casts(decoded_cursor)
     operator = "<" if before else ">"
 
     for i, c in enumerate(order_by):
         cursor_arr.append(f"{c} AS cursor_{i}")
-        pagination_arr.append(f"{c} {'DESC' if last else ''}")
+        ordering_arr.append(f"{c} {'DESC' if last else ''}")
+
+    # Okay. I know this looks like something a 5YO would write, but hear me out.
+    # We don't need to support more than two cursors. Hopefully.
+    # So trust me, even if this is a mess, it is still MUCH more readable than
+    # doing it a loop for every cursor element. We just cover two cases,
+    # (or three if you're counting 'no cursor').
 
     if len(decoded_cursor) == 1:
         conditions = f"""
-        -- paging conditions
-        (
-            {order_by[0]}{casts[0]} {operator} {decoded_cursor[0]}{casts[0]}
-        )
+        ({order_by[0]}){casts[0]} {operator} {decoded_cursor[0]}{casts[0]}
         """
     elif len(decoded_cursor) == 2:
         conditions = f"""
-        -- paging conditions
-        (
-            {order_by[0]}{casts[0]} {operator} {decoded_cursor[0]}{casts[0]}
-        OR (
-
-            {order_by[0]}{casts[0]} = {decoded_cursor[0]}{casts[0]}
-            AND
-            {order_by[1]}{casts[1]} {operator} {decoded_cursor[1]}{casts[1]}
-        )
-        """
+(
+    ({order_by[0]}){casts[0]} {operator} {decoded_cursor[0]}{casts[0]}
+    OR (
+        ({order_by[0]}){casts[0]} = {decoded_cursor[0]}{casts[0]}
+        AND
+        ({order_by[1]}){casts[1]} {operator} {decoded_cursor[1]}{casts[1]}
+    )
+)
+"""
     else:
         conditions = ""
 
-    pagination = "ORDER BY " + ", ".join(pagination_arr)
+    ordering = "ORDER BY " + ", ".join(ordering_arr)
     cursor = ", ".join(cursor_arr)
+    return ordering, conditions, cursor
 
-    return pagination, [conditions] if conditions else [], cursor
 
+#
+# Actual resolver
+#
 
 R = TypeVar("R")
 
@@ -247,8 +224,9 @@ async def resolve(
     connection_type: Callable[..., R],
     edge_type,
     node_type,
-    project_name: str | None,
     query: str,
+    *,
+    project_name: str | None = None,
     first: int | None = None,
     last: int | None = None,
     context: dict[str, Any] | None = None,
@@ -265,19 +243,22 @@ async def resolve(
 
     edges: list[Any] = []
     async for record in Postgres.iterate(query):
+        # Create a standard dictionary from the record
+        record_dict = dict(record)
+
+        # Create cursor:
+        # We need to do that first, because we need to get rid of
+        # the cursor data from the record
+        cdata = []
+        for i, c in enumerate(order_by or []):
+            cdata.append(record_dict.pop(f"cursor_{i}"))
+        cursor = _encode_cursor(cdata)
+
         try:
-            node = node_type.from_record(project_name, record, context=context)
+            node = node_type.from_record(project_name, record_dict, context=context)
         except ForbiddenException:
             continue
 
-        cdata = []
-        for i, c in enumerate(order_by or []):
-            cdata.append(record[f"cursor_{i}"])
-        if cdata:
-            logger.debug(f"Cursor data: {cdata}")
-        cursor = b64encode(json_dumps(cdata).encode()).decode()
-
-        # cursor = record["cursor"]
         edges.append(edge_type(node=node, cursor=cursor))
         if count and count == len(edges):
             break

--- a/ayon_server/graphql/resolvers/events.py
+++ b/ayon_server/graphql/resolvers/events.py
@@ -11,7 +11,6 @@ from ayon_server.graphql.resolvers.common import (
     ARGFirst,
     ARGIds,
     ARGLast,
-    FieldInfo,
     argdesc,
     create_pagination,
     resolve,
@@ -114,21 +113,13 @@ async def get_events(
         if lconds:
             sql_conditions.extend(lconds)
 
-    paging_fields = FieldInfo(info, ["events"])
-    need_cursor = paging_fields.has_any(
-        "events.pageInfo.startCursor",
-        "events.pageInfo.endCursor",
-        "events.edges.cursor",
-    )
-
     order_by = ["creation_order"]
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by,
         first,
         after,
         last,
         before,
-        need_cursor=need_cursor,
     )
     sql_conditions.append(paging_conds)
 
@@ -141,7 +132,7 @@ async def get_events(
     query = f"""
         SELECT {cursor}, * FROM events
         {SQLTool.conditions(sql_conditions)}
-        {pagination}
+        {ordering}
     """
 
     return await resolve(

--- a/ayon_server/graphql/resolvers/events.py
+++ b/ayon_server/graphql/resolvers/events.py
@@ -12,9 +12,9 @@ from ayon_server.graphql.resolvers.common import (
     ARGIds,
     ARGLast,
     argdesc,
-    create_pagination,
     resolve,
 )
+from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.types import (
     validate_name_list,

--- a/ayon_server/graphql/resolvers/events.py
+++ b/ayon_server/graphql/resolvers/events.py
@@ -130,7 +130,7 @@ async def get_events(
         before,
         need_cursor=need_cursor,
     )
-    sql_conditions.extend(paging_conds)
+    sql_conditions.append(paging_conds)
 
     if (event_history := await Constraints.check("eventHistory")) is not None:
         event_history = event_history or 7
@@ -148,9 +148,9 @@ async def get_events(
         EventsConnection,
         EventEdge,
         EventNode,
-        None,
         query,
-        first,
-        last,
+        first=first,
+        last=last,
         context=info.context,
+        order_by=order_by,
     )

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -336,9 +336,9 @@ async def get_folders(
 
     paging_fields = FieldInfo(info, ["folders"])
     need_cursor = paging_fields.has_any(
-        "folders.pageInfo.startCursor",
-        "folders.pageInfo.endCursor",
-        "folders.edges.cursor",
+        "pageInfo.startCursor",
+        "pageInfo.endCursor",
+        "edges.cursor",
     )
 
     pagination, paging_conds, cursor = create_pagination(

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -16,11 +16,11 @@ from ayon_server.graphql.resolvers.common import (
     FieldInfo,
     argdesc,
     create_folder_access_list,
-    create_pagination,
     get_has_links_conds,
     resolve,
     sortdesc,
 )
+from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.types import (
     validate_name,

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -334,20 +334,12 @@ async def get_folders(
         else:
             raise ValueError(f"Invalid sort_by value: {sort_by}")
 
-    paging_fields = FieldInfo(info, ["folders"])
-    need_cursor = paging_fields.has_any(
-        "pageInfo.startCursor",
-        "pageInfo.endCursor",
-        "edges.cursor",
-    )
-
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by,
         first,
         after,
         last,
         before,
-        need_cursor=need_cursor,
     )
     sql_conditions.append(paging_conds)
 
@@ -369,7 +361,7 @@ async def get_folders(
         {SQLTool.conditions(sql_conditions)}
         GROUP BY {",".join(sql_group_by)}
         {SQLTool.conditions(sql_having).replace("WHERE", "HAVING", 1)}
-        {pagination}
+        {ordering}
     """
 
     return await resolve(

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -349,7 +349,7 @@ async def get_folders(
         before,
         need_cursor=need_cursor,
     )
-    sql_conditions.extend(paging_conds)
+    sql_conditions.append(paging_conds)
 
     #
     # Query
@@ -376,10 +376,11 @@ async def get_folders(
         FoldersConnection,
         FolderEdge,
         FolderNode,
-        project_name,
         query,
-        first,
-        last,
+        project_name=project_name,
+        first=first,
+        last=last,
+        order_by=order_by,
         context=info.context,
     )
 

--- a/ayon_server/graphql/resolvers/inbox.py
+++ b/ayon_server/graphql/resolvers/inbox.py
@@ -90,10 +90,8 @@ async def get_inbox(
         ActivitiesConnection,
         ActivityEdge,
         ActivityNode,
-        None,
         query,
-        None,
-        last,
+        last=last,
         context=info.context,
     )
     # end_time = time.monotonic()

--- a/ayon_server/graphql/resolvers/kanban.py
+++ b/ayon_server/graphql/resolvers/kanban.py
@@ -176,10 +176,8 @@ async def get_kanban(
         KanbanConnection,
         KanbanEdge,
         KanbanNode,
-        None,
         query,
-        None,
-        last,
+        last=last,
         context=info.context,
     )
     return res

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -1,0 +1,114 @@
+from base64 import b64decode, b64encode
+from typing import Any
+
+from ayon_server.entities.core.attrib import attribute_library
+from ayon_server.exceptions import BadRequestException
+from ayon_server.logging import logger
+from ayon_server.utils import json_dumps, json_loads
+
+
+async def get_attrib_sort_case(attr: str, exp: str) -> str:
+    try:
+        attr_data = attribute_library.by_name(attr)
+    except KeyError:
+        raise BadRequestException(f"Invalid attribute {attr}")
+    enum = attr_data.get("enum", [])
+    if not enum:
+        return f"{exp}->'{attr}'"
+    case = "CASE"
+    i = 0
+    for i, eval in enumerate(enum):
+        e = eval["value"]
+        case += f" WHEN {exp}->>'{attr}' = '{e}' THEN {i}"
+    case += f" ELSE {i+1}"
+    case += " END"
+    return case
+
+
+def decode_cursor(cursor: str | None) -> list[Any]:
+    if not cursor:
+        return []
+    try:
+        return json_loads(b64decode(cursor).decode())
+    except Exception as e:
+        logger.debug(f"Invalid cursor {e}")
+        return []
+
+
+def encode_cursor(decoded_cursor: list[Any]) -> str:
+    return b64encode(json_dumps(decoded_cursor).encode()).decode()
+
+
+def get_casts(decoded_cursor: list[Any]) -> list[str]:
+    casts = []
+    for dval in decoded_cursor:
+        if isinstance(dval, str):
+            casts.append("::text")
+        else:
+            casts.append("::numeric")
+    return casts
+
+
+def create_pagination(
+    order_by: list[str],
+    first: int | None = None,
+    after: str | None = None,
+    last: int | None = None,
+    before: str | None = None,
+) -> tuple[str, str, str]:
+    """
+    Generates a pagination SQL query for a GraphQL resolver.
+
+    Accepts a list of columns to sort by and GraphQL pagination
+    parameters (`after`, `before`, `first`, `last`).
+
+    Returns a tuple of three strings: `ordering`, `conditions`, and `cursor`.
+
+    - `ordering`: The "ORDER BY" clause of the query,
+        including the `ORDER BY` statement itself.
+    - `conditions`: Conditions for the `WHERE` clause,
+        meant to be combined with other conditions using `AND`.
+    - `cursor`: A set of virtual columns in the `SELECT` section,
+        which the resolver uses to construct the actual cursor.
+    """
+
+    if len(order_by) > 2:
+        raise ValueError("Order by can have only two fields")
+
+    cursor_arr = []
+    ordering_arr = []
+    decoded_cursor = decode_cursor(before or after)
+    casts = get_casts(decoded_cursor)
+    operator = "<" if before else ">"
+
+    for i, c in enumerate(order_by):
+        cursor_arr.append(f"{c} AS cursor_{i}")
+        ordering_arr.append(f"{c} {'DESC' if last else ''}")
+
+    # Okay. I know this looks like something a 5YO would write, but hear me out.
+    # We don't need to support more than two cursors. Hopefully.
+    # So trust me, even if this is a mess, it is still MUCH more readable than
+    # doing it a loop for every cursor element. We just cover two cases,
+    # (or three if you're counting 'no cursor').
+
+    if len(decoded_cursor) == 1:
+        conditions = f"""
+        ({order_by[0]}){casts[0]} {operator} {decoded_cursor[0]}{casts[0]}
+        """
+    elif len(decoded_cursor) == 2:
+        conditions = f"""
+(
+    ({order_by[0]}){casts[0]} {operator} {decoded_cursor[0]}{casts[0]}
+    OR (
+        ({order_by[0]}){casts[0]} = {decoded_cursor[0]}{casts[0]}
+        AND
+        ({order_by[1]}){casts[1]} {operator} {decoded_cursor[1]}{casts[1]}
+    )
+)
+"""
+    else:
+        conditions = ""
+
+    ordering = "ORDER BY " + ", ".join(ordering_arr)
+    cursor = ", ".join(cursor_arr)
+    return ordering, conditions, cursor

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -254,20 +254,12 @@ async def get_products(
         else:
             raise ValueError(f"Invalid sort_by value: {sort_by}")
 
-    paging_fields = FieldInfo(info, ["products"])
-    need_cursor = paging_fields.has_any(
-        "products.pageInfo.startCursor",
-        "products.pageInfo.endCursor",
-        "products.edges.cursor",
-    )
-
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by,
         first,
         after,
         last,
         before,
-        need_cursor=need_cursor,
     )
     sql_conditions.append(paging_conds)
 
@@ -280,7 +272,7 @@ async def get_products(
         FROM project_{project_name}.products
         {" ".join(sql_joins)}
         {SQLTool.conditions(sql_conditions)}
-        {pagination}
+        {ordering}
     """
 
     return await resolve(

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -269,7 +269,7 @@ async def get_products(
         before,
         need_cursor=need_cursor,
     )
-    sql_conditions.extend(paging_conds)
+    sql_conditions.append(paging_conds)
 
     #
     # Query
@@ -287,10 +287,11 @@ async def get_products(
         ProductsConnection,
         ProductEdge,
         ProductNode,
-        project_name,
         query,
-        first,
-        last,
+        project_name=project_name,
+        first=first,
+        last=last,
+        order_by=order_by,
         context=info.context,
     )
 

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -14,11 +14,11 @@ from ayon_server.graphql.resolvers.common import (
     ARGLast,
     FieldInfo,
     argdesc,
-    create_pagination,
     get_has_links_conds,
     resolve,
     sortdesc,
 )
+from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.types import validate_name_list, validate_status_list
 from ayon_server.utils import SQLTool

--- a/ayon_server/graphql/resolvers/projects.py
+++ b/ayon_server/graphql/resolvers/projects.py
@@ -11,9 +11,9 @@ from ayon_server.graphql.resolvers.common import (
     ARGLast,
     FieldInfo,
     argdesc,
-    create_pagination,
     resolve,
 )
+from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.types import validate_name
 from ayon_server.utils import SQLTool

--- a/ayon_server/graphql/resolvers/projects.py
+++ b/ayon_server/graphql/resolvers/projects.py
@@ -68,21 +68,21 @@ async def get_projects(
     #
 
     order_by = ["name"]
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by, first, after, last, before
     )
     sql_conditions.append(paging_conds)
     cols.append(cursor)
 
     #
-    #
+    # Query
     #
 
     query = f"""
         SELECT {', '.join(cols)}
         FROM projects
         {SQLTool.conditions(sql_conditions)}
-        {pagination}
+        {ordering}
     """
 
     return await resolve(

--- a/ayon_server/graphql/resolvers/projects.py
+++ b/ayon_server/graphql/resolvers/projects.py
@@ -71,7 +71,7 @@ async def get_projects(
     pagination, paging_conds, cursor = create_pagination(
         order_by, first, after, last, before
     )
-    sql_conditions.extend(paging_conds)
+    sql_conditions.append(paging_conds)
     cols.append(cursor)
 
     #
@@ -89,10 +89,10 @@ async def get_projects(
         ProjectsConnection,
         ProjectEdge,
         ProjectNode,
-        None,
         query,
-        first,
-        last,
+        first=first,
+        last=last,
+        order_by=order_by,
         context=info.context,
     )
 

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -141,7 +141,7 @@ async def get_representations(
     pagination, paging_conds, cursor = create_pagination(
         order_by, first, after, last, before
     )
-    sql_conditions.extend(paging_conds)
+    sql_conditions.append(paging_conds)
 
     #
     # Query
@@ -159,10 +159,11 @@ async def get_representations(
         RepresentationsConnection,
         RepresentationEdge,
         RepresentationNode,
-        project_name,
         query,
-        first,
-        last,
+        project_name=project_name,
+        first=first,
+        last=last,
+        order_by=order_by,
         context=info.context,
     )
 

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -138,7 +138,7 @@ async def get_representations(
     #
 
     order_by = ["representations.creation_order"]
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by, first, after, last, before
     )
     sql_conditions.append(paging_conds)
@@ -152,7 +152,7 @@ async def get_representations(
         FROM project_{project_name}.representations
         {' '.join(sql_joins)}
         {SQLTool.conditions(sql_conditions)}
-        {pagination}
+        {ordering}
     """
 
     return await resolve(

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -13,10 +13,10 @@ from ayon_server.graphql.resolvers.common import (
     ARGLast,
     argdesc,
     create_folder_access_list,
-    create_pagination,
     get_has_links_conds,
     resolve,
 )
+from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.types import validate_name_list, validate_status_list
 from ayon_server.utils import SQLTool

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -307,7 +307,7 @@ async def get_tasks(
     # Joins
     #
 
-    if attributes or fields.any_endswith("attrib"):
+    if attributes or fields.any_endswith("attrib") or fields.any_endswith("allAttrib"):
         sql_columns.append("pf.attrib as parent_folder_attrib")
         sql_joins.append(
             f"""

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -17,14 +17,15 @@ from ayon_server.graphql.resolvers.common import (
     FieldInfo,
     argdesc,
     create_folder_access_list,
-    create_pagination,
     get_has_links_conds,
     resolve,
     sortdesc,
 )
+from ayon_server.graphql.resolvers.pagination import (
+    create_pagination,
+    get_attrib_sort_case,
+)
 from ayon_server.graphql.types import Info
-from ayon_server.lib.postgres import Postgres
-from ayon_server.logging import logger
 from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import (
     sanitize_string_list,
@@ -42,23 +43,6 @@ SORT_OPTIONS = {
     "taskType": "tasks.folder_type",
     "assignees": "array_to_string(tasks.assignees, '')",
 }
-
-
-async def get_priority_case() -> str:
-    attr = "priority"
-    res = await Postgres.fetch(
-        "SELECT data->'enum' as enum FROM attributes where name = $1", attr
-    )
-    if not res or not res[0]["enum"]:
-        return f"(pf.attrib || tasks.attrib)->>'{attr}'"
-    case = "CASE"
-    i = 0
-    for i, eval in enumerate(res[0]["enum"]):
-        e = eval["value"]
-        case += f" WHEN (pf.attrib || tasks.attrib)->>'{attr}' = '{e}' THEN {i}"
-    case += f" ELSE {i+1}"
-    case += " END"
-    return case
 
 
 async def get_tasks(
@@ -227,9 +211,6 @@ async def get_tasks(
     elif root.__class__.__name__ == "FolderNode":
         # cannot use isinstance here because of circular imports
         sql_conditions.append(f"tasks.folder_id = '{root.id}'")
-
-    # if name:
-    #     sql_conditions.append(f"tasks.name ILIKE '{name}'")
 
     if names is not None:
         if not names:
@@ -429,12 +410,11 @@ async def get_tasks(
     if sort_by is not None:
         if sort_by in SORT_OPTIONS:
             order_by.insert(0, SORT_OPTIONS[sort_by])
-        if sort_by == "attrib.priority":
-            priority_case = await get_priority_case()
-            order_by.insert(0, priority_case)
         elif sort_by.startswith("attrib."):
-            r = f"(pf.attrib || tasks.attrib)->'{sort_by[7:]}'"  # noqa
-            order_by.insert(0, r)
+            attr_name = sort_by[7:]
+            exp = "(pf.attrib || tasks.attrib)"
+            attr_case = await get_attrib_sort_case(attr_name, exp)
+            order_by.insert(0, attr_case)
         else:
             raise ValueError(f"Invalid sort_by value: {sort_by}")
 
@@ -470,7 +450,7 @@ FROM project_{project_name}.tasks AS tasks
 {ordering}
     """
 
-    logger.debug(f"Task query\n{query}")
+    # logger.debug(f"Task query\n{query}")
 
     return await resolve(
         TasksConnection,

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -22,7 +22,6 @@ from ayon_server.graphql.resolvers.common import (
     sortdesc,
 )
 from ayon_server.graphql.types import Info
-from ayon_server.logging import logger
 from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import (
     sanitize_string_list,
@@ -322,10 +321,10 @@ async def get_tasks(
     # We need it if we want to show the task attributes or filter by them
     if (
         attributes
+        or filter
+        or sort_by
         or fields.any_endswith("attrib")
         or fields.any_endswith("allAttrib")
-        or attributes
-        or filter
     ):
         sql_columns.append("pf.attrib as parent_folder_attrib")
         sql_joins.append(
@@ -410,7 +409,6 @@ async def get_tasks(
         before,
     )
     sql_conditions.append(paging_conds)
-    logger.debug(f"Cursor: {cursor}")
 
     #
     # Query
@@ -434,8 +432,6 @@ FROM project_{project_name}.tasks AS tasks
 {SQLTool.conditions(sql_conditions)}
 {ordering}
     """
-
-    logger.debug(f"GraphQL tasks query: \n{query}")
 
     return await resolve(
         TasksConnection,

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -402,24 +402,14 @@ async def get_tasks(
         else:
             raise ValueError(f"Invalid sort_by value: {sort_by}")
 
-    paging_fields = FieldInfo(info, ["tasks"])
-    logger.debug(f"Paging fields: {paging_fields.fields}")
-    need_cursor = paging_fields.has_any(
-        "pageInfo.startCursor",
-        "pageInfo.endCursor",
-        "edges.cursor",
-    )
-
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by,
         first,
         after,
         last,
         before,
-        need_cursor=need_cursor,
     )
-    sql_conditions.extend(paging_conds)
-    logger.debug(f"Needs cursor: {need_cursor}")
+    sql_conditions.append(paging_conds)
     logger.debug(f"Cursor: {cursor}")
 
     #
@@ -442,7 +432,7 @@ SELECT
 FROM project_{project_name}.tasks AS tasks
 {" ".join(sql_joins)}
 {SQLTool.conditions(sql_conditions)}
-{pagination}
+{ordering}
     """
 
     logger.debug(f"GraphQL tasks query: \n{query}")
@@ -451,12 +441,12 @@ FROM project_{project_name}.tasks AS tasks
         TasksConnection,
         TaskEdge,
         TaskNode,
-        project_name,
         query,
-        first,
-        last,
-        context=info.context,
+        project_name=project_name,
+        first=first,
+        last=last,
         order_by=order_by,
+        context=info.context,
     )
 
 

--- a/ayon_server/graphql/resolvers/users.py
+++ b/ayon_server/graphql/resolvers/users.py
@@ -92,10 +92,10 @@ async def get_users(
     #
 
     order_by = ["name"]
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by, first, after, last, before
     )
-    sql_conditions.extend(paging_conds)
+    sql_conditions.append(paging_conds)
 
     #
     # Query
@@ -104,18 +104,18 @@ async def get_users(
     query = f"""
         SELECT {cursor}, * FROM users
         {SQLTool.conditions(sql_conditions)}
-        {pagination}
+        {ordering}
     """
 
     return await resolve(
         UsersConnection,
         UserEdge,
         UserNode,
-        None,
         query,
-        first,
-        last,
+        first=first,
+        last=last,
         context=info.context,
+        order_by=order_by,
     )
 
 

--- a/ayon_server/graphql/resolvers/users.py
+++ b/ayon_server/graphql/resolvers/users.py
@@ -10,9 +10,9 @@ from ayon_server.graphql.resolvers.common import (
     ARGFirst,
     ARGLast,
     argdesc,
-    create_pagination,
     resolve,
 )
+from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.types import validate_name_list, validate_user_name
 from ayon_server.utils import SQLTool

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -223,20 +223,12 @@ async def get_versions(
         else:
             raise ValueError(f"Invalid sort_by value: {sort_by}")
 
-    paging_fields = FieldInfo(info, ["versions"])
-    need_cursor = paging_fields.has_any(
-        "versions.pageInfo.startCursor",
-        "versions.pageInfo.endCursor",
-        "versions.edges.cursor",
-    )
-
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by,
         first,
         after,
         last,
         before,
-        need_cursor=need_cursor,
     )
     sql_conditions.append(paging_conds)
 
@@ -256,7 +248,7 @@ async def get_versions(
         FROM project_{project_name}.versions AS versions
         {" ".join(sql_joins)}
         {SQLTool.conditions(sql_conditions)}
-        {pagination}
+        {ordering}
     """
 
     return await resolve(

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -14,11 +14,11 @@ from ayon_server.graphql.resolvers.common import (
     FieldInfo,
     argdesc,
     create_folder_access_list,
-    create_pagination,
     get_has_links_conds,
     resolve,
     sortdesc,
 )
+from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.types import validate_name_list, validate_status_list
 from ayon_server.utils import SQLTool

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -238,7 +238,7 @@ async def get_versions(
         before,
         need_cursor=need_cursor,
     )
-    sql_conditions.extend(paging_conds)
+    sql_conditions.append(paging_conds)
 
     #
     # Query
@@ -263,10 +263,11 @@ async def get_versions(
         VersionsConnection,
         VersionEdge,
         VersionNode,
-        project_name,
         query,
-        first,
-        last,
+        project_name=project_name,
+        first=first,
+        last=last,
+        order_by=order_by,
         context=info.context,
     )
 

--- a/ayon_server/graphql/resolvers/workfiles.py
+++ b/ayon_server/graphql/resolvers/workfiles.py
@@ -13,11 +13,11 @@ from ayon_server.graphql.resolvers.common import (
     ARGLast,
     argdesc,
     create_folder_access_list,
-    create_pagination,
     get_has_links_conds,
     resolve,
     sortdesc,
 )
+from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.types import validate_name_list, validate_status_list
 from ayon_server.utils import SQLTool

--- a/ayon_server/graphql/resolvers/workfiles.py
+++ b/ayon_server/graphql/resolvers/workfiles.py
@@ -10,7 +10,6 @@ from ayon_server.graphql.resolvers.common import (
     ARGHasLinks,
     ARGIds,
     ARGLast,
-    FieldInfo,
     argdesc,
     create_folder_access_list,
     create_pagination,
@@ -152,20 +151,12 @@ async def get_workfiles(
         else:
             raise ValueError(f"Invalid sort_by value: {sort_by}")
 
-    paging_fields = FieldInfo(info, ["workfiles"])
-    need_cursor = paging_fields.has_any(
-        "workfiles.pageInfo.startCursor",
-        "workfiles.pageInfo.endCursor",
-        "workfiles.edges.cursor",
-    )
-
-    pagination, paging_conds, cursor = create_pagination(
+    ordering, paging_conds, cursor = create_pagination(
         order_by,
         first,
         after,
         last,
         before,
-        need_cursor=need_cursor,
     )
     sql_conditions.append(paging_conds)
 
@@ -178,7 +169,7 @@ async def get_workfiles(
         FROM project_{project_name}.workfiles AS workfiles
         {" ".join(sql_joins)}
         {SQLTool.conditions(sql_conditions)}
-        {pagination}
+        {ordering}
     """
 
     return await resolve(

--- a/ayon_server/graphql/resolvers/workfiles.py
+++ b/ayon_server/graphql/resolvers/workfiles.py
@@ -167,7 +167,7 @@ async def get_workfiles(
         before,
         need_cursor=need_cursor,
     )
-    sql_conditions.extend(paging_conds)
+    sql_conditions.append(paging_conds)
 
     #
     # Query
@@ -185,10 +185,11 @@ async def get_workfiles(
         WorkfilesConnection,
         WorkfileEdge,
         WorkfileNode,
-        project_name,
         query,
-        first,
-        last,
+        project_name=project_name,
+        first=first,
+        last=last,
+        order_by=order_by,
         context=info.context,
     )
 

--- a/ayon_server/graphql/utils.py
+++ b/ayon_server/graphql/utils.py
@@ -22,13 +22,13 @@ ATTRIB_WHITELIST = [
 
 
 def parse_attrib_data(
-    target_type,
+    target_type: Any,
     own_attrib: dict[str, Any],
     user: UserEntity,
     project_name: str | None = None,
     inherited_attrib: dict[str, Any] | None = None,
     project_attrib: dict[str, Any] | None = None,
-):
+) -> dict[str, Any]:
     """ACL agnostic attribute list parser"""
 
     attr_limit: list[str] | Literal["all"] = []
@@ -74,7 +74,7 @@ def parse_attrib_data(
                 data[key] = project_attrib[key]
 
     if not data:
-        return target_type()
+        return {}
     result = {}
     expected_keys = target_type.__dataclass_fields__.keys()
     for key in expected_keys:
@@ -84,4 +84,4 @@ def parse_attrib_data(
                 if attribute_library.by_name(key)["type"] == "datetime":
                     value = datetime.fromisoformat(value)
                 result[key] = value
-    return target_type(**result)
+    return result

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -1,12 +1,22 @@
 import json
 import re
-from typing import Annotated, Literal, Union
+from typing import Annotated, Any, Literal, Union
 
-from pydantic import validator
+from pydantic import StrictFloat, StrictInt, StrictStr, validator
 
+from ayon_server.logging import logger
 from ayon_server.types import Field, OPModel
 
-ValueType = str | int | float | list[str] | list[int] | list[float] | None
+ValueType = (
+    StrictStr
+    | StrictInt
+    | StrictFloat
+    | list[StrictStr]
+    | list[StrictInt]
+    | list[StrictFloat]
+    | None
+)
+
 
 OperatorType = Literal[
     "eq",
@@ -63,7 +73,8 @@ class QueryCondition(OPModel):
         return v.lower()
 
     @validator("value")
-    def validate_value(cls, v, values):
+    def validate_value(cls, v: ValueType, values: dict[str, Any]):
+        logger.debug(f"Validating {type(v)} value {v} with {values}")
         if values.get("operator") in ("in", "notin", "any"):
             if not isinstance(v, list):
                 raise ValueError("Value must be a list")
@@ -139,6 +150,7 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
     json_fields = kwargs.get("json_fields", JSON_FIELDS)
     table_prefix = kwargs.get("table_prefix")
     column_whitelist = kwargs.get("column_whitelist", None)
+    column_map: dict[str, str] = kwargs.get("column_map", {})
 
     path = create_path_from_key(c.key, column_whitelist)
     value = c.value
@@ -147,6 +159,8 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
     safe_value: ValueType = None
 
     column = path[0]
+    if column in column_map:
+        column = column_map[column]
 
     if len(path) == 1 and path[0] not in json_fields:
         # Hack to map project and user to their respective db column names
@@ -162,18 +176,19 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
             cast_type = "integer" if isinstance(value, int) else "number"
             safe_value = value
 
-    elif len(path) > 1 and column in json_fields:
+    elif len(path) > 1 and path[0] in json_fields:
         for k in path[1:]:
             column += f"->'{k}'"
 
         if isinstance(value, str | int | float):
             safe_value = json.dumps(value).replace("'", "''")
             safe_value = f"'{safe_value}'"
+            logger.debug(f"Safe value of {type(value)} {value}: {safe_value}")
 
     else:
         raise ValueError(f"Invalid path: {path}")
 
-    if table_prefix:
+    if table_prefix and path[0] not in column_map:
         column = f"{table_prefix}.{column}"
 
     if isinstance(value, list):
@@ -245,9 +260,11 @@ def build_filter(f: QueryFilter | None, **kwargs) -> str | None:
     """Return a SQL WHERE clause from a Filter object."""
 
     if f is None:
+        logger.debug("Empty filter")
         return None
 
     if not f.conditions:
+        logger.debug(f"Empty conditions {f.dict()}")
         return None
 
     result = []

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -74,7 +74,7 @@ class QueryCondition(OPModel):
 
     @validator("value")
     def validate_value(cls, v: ValueType, values: dict[str, Any]):
-        logger.debug(f"Validating {type(v)} value {v} with {values}")
+        logger.trace(f"Validating {type(v)} value {v} with {values}")
         if values.get("operator") in ("in", "notin", "any"):
             if not isinstance(v, list):
                 raise ValueError("Value must be a list")
@@ -183,7 +183,7 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
         if isinstance(value, str | int | float):
             safe_value = json.dumps(value).replace("'", "''")
             safe_value = f"'{safe_value}'"
-            logger.debug(f"Safe value of {type(value)} {value}: {safe_value}")
+            logger.trace(f"Safe value of {type(value)} {value}: {safe_value}")
 
     else:
         raise ValueError(f"Invalid path: {path}")
@@ -260,11 +260,11 @@ def build_filter(f: QueryFilter | None, **kwargs) -> str | None:
     """Return a SQL WHERE clause from a Filter object."""
 
     if f is None:
-        logger.debug("Empty filter")
+        logger.trace("Empty filter")
         return None
 
     if not f.conditions:
-        logger.debug(f"Empty conditions {f.dict()}")
+        logger.trace(f"Empty conditions {f.dict()}")
         return None
 
     result = []

--- a/ayon_server/utils/sqltool.py
+++ b/ayon_server/utils/sqltool.py
@@ -52,6 +52,9 @@ class SQLTool:
 
         list(['a = 1', 'b = 2']) becomes str("a = 1 AND b = 2")
         """
+        condition_list = [
+            condition.strip() for condition in condition_list if condition.strip()
+        ]
         if condition_list:
             return ("WHERE " if add_where else "") + (
                 f" {operand} ".join(condition_list)


### PR DESCRIPTION
This pull request includes several changes to the `graphql` module.

### New pagination

Pagination and sorting was rewritten from scratch and now uses opaque cursors and respect types used for the sorting.

![image](https://github.com/user-attachments/assets/5a8d14fe-ee5f-4dd6-9364-71367deab310)

### Addition of `all_attrib` Field:

* Added `all_attrib` field to multiple GraphQL node classes (`FolderNode`, `ProductNode`, `ProjectNode`, `RepresentationNode`, `TaskNode`, `UserNode`, `VersionNode`, `WorkfileNode`). This field stores a JSON representation of all attributes user has access to.
* Refactored attribute parsing to use a new `parse_attrib_data` function, which now returns a dictionary instead of an instance of the attribute type. This change affects the `folder_from_record`, `product_from_record`, `project_from_record`, `representation_from_record`, `task_from_record`, `user_from_record`, `version_from_record`, and `workfile_from_record` functions. 

![image](https://github.com/user-attachments/assets/5b87b0b0-cf5a-4ff0-8b0c-af45bf47db34)
