### PR TITLE
Support for ACL with horizontal scaling

### DIFF
--- a/api/access/access_groups.py
+++ b/api/access/access_groups.py
@@ -219,11 +219,10 @@ async def delete_access_group(
             DELETE FROM {schema}.access_groups
             WHERE name = $1 RETURNING *
         )
-        SELECT * FROM deleted
+        SELECT name FROM deleted
     """
 
-    res = await Postgres.fetch(query, access_group_name)
-    if not res[0]["count"]:
+    if not await Postgres.fetch(query, access_group_name):
         raise NotFoundException(f"Access group {access_group_name} not found")
 
     if schema == "public":

--- a/api/access/access_groups.py
+++ b/api/access/access_groups.py
@@ -88,22 +88,27 @@ async def get_access_groups(
     project_name: ProjectNameOrUnderscore,
 ) -> list[AccessGroupObject]:
     """Get a list of access group for a given project"""
-    rdict = {}
 
-    for ag_key, _perms in AccessGroups.access_groups.items():
-        access_group_name, pname = ag_key
-        if pname == "_":
-            if access_group_name in rdict:
-                continue
-            else:
-                rdict[access_group_name] = {"isProjectLevel": False}
-        elif pname == project_name:
-            rdict[access_group_name] = {"isProjectLevel": pname != "_"}
-
-    result: list[AccessGroupObject] = []
-    for access_group_name, data in rdict.items():
-        result.append(AccessGroupObject(name=access_group_name, **data))
-    result.sort(key=lambda x: x.name)
+    if project_name == "_":
+        query = """
+            SELECT name, FALSE AS is_project_level
+            FROM public.access_groups ORDER BY name
+        """
+    else:
+        query = f"""
+            SELECT g.name, p.data IS NOT NULL AS is_project_level
+            FROM public.access_groups g
+            LEFT JOIN project_{project_name}.access_groups p ON g.name = p.name
+            ORDER BY g.name
+        """
+    result = []
+    async for row in Postgres.iterate(query):
+        result.append(
+            AccessGroupObject(
+                name=row["name"],
+                is_project_level=row["is_project_level"],
+            )
+        )
     return result
 
 
@@ -117,7 +122,27 @@ async def get_access_group(
     project_name: ProjectNameOrUnderscore,
 ) -> Permissions:
     """Get an access group definition"""
-    return AccessGroups.combine([access_group_name], project_name)
+    # return AccessGroups.combine([access_group_name], project_name)
+
+    if project_name == "_":
+        query = """
+            SELECT name, data
+            FROM public.access_groups
+            WHERE name = $1
+        """
+    else:
+        query = f"""
+            SELECT g.name, COALESCE(p.data, g.data) as data
+            FROM public.access_groups g
+            LEFT JOIN project_{project_name}.access_groups p ON g.name = p.name
+            WHERE g.name = $1
+        """
+
+    res = await Postgres.fetchrow(query, access_group_name)
+    if res is None:
+        raise NotFoundException(f"Access group '{access_group_name}' not found")
+
+    return Permissions.from_record(res["data"])
 
 
 @router.put(
@@ -162,7 +187,7 @@ async def save_access_group(
             f"Unable to add access group {access_group_name}"
         ) from None
 
-    await AccessGroups.load()
+    # await AccessGroups.load()
     # TODO: messaging: notify other instances
     return EmptyResponse()
 
@@ -196,7 +221,7 @@ async def delete_access_group(
     if scope == "public":
         background_tasks.add_task(clean_up_user_access_groups)
 
-    await AccessGroups.load()
+    # await AccessGroups.load()
     # TODO: messaging: notify other instances
 
     return EmptyResponse()

--- a/api/folders/list_folders.py
+++ b/api/folders/list_folders.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi import Query, Response
 
-from ayon_server.access.utils import folder_access_list
+from ayon_server.access.utils import AccessChecker
 from ayon_server.api.dependencies import CurrentUser, ProjectName
 from ayon_server.helpers.hierarchy_cache import rebuild_hierarchy_cache
 from ayon_server.lib.redis import Redis
@@ -92,18 +92,11 @@ class FolderListLoader:
     def _build_response(
         self,
         folder_list: list[dict[str, Any]],
-        folder_access_list: set[str] | None,
+        access_checker: AccessChecker,
     ) -> Response:
         return Response(
             json_dumps(
-                {
-                    "folders": [
-                        record
-                        for record in folder_list
-                        if folder_access_list is None
-                        or record["path"] in folder_access_list
-                    ]
-                }
+                {"folders": [r for r in folder_list if access_checker[r["path"]]]}
             ),
             media_type="application/json",
         )
@@ -111,14 +104,14 @@ class FolderListLoader:
     async def build_response(
         self,
         folder_list: list[dict[str, Any]],
-        folder_access_list: set[str] | None,
+        access_checker: AccessChecker,
     ) -> Response:
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(
             None,
             self._build_response,
             folder_list,
-            folder_access_list,
+            access_checker,
         )
 
 
@@ -157,8 +150,15 @@ async def get_folder_list(
     #   does not have access to. So we cannot avoid parsing the JSON, solving the ACL
 
     start_time = time.monotonic()
-    _access_list = await folder_access_list(user, project_name, "read")
-    access_list: set[str] | None = None if _access_list is None else set(_access_list)
+    # _access_list = await folder_access_list(user, project_name, "read")
+    # access_list: set[str] | None = (
+    #     None if _access_list is None else {r.strip('"') for r in _access_list}
+    # )
+
+    access_checker = AccessChecker()
+    await access_checker.load(user, project_name, "read")
+    access_checker.visualize()
+
     elapsed_time = time.monotonic() - start_time
     logger.trace(f"Loaded folder access list in {elapsed_time:.3f} seconds")
 
@@ -170,4 +170,4 @@ async def get_folder_list(
     detail = f"{me} fetched in {elapsed_time:.3f} seconds"
     logger.trace(detail)
 
-    return await folder_list_loader.build_response(entities, access_list)
+    return await folder_list_loader.build_response(entities, access_checker)

--- a/api/folders/list_folders.py
+++ b/api/folders/list_folders.py
@@ -150,14 +150,8 @@ async def get_folder_list(
     #   does not have access to. So we cannot avoid parsing the JSON, solving the ACL
 
     start_time = time.monotonic()
-    # _access_list = await folder_access_list(user, project_name, "read")
-    # access_list: set[str] | None = (
-    #     None if _access_list is None else {r.strip('"') for r in _access_list}
-    # )
-
     access_checker = AccessChecker()
     await access_checker.load(user, project_name, "read")
-    access_checker.visualize()
 
     elapsed_time = time.monotonic() - start_time
     logger.trace(f"Loaded folder access list in {elapsed_time:.3f} seconds")

--- a/api/tasks_folders/tasks_folders.py
+++ b/api/tasks_folders/tasks_folders.py
@@ -83,10 +83,15 @@ async def query_tasks_folders(
             OR tasks.task_type ILIKE '{term}%'
             OR f.path ILIKE '%{term}%'
             )"""
