### PR TITLE
Use attribute whitelist for entity updates

### DIFF
--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -61,6 +61,6 @@ async def update_project_level_entity(
     if user:
         for event in events:
             event["user"] = user.name
-    entity.patch(payload)
+    entity.patch(payload, user=user)
     await entity.save(transaction=transaction)
     return entity, events, 204


### PR DESCRIPTION
This pull request includes several changes to the `ayon_server` module, primarily focusing on adding user permission checks and improving event handling for attribute changes. The most important changes are grouped by theme below:

### Permission Checks:

* Added `ForbiddenException` import to `ayon_server/entities/core/base.py` to handle unauthorized attribute modifications.
* Enhanced the `patch` method in `ayon_server/entities/core/base.py` to include user permission checks for attribute modifications, ensuring that unauthorized users cannot modify restricted attributes.
* Improved the `build_pl_entity_change_events` function in `ayon_server/events/patch.py` to better handle old and new attribute values, ensuring accurate event descriptions and payloads for attribute changes.
* Updated the `update_project_level_entity` function in `ayon_server/operations/project_level/entity_update.py` to pass the user object to the `patch` method, ensuring that user permissions are correctly applied during the patch operation.