### PR TITLE
Propagate user to settings.changed events

### DIFF
--- a/api/addons/common.py
+++ b/api/addons/common.py
@@ -20,6 +20,7 @@ async def remove_override(
     path: list[str],
     variant: str = "production",
     project_name: str | None = None,
+    user_name: str | None = None,
 ):
     if (addon := AddonLibrary.addon(addon_name, addon_version)) is None:
         raise NotFoundException(f"Addon {addon_name} {addon_version} not found")
@@ -43,6 +44,7 @@ async def remove_override(
         overrides,
         variant=variant,
         project_name=project_name,
+        user_name=user_name,
     )
 
 
@@ -52,6 +54,7 @@ async def pin_override(
     path: list[str],
     variant: str = "production",
     project_name: str | None = None,
+    user_name: str | None = None,
 ):
     if (addon := AddonLibrary.addon(addon_name, addon_version)) is None:
         raise NotFoundException(f"Addon {addon_name} {addon_version} not found")
@@ -106,6 +109,7 @@ async def pin_override(
         overrides,
         variant=variant,
         project_name=project_name,
+        user_name=user_name,
     )
 
 

--- a/api/addons/project_settings.py
+++ b/api/addons/project_settings.py
@@ -214,6 +214,7 @@ async def set_addon_project_settings(
             addon_name=addon_name,
             addon_version=version,
             project_name=project_name,
+            user_name=user.name,
             variant=variant,
             data=data,
         )
@@ -277,6 +278,7 @@ async def delete_addon_project_overrides(
             addon_name=addon_name,
             addon_version=version,
             project_name=project_name,
+            user_name=user.name,
             variant=variant,
             data=None,
         )
@@ -351,6 +353,7 @@ async def modify_project_overrides(
             payload.path,
             project_name=project_name,
             variant=variant,
+            user_name=user.name,
         )
     elif payload.action == "pin":
         await pin_override(
@@ -359,6 +362,7 @@ async def modify_project_overrides(
             payload.path,
             project_name=project_name,
             variant=variant,
+            user_name=user.name,
         )
 
     return EmptyResponse()

--- a/api/addons/studio_settings.py
+++ b/api/addons/studio_settings.py
@@ -113,6 +113,7 @@ async def set_addon_studio_settings(
         addon_version,
         data,
         variant=variant,
+        user_name=user.name,
     )
 
     return EmptyResponse()
@@ -152,6 +153,7 @@ async def delete_addon_studio_overrides(
         addon_version,
         None,
         variant=variant,
+        user_name=user.name,
     )
     return EmptyResponse()
 
@@ -168,9 +170,21 @@ async def modify_studio_overrides(
         raise ForbiddenException
 
     if payload.action == "delete":
-        await remove_override(addon_name, addon_version, payload.path, variant=variant)
+        await remove_override(
+            addon_name,
+            addon_version,
+            payload.path,
+            variant=variant,
+            user_name=user.name,
+        )
     elif payload.action == "pin":
-        await pin_override(addon_name, addon_version, payload.path, variant=variant)
+        await pin_override(
+            addon_name,
+            addon_version,
+            payload.path,
+            variant=variant,
+            user_name=user.name,
+        )
 
     return EmptyResponse()
 

--- a/api/settings/settings.py
+++ b/api/settings/settings.py
@@ -129,9 +129,10 @@ async def get_all_settings(
             try:
                 addon = AddonLibrary.addon(addon_name, addon_version)
             except NotFoundException:
+                bundle_title = bundle_name or f"{variant} bundle"
                 logger.warning(
                     f"Addon {addon_name} {addon_version} "
-                    f"declared in {bundle_name} not found"
+                    f"declared in {bundle_title} not found"
                 )
 
                 broken_reason = AddonLibrary.is_broken(addon_name, addon_version)


### PR DESCRIPTION
This pull request introduces a new `user_name` parameter to several functions across multiple files to enhance user-specific tracking and logging. Additionally, it improves error logging for missing addons by including more descriptive bundle titles.