### PR TITLE
Fallback status for entities

### DIFF
--- a/ayon_server/helpers/statuses.py
+++ b/ayon_server/helpers/statuses.py
@@ -1,5 +1,6 @@
 from ayon_server.exceptions import AyonException
 from ayon_server.lib.postgres import Postgres
+from ayon_server.logging import logger
 
 
 async def get_default_status_for_entity(
@@ -13,14 +14,26 @@ async def get_default_status_for_entity(
         ORDER BY position ASC
     """
 
+    fallback_status: str | None = None
+
     async for row in Postgres.iterate(query):
         name = row["name"]
         data = row["data"]
+
+        if fallback_status is None:
+            fallback_status = name
 
         if (entity_scope_filter := data.get("scope")) is not None:
             if entity_type not in entity_scope_filter:
                 continue
 
         return name
+
+    if fallback_status is not None:
+        logger.warning(
+            f"Default status for {entity_type} not found, "
+            f"using fallback: {fallback_status}"
+        )
+        return fallback_status
 
     raise AyonException("No default status available")


### PR DESCRIPTION
This pull request introduces a fallback mechanism and logging enhancements to the `get_default_status_for_entity` function in `ayon_server/helpers/statuses.py`. These changes improve error handling and provide better visibility into fallback behavior when a default status is not found.