### PR TITLE
Filter users by emails in GraphQL

### DIFF
--- a/ayon_server/types.py
+++ b/ayon_server/types.py
@@ -83,6 +83,7 @@ PROJECT_CODE_REGEX = r"^[a-zA-Z0-9_][a-zA-Z0-9_]*[a-zA-Z0-9_]$"
 # api key can contain alphanumeric characters and hyphens
 API_KEY_REGEX = r"^[a-zA-Z0-9\-]*$"
 SEMVER_REGEX = r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"  # noqa: E501
+EMAIL_REGEX = r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"
 
 
 def validate_name(name: str, regex: str = NAME_REGEX) -> str:
@@ -99,6 +100,18 @@ def validate_user_name(name: str) -> str:
             f"User name '{name}' does not match regex '{USER_NAME_REGEX}'"
         )
     return name
+
+
+def validate_email(email: str) -> str:
+    """Validate email."""
+    if not re.match(EMAIL_REGEX, email):
+        raise BadRequestException(f"Invalid email: '{email}'")
+    return email
+
+
+def validate_email_list(emails: list[str]) -> list[str]:
+    """Validate list of emails."""
+    return [validate_email(email) for email in emails]
 
 
 def validate_name_list(names: list[str], regex: str = NAME_REGEX) -> list[str]:


### PR DESCRIPTION
This pull request introduces new functionality to filter users by email in the GraphQL users resolver. Multiple email addresses can be passed as `emails` argument to the resolver. search is case-insensitive.