### PR TITLE
Chore: Templates enum

### DIFF
--- a/ayon_server/settings/enum.py
+++ b/ayon_server/settings/enum.py
@@ -147,8 +147,6 @@ def anatomy_template_items_enum(
 
     Wrapper for actual function as Settings require callable.
 
-    If no category is required it must be used as:
-        `enum_resolver=anatomy_template_items_enum()`
     Args:
         project_name: str
         category: str: type of templates 'publish'|'render'...

--- a/ayon_server/settings/enum.py
+++ b/ayon_server/settings/enum.py
@@ -186,8 +186,7 @@ async def _get_template_names_project(
     async for row in Postgres.iterate(query):
         templates = row["tpls"]
         template_category = templates.get(category, {})
-        for template_name in list(template_category.keys()):
-            template_names.append(template_name)
+        template_names.extend(template_category.keys())
     return template_names
 
 

--- a/ayon_server/settings/enum.py
+++ b/ayon_server/settings/enum.py
@@ -134,6 +134,10 @@ async def anatomy_presets_enum():
     return result
 
 
+#
+# Anatomy template items
+#
+
 TemplateItemsCategory = Literal[
     "work", "publish", "hero", "delivery", "others", "staging"
 ]

--- a/ayon_server/settings/enum.py
+++ b/ayon_server/settings/enum.py
@@ -141,14 +141,12 @@ TemplateItemsCategory = Literal[
 
 def anatomy_template_items_enum(
     category: TemplateItemsCategory,
-    project_name: str | None = None,
 ) -> functools.partial[Coroutine[Any, Any, list[dict[str, str]]]]:
     """Provides values of template names from Anatomy as dropdown.
 
     Wrapper for actual function as Settings require callable.
 
     Args:
-        project_name: str
         category: str: type of templates 'publish'|'render'...
 
     Returns:
@@ -156,7 +154,7 @@ def anatomy_template_items_enum(
 
     """
     return functools.partial(
-        _anatomy_template_items_enum, project_name=project_name, category=category
+        _anatomy_template_items_enum, project_name=None, category=category
     )
 
 


### PR DESCRIPTION
## Description of changes
Small enhancements for templates enum for settings.

### Technical details
Removed unnecessary `project_name` argument from enum function `anatomy_template_items_enum`. Whatever would be passed to the function would not be used anyways, so why to bother developer by having argument that does nothing?

Removed outdated information from docstring.

Avoid creation of <dict.Key> -> <list[str]> -> iterable[str] just to extend list.
