### PR TITLE
Use timestamptz casting when sorting timestamps

### DIFF
--- a/ayon_server/graphql/resolvers/activities.py
+++ b/ayon_server/graphql/resolvers/activities.py
@@ -150,6 +150,9 @@ async def get_activities(
         {ordering}
     """
 
+    # from ayon_server.logging import logger
+    # logger.trace(f"Querying activities: {query}")
+
     return await resolve(
         ActivitiesConnection,
         ActivityEdge,

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -40,7 +40,7 @@ def decode_cursor(cursor: str | None) -> tuple[list[str], list[str]]:
         for c in cur_data:
             if isinstance(c, str):
                 # Check if the value is a timestamp in ISO format
-                if re.match(r"^\d{4}-\d{2}-\d{2}T.*", c):
+                if re.match(r"^\d{4}-\d{2}-\d{2}T[0-9:\.\+\-Z]+$", c):
                     # Convert to timestamp
                     vals.append(f"'{c}'::timestamptz")
                     casts.append("::timestamptz")

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -1,3 +1,4 @@
+import re
 from base64 import b64decode, b64encode
 from typing import Any
 
@@ -38,9 +39,15 @@ def decode_cursor(cursor: str | None) -> tuple[list[str], list[str]]:
         casts = []
         for c in cur_data:
             if isinstance(c, str):
-                val = c.replace("'", "''")
-                vals.append(f"'{val}'::text")
-                casts.append("::text")
+                # Check if the value is a timestamp in ISO format
+                if re.match(r"^\d{4}-\d{2}-\d{2}T.*", c):
+                    # Convert to timestamp
+                    vals.append(f"'{c}'::timestamptz")
+                    casts.append("::timestamptz")
+                else:
+                    val = c.replace("'", "''")
+                    vals.append(f"'{val}'::text")
+                    casts.append("::text")
             else:
                 vals.append(f"{c}::numeric")
                 casts.append("::numeric")


### PR DESCRIPTION
This pull request introduces minor logging enhancements and a new feature to handle ISO timestamp values in cursor decoding for GraphQL resolvers. 

Added a regular expression check to identify ISO timestamp values in the `decode_cursor` function. If a match is found, the value is converted to a PostgreSQL `timestamptz` format for proper handling.