### PR TITLE
Provide error messages in 401 responses

### DIFF
--- a/api/users/users.py
+++ b/api/users/users.py
@@ -442,7 +442,8 @@ async def delete_user_session(
         raise ForbiddenException(
             "You are not allowed to delete sessions which don't belong to you"
         )
-    await Session.delete(session_id)
+    msg = f"Logged out by {current_user.name}"
+    await Session.delete(session_id, message=msg)
     return EmptyResponse()
 
 

--- a/ayon_server/api/authmw.py
+++ b/ayon_server/api/authmw.py
@@ -32,6 +32,27 @@ def access_token_from_request(request: Request) -> str | None:
     return token
 
 
+async def get_logout_reason(token: str) -> str:
+    reason = await Redis.get_json("logoutreason", token)
+    if not reason:
+        res = await Postgres.fetch(
+            """
+            SELECT description FROM events
+            WHERE topic = 'auth.logout'
+            AND summary->>'token' = $1
+            AND created_at > NOW() - interval '5 minutes'
+            ORDER BY created_at DESC LIMIT 1
+            """,
+            token,
+        )
+        if res:
+            reason = res[0]["description"]
+        else:
+            reason = "Invalid session"
+        await Redis.set_json("logoutreason", "token", reason, ttl=600)
+    return reason
+
+
 async def user_from_api_key(api_key: str) -> UserEntity:
     """Return a user associated with the given API key.
 
@@ -89,6 +110,8 @@ async def user_from_request(request: Request) -> UserEntity:
         if authorization:
             api_key = parse_api_key(authorization)
 
+    access_token: str | None = None
+
     if api_key:
         if (session_data := await Session.check(api_key, request)) is None:
             user = await user_from_api_key(api_key)
@@ -101,7 +124,12 @@ async def user_from_request(request: Request) -> UserEntity:
         raise UnauthorizedException("Access token is missing")
 
     if not session_data:
-        raise UnauthorizedException("Invalid access token")
+        if access_token:
+            reason = await get_logout_reason(access_token)
+        else:
+            reason = "Invalid API key"
+        logger.debug(f"Unauthorized request: {reason}")
+        raise UnauthorizedException(reason)
 
     await Redis.incr("user-requests", session_data.user.name)
     user = UserEntity.from_record(session_data.user.dict())

--- a/ayon_server/helpers/rename_user.py
+++ b/ayon_server/helpers/rename_user.py
@@ -78,7 +78,9 @@ async def rename_user(
 
     # Renaming user has many side effects, so we need to log out all Sessions
     # and let the user log in again
-    await Session.logout_user(old_name)
+    await Session.logout_user(
+        old_name, message="User has been logged out after renaming."
+    )
 
     await EventStream.dispatch(
         "entity.user.renamed",


### PR DESCRIPTION
Reason of the "unauthorized" response is logged to the event stream and is returned with 401 responses.

![image](https://github.com/user-attachments/assets/a36f310a-3766-4ecf-a160-251edc6ecb03)

 Handling `response.detail` this must now be implemented in the frontend.

