### PR TITLE
Polished service configuration updates

### DIFF
--- a/api/services/hosts.py
+++ b/api/services/hosts.py
@@ -1,9 +1,6 @@
 from datetime import datetime
 
-from fastapi import Depends
-
-from ayon_server.api.dependencies import NoTraces, dep_current_user
-from ayon_server.entities import UserEntity
+from ayon_server.api.dependencies import CurrentUser, NoTraces
 from ayon_server.exceptions import ForbiddenException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.types import Field, OPModel
@@ -59,7 +56,7 @@ class HeartbeatResponseModel(OPModel):
     response_model=HostListResponseModel,
     tags=["Services"],
 )
-async def list_hosts(user: UserEntity = Depends(dep_current_user)):
+async def list_hosts(user: CurrentUser):
     """Return a list of all hosts.
 
     A host is an instance of Ayon Service Host (ASH) that is capable of
@@ -79,10 +76,7 @@ async def list_hosts(user: UserEntity = Depends(dep_current_user)):
     tags=["Services"],
     dependencies=[NoTraces],
 )
-async def host_heartbeat(
-    payload: HeartbeatRequestModel,
-    user: UserEntity = Depends(dep_current_user),
-):
+async def host_heartbeat(payload: HeartbeatRequestModel, user: CurrentUser):
     """Send a heartbeat from a host.
 
     This endpoint is called by ASH to send a heartbeat to the API. The

--- a/api/services/services.py
+++ b/api/services/services.py
@@ -154,7 +154,6 @@ async def patch_service(
     service_data = dict(service_data_record)
 
     patch_dict = payload.dict(exclude_unset=True)
-    service_data["data"].update(patch_dict)
 
     if (should_run := patch_dict.pop("should_run", None)) is not None:
         service_data["should_run"] = should_run
@@ -162,7 +161,10 @@ async def patch_service(
     if (hostname := patch_dict.pop("hostname", None)) is not None:
         service_data["hostname"] = hostname
 
+    service_data["data"].update(patch_dict)
+
     if (patch_config := patch_dict.pop("config", None)) is not None:
+        # Old-style config (deprecated)
         service_data["data"].update(patch_config)
 
     await Postgres.execute(

--- a/api/services/services.py
+++ b/api/services/services.py
@@ -161,11 +161,13 @@ async def patch_service(
     if (hostname := patch_dict.pop("hostname", None)) is not None:
         service_data["hostname"] = hostname
 
-    service_data["data"].update(patch_dict)
-
+    # Old-style config (deprecated)
     if (patch_config := patch_dict.pop("config", None)) is not None:
-        # Old-style config (deprecated)
         service_data["data"].update(patch_config)
+
+    # at this point patch_dict should only contain config fields
+    # and this is the new style config that should take precedence
+    service_data["data"].update(patch_dict)
 
     await Postgres.execute(
         *SQLTool.update(

--- a/api/services/services.py
+++ b/api/services/services.py
@@ -133,7 +133,7 @@ class PatchServiceRequestModel(ServiceConfigModel):
         title="Config",
         deprecated=True,
         description="Deprecated, use top level fields instead",
-        example=None,
+        example={},
     )
 
 
@@ -163,7 +163,7 @@ async def patch_service(
         service_data["hostname"] = hostname
 
     if (patch_config := patch_dict.pop("config", None)) is not None:
-        patch_dict.update(patch_config)
+        service_data["data"].update(patch_config)
 
     await Postgres.execute(
         *SQLTool.update(


### PR DESCRIPTION
- Added `NoTraces` as a dependency to the `list_services` endpoint to ensure no traces are logged during service listing.
- Updated the `PatchServiceRequestModel` class to include a `hostname` field and marked the `config` field as deprecated for backwards compatibility.
- Refactored the `patch_service` function to handle service data updates more efficiently, including updating fields such as `should_run`, `hostname`, and nested `config` fields.

This is a backend counterpart to https://github.com/ynput/ayon-frontend/pull/1094

![image](https://github.com/user-attachments/assets/ae0a170e-209a-4eea-b091-b8aec2a07550)
