### PR TITLE
Fixed invalid condition in action multiselection

### DIFF
--- a/api/actions/listing.py
+++ b/api/actions/listing.py
@@ -104,7 +104,7 @@ async def evaluate_simple_action(
         if not context.entity_ids:
             return False
 
-        if not action.allow_multiselection and len(context.entity_ids) != 1:
+        if not action.allow_multiselection and len(context.entity_ids) > 1:
             return False
 
         if action.entity_subtypes:

--- a/api/actions/listing.py
+++ b/api/actions/listing.py
@@ -104,7 +104,7 @@ async def evaluate_simple_action(
         if not context.entity_ids:
             return False
 
-        if action.allow_multiselection and len(context.entity_ids) != 1:
+        if not action.allow_multiselection and len(context.entity_ids) != 1:
             return False
 
         if action.entity_subtypes:


### PR DESCRIPTION
This pull request includes a correction to a conditional statement in the `evaluate_simple_action` function within the `api/actions/listing.py` file. This change ensures that the condition properly checks for the `allow_multiselection` attribute of the `action` object.