### PR TITLE
Get project tags endpoint

### DIFF
--- a/api/projects/__init__.py
+++ b/api/projects/__init__.py
@@ -6,8 +6,9 @@ __all__ = [
     "list_projects",
     "projects",
     "roots",
+    "tags",
     "users",
 ]
 
-from . import anatomy, bundle, deploy, list_projects, projects, roots, users
+from . import anatomy, bundle, deploy, list_projects, projects, roots, tags, users
 from .router import router

--- a/api/projects/tags.py
+++ b/api/projects/tags.py
@@ -1,0 +1,66 @@
+from ayon_server.api.dependencies import CurrentUser, ProjectName
+from ayon_server.lib.postgres import Postgres
+from ayon_server.logging import logger
+from ayon_server.types import OPModel
+
+from .router import router
+
+
+class ProjectTagsModel(OPModel):
+    folders: list[str]
+    tasks: list[str]
+    products: list[str]
+    versions: list[str]
+    representations: list[str]
+    workfiles: list[str]
+
+
+@router.get("/projects/{project_name}/tags")
+async def get_project_tags(
+    user: CurrentUser,
+    project_name: ProjectName,
+) -> ProjectTagsModel:
+    """List tags used in the project."""
+
+    query = """
+        select jsonb_object_agg(table_name, tags_array) as res
+        from (
+          select 'folders' as table_name, array_agg(distinct tag) as tags_array
+          from folders, unnest(folders.tags) as tag
+
+          union all
+
+          select 'tasks', array_agg(distinct tag)
+          from tasks, unnest(tasks.tags) as tag
+
+          union all
+
+          select 'products', array_agg(distinct tag)
+          from products, unnest(products.tags) as tag
+
+          union all
+
+          select 'versions', array_agg(distinct tag)
+          from versions, unnest(versions.tags) as tag
+
+          union all
+
+          select 'representations', array_agg(distinct tag)
+          from representations, unnest(representations.tags) as tag
+
+          union all
+
+          select 'workfiles', array_agg(distinct tag)
+          from workfiles, unnest(workfiles.tags) as tag
+        ) sub;
+
+        """
+
+    async with Postgres.acquire() as conn, conn.transaction():
+        await conn.execute(f"set local search_path to project_{project_name}")
+        result = await conn.fetchrow(query)
+
+        result = dict(result["res"]) if result else {}
+        logger.debug(f"{result}")
+
+        return ProjectTagsModel(**result)

--- a/api/projects/tags.py
+++ b/api/projects/tags.py
@@ -1,18 +1,50 @@
+from typing import Annotated
+
 from ayon_server.api.dependencies import CurrentUser, ProjectName
 from ayon_server.lib.postgres import Postgres
-from ayon_server.logging import logger
-from ayon_server.types import OPModel
+from ayon_server.types import Field, OPModel
 
 from .router import router
 
 
 class ProjectTagsModel(OPModel):
-    folders: list[str]
-    tasks: list[str]
-    products: list[str]
-    versions: list[str]
-    representations: list[str]
-    workfiles: list[str]
+    folders: Annotated[list[str], Field(default_factory=list)]
+    tasks: Annotated[list[str], Field(default_factory=list)]
+    products: Annotated[list[str], Field(default_factory=list)]
+    versions: Annotated[list[str], Field(default_factory=list)]
+    representations: Annotated[list[str], Field(default_factory=list)]
+    workfiles: Annotated[list[str], Field(default_factory=list)]
+
+
+QUERY = """
+      select 'folders' as table_name, array_agg(distinct tag) as tags_array
+      from folders, unnest(folders.tags) as tag
+
+      union all
+
+      select 'tasks', array_agg(distinct tag)
+      from tasks, unnest(tasks.tags) as tag
+
+      union all
+
+      select 'products', array_agg(distinct tag)
+      from products, unnest(products.tags) as tag
+
+      union all
+
+      select 'versions', array_agg(distinct tag)
+      from versions, unnest(versions.tags) as tag
+
+      union all
+
+      select 'representations', array_agg(distinct tag)
+      from representations, unnest(representations.tags) as tag
+
+      union all
+
+      select 'workfiles', array_agg(distinct tag)
+      from workfiles, unnest(workfiles.tags) as tag
+"""
 
 
 @router.get("/projects/{project_name}/tags")
@@ -22,45 +54,12 @@ async def get_project_tags(
 ) -> ProjectTagsModel:
     """List tags used in the project."""
 
-    query = """
-        select jsonb_object_agg(table_name, tags_array) as res
-        from (
-          select 'folders' as table_name, array_agg(distinct tag) as tags_array
-          from folders, unnest(folders.tags) as tag
-
-          union all
-
-          select 'tasks', array_agg(distinct tag)
-          from tasks, unnest(tasks.tags) as tag
-
-          union all
-
-          select 'products', array_agg(distinct tag)
-          from products, unnest(products.tags) as tag
-
-          union all
-
-          select 'versions', array_agg(distinct tag)
-          from versions, unnest(versions.tags) as tag
-
-          union all
-
-          select 'representations', array_agg(distinct tag)
-          from representations, unnest(representations.tags) as tag
-
-          union all
-
-          select 'workfiles', array_agg(distinct tag)
-          from workfiles, unnest(workfiles.tags) as tag
-        ) sub;
-
-        """
-
     async with Postgres.acquire() as conn, conn.transaction():
         await conn.execute(f"set local search_path to project_{project_name}")
-        result = await conn.fetchrow(query)
-
-        result = dict(result["res"]) if result else {}
-        logger.debug(f"{result}")
-
-        return ProjectTagsModel(**result)
+        result = await conn.fetch(QUERY)
+        data = {}
+        for row in result:
+            table_name = row["table_name"]
+            tags_array = row["tags_array"]
+            data[table_name] = tags_array or []
+        return ProjectTagsModel(**data)


### PR DESCRIPTION
This pull request introduces a new feature to support retrieving tags associated with various project entities. The changes include adding a new API endpoint and updating the project module imports to include the new functionality.

### New feature: Project tags API

* **Added a new API endpoint to list tags for a project**: Introduced the `get_project_tags` function in `api/projects/tags.py`, which queries the database to retrieve distinct tags for various project entities (folders, tasks, products, versions, representations, and workfiles). The endpoint returns the tags in a structured format defined by the new `ProjectTagsModel` class.
