### PR TITLE
Add representation traits to graphql

### DIFF
--- a/ayon_server/graphql/nodes/representation.py
+++ b/ayon_server/graphql/nodes/representation.py
@@ -38,6 +38,7 @@ class RepresentationNode(BaseNode):
     attrib: RepresentationAttribType
     all_attrib: str
     data: str | None
+    traits: str | None
 
     # GraphQL specifics
 
@@ -107,6 +108,7 @@ def representation_from_record(
         updated_at=record["updated_at"],
         context=json_dumps(data.get("context", {})),
         files=parse_files(record.get("files", [])),
+        traits=json_dumps(record["traits"]) if record["traits"] else None,
     )
 
 

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -62,6 +62,7 @@ async def get_representations(
         "representations.creation_order AS creation_order",
         "representations.files AS files",  # TODO: query conditionally
         "representations.data AS data",
+        "representations.traits AS traits",
     ]
 
     sql_joins = []


### PR DESCRIPTION
## PR Checklist

Adding representation traits to the node in GraphQL.

## Description of changes

Traits are JSON serialized data, in GraphQL represented as string to simplify model definitions.

### Technical details

This is done so pipeline code can work with traits retrieved via graphql.

### Additional context

**Related PRs:**
[ayon-core#](https://github.com/ynput/ayon-core/pull/979)
#466
#431