-        conditions.append(cond)
+            conditions.append(cond)
 
     if not conditions:
         raise BadRequestException("No filter or search term provided")
+
+    facl = await folder_access_list(user, project_name, "read")
+    if facl is not None:
+        cond = f"f.path like ANY ('{{ {','.join(facl)} }}')"
+        conditions.append(cond)
 
     query = f"""
         SELECT DISTINCT tasks.folder_id
@@ -96,11 +101,7 @@ async def query_tasks_folders(
         {SQLTool.conditions(conditions)}
     """
 
-    facl = await folder_access_list(user, project_name, "read")
-
     async for row in Postgres.iterate(query):
-        if facl is not None and row["folder_id"] not in facl:
-            continue
         result.append(row["folder_id"])
 
     return TasksFoldersResponse(folder_ids=result)

--- a/ayon_server/access/access_groups.py
+++ b/ayon_server/access/access_groups.py
@@ -45,8 +45,7 @@ class AccessGroups:
     access_groups: dict[tuple[str, str], Permissions] = {}
 
     @classmethod
-    async def load(cls, *args, **kwargs) -> None:
-        logger.trace(f"Loading access groups {args}")
+    async def load(cls) -> None:
         cls.access_groups = {}
         async for row in Postgres.iterate(
             "SELECT name, data FROM public.access_groups"

--- a/ayon_server/access/access_groups.py
+++ b/ayon_server/access/access_groups.py
@@ -1,4 +1,5 @@
-from typing import Any
+import asyncio
+from typing import TYPE_CHECKING, Any
 
 from ayon_server.access.permissions import (
     AttributeAccessList,
@@ -7,16 +8,45 @@ from ayon_server.access.permissions import (
     FolderAccessList,
     Permissions,
 )
+from ayon_server.exceptions import NotFoundException
 from ayon_server.helpers.project_list import get_project_list
 from ayon_server.lib.postgres import Postgres
+from ayon_server.lib.redis import Redis
+from ayon_server.logging import logger
 from ayon_server.types import normalize_to_dict
+
+if TYPE_CHECKING:
+    from ayon_server.events import EventModel
+
+
+async def get_access_group(
+    access_group_name: str, project_name: str = "_"
+) -> Permissions:
+    """Too bad we cannot use this :-(
+    We need to access access group without async... but i'll keep this here for now.
+    Who knows...
+    """
+    ns = "access-group"
+    key = f"{access_group_name}:{project_name}"
+    lock = asyncio.Lock()
+    async with lock:
+        if (data := await Redis.get_json(ns, key)) is None:
+            schema = "public" if project_name == "_" else f"project_{project_name}"
+            query = f" SELECT name, data FROM {schema}.access_groups WHERE name = $1"
+            res = await Postgres.fetchrow(query, access_group_name)
+            if res is None:
+                raise NotFoundException(f"Access group '{access_group_name}' not found")
+            data = dict(res)
+            await Redis.set_json(ns, key, data)
+    return Permissions.from_record(data)
 
 
 class AccessGroups:
     access_groups: dict[tuple[str, str], Permissions] = {}
 
     @classmethod
-    async def load(cls) -> None:
+    async def load(cls, *args, **kwargs) -> None:
+        logger.trace(f"Loading access groups {args}")
         cls.access_groups = {}
         async for row in Postgres.iterate(
             "SELECT name, data FROM public.access_groups"
@@ -38,6 +68,26 @@ class AccessGroups:
                     project_name,
                     Permissions.from_record(row["data"]),
                 )
+
+    @classmethod
+    async def update_hook(cls, event: "EventModel") -> None:
+        if event.topic == "access_group.deleted":
+            cls.access_groups.pop((event.summary["name"], event.project or "_"), None)
+            return
+        if event.topic != "access_group.updated":
+            return
+        schema = "public" if not event.project else f"project_{event.project}"
+        name = event.summary["name"]
+        query = f"SELECT data FROM {schema}.access_groups WHERE name = $1"
+        res = await Postgres.fetchrow(query, name)
+        if not res:
+            logger.warning(f"Unable to update access group {name}: not found")
+            return
+        cls.access_groups[(name, event.project or "_")] = Permissions.from_record(
+            res["data"]
+        )
+        suffix = f" for project {event.project}" if event.project else ""
+        logger.debug(f"Updated access group {name}{suffix}")
 
     @classmethod
     def add_access_group(

--- a/ayon_server/access/access_groups.py
+++ b/ayon_server/access/access_groups.py
@@ -72,6 +72,7 @@ class AccessGroups:
     async def update_hook(cls, event: "EventModel") -> None:
         if event.topic == "access_group.deleted":
             cls.access_groups.pop((event.summary["name"], event.project or "_"), None)
+            logger.trace(f"Deleted access group {event.summary['name']}")
             return
         if event.topic != "access_group.updated":
             return

--- a/ayon_server/access/utils.py
+++ b/ayon_server/access/utils.py
@@ -1,4 +1,3 @@
-import sys
 from typing import TYPE_CHECKING, Literal
 
 from ayon_server.exceptions import ForbiddenException
@@ -296,12 +295,3 @@ class AccessChecker:
                 node.is_end = True
             else:
                 self.exact_paths.add(path)
-
-    def visualize(self) -> None:
-        def _visualize(node: TrieNode, prefix: str) -> None:
-            if node.is_end:
-                print(prefix + "*", file=sys.stderr, flush=True)
-            for char, child in node.children.items():
-                _visualize(child, prefix + char)
-
-        _visualize(self.root, "")

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -33,8 +33,8 @@ async def load_access_groups() -> None:
     from ayon_server.access.access_groups import AccessGroups
 
     await AccessGroups.load()
-    EventStream.subscribe("access_group.updated", AccessGroups.load, True)
-    EventStream.subscribe("access_group.deleted", AccessGroups.load, True)
+    EventStream.subscribe("access_group.updated", AccessGroups.update_hook, True)
+    EventStream.subscribe("access_group.deleted", AccessGroups.update_hook, True)
 
 
 def init_addon_endpoints(target_app: "FastAPI") -> None:

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -33,6 +33,8 @@ async def load_access_groups() -> None:
     from ayon_server.access.access_groups import AccessGroups
 
     await AccessGroups.load()
+    EventStream.subscribe("access_group.updated", AccessGroups.load, True)
+    EventStream.subscribe("access_group.deleted", AccessGroups.load, True)
 
 
 def init_addon_endpoints(target_app: "FastAPI") -> None:


### PR DESCRIPTION
This pull request includes several significant changes to the access groups and folder access logic in the `api` and `ayon_server` modules. The main improvements involve replacing the `AccessGroups` class with direct database queries, adding event dispatching for access group updates, and refactoring folder access checks to improve performance and clarity.

Access groups changes are now propagated to all running replicas:

![image](https://github.com/user-attachments/assets/cc25e76a-e97a-4ffd-b79c-8c676342609c)

