### PR TITLE
Sanity check for dev bundle settings migration

### DIFF
--- a/api/bundles/migration.py
+++ b/api/bundles/migration.py
@@ -83,7 +83,7 @@ async def _migrate_settings_by_bundle(
     addons_to_migrate = set(source_addons.keys()) & set(target_addons.keys())
 
     logger.debug(
-        f"Migratig settings from {source_bundle} ({source_variant}) "
+        f"Migrating settings from {source_bundle} ({source_variant}) "
         f"to {target_bundle} ({target_variant})"
     )
 

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -319,9 +319,7 @@ class BaseServerAddon:
                 SELECT data FROM settings
                 WHERE addon_name = $1 AND addon_version = $2 AND variant = $3
                 """
-            res = await Postgres.fetch(
-                query, self.definition.name, self.version, variant
-            )
+            res = await Postgres.fetch(query, self.name, self.version, variant)
             if res:
                 data = res[0]["data"]
 


### PR DESCRIPTION
Added validation to ensure `source_variant` and `target_variant` are either "production" or "staging," or match their respective bundles when not. If these conditions are not met, a `BadRequestException` is raised.