### PR TITLE
Entity list items filtering

### DIFF
--- a/ayon_server/api/logging.py
+++ b/ayon_server/api/logging.py
@@ -110,6 +110,7 @@ def handle_undhandled_exception(request: Request, exc: Exception) -> JSONRespons
 
     path_prefix = f"{os.getcwd()}/"
     formatted = "".join(traceback.format_exception_only(type(exc), exc)).strip()
+    formatted = formatted.replace("{", "{{").replace("}", "}}")
     tb = traceback.extract_tb(exc.__traceback__)
     traceback_msg = ""
     for frame in tb[-20:]:

--- a/ayon_server/graphql/__init__.py
+++ b/ayon_server/graphql/__init__.py
@@ -207,7 +207,7 @@ class AyonSchema(strawberry.Schema):
                 else:
                     path = ""
 
-                message = error.message
+                message = error.message.replace("{", "{{").replace("}", "}}")
                 logger.error(
                     f"[GRAPHQL] Error resolving {path} (line {line_no}): {message}",
                     module=fname,

--- a/ayon_server/graphql/nodes/entity_list.py
+++ b/ayon_server/graphql/nodes/entity_list.py
@@ -196,6 +196,7 @@ class EntityListNode:
         before: str | None = None,
         sort_by: str | None = None,
         accessible_only: bool = False,
+        filter: str | None = None,
     ) -> EntityListItemsConnection:
         if first is None and last is None:
             first = 200
@@ -209,6 +210,7 @@ class EntityListNode:
             last=last,
             before=before,
             sort_by=sort_by,
+            filter=filter,
             accessible_only=accessible_only,
         )
 

--- a/ayon_server/graphql/nodes/entity_list.py
+++ b/ayon_server/graphql/nodes/entity_list.py
@@ -24,6 +24,7 @@ class EntityListItemEdge(BaseEdge):
     position: int = strawberry.field(default=0)
 
     attrib: str = strawberry.field(default="{}")
+    folder_path: str = strawberry.field(default="")
 
     tags: list[str] = strawberry.field(default_factory=list)
 
@@ -109,9 +110,9 @@ class EntityListItemEdge(BaseEdge):
                 # logger.trace(f"Using {getter_name} to get entity")
                 entity = getter(project_name, vdict, context)
 
+        folder_path = record.get("folder_path", "")
         node_access_forbidden = False
         if access_checker := (context or {}).get("access_checker"):
-            folder_path = record.get("folder_path")
             if folder_path and not access_checker[folder_path]:
                 logger.trace(f"Access denied for {folder_path}")
                 node_access_forbidden = True
@@ -122,6 +123,7 @@ class EntityListItemEdge(BaseEdge):
             entity_type=context["entity_type"],
             entity_id=record["entity_id"],
             position=record["position"],
+            folder_path=folder_path,
             tags=record["tags"] or [],
             created_by=record["created_by"],
             updated_by=record["updated_by"],

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -262,6 +262,7 @@ async def get_entity_list_items(
             [
                 "pf.folder_type as _parent_folder_type",
                 "pd.product_type as _parent_product_type",
+                "pt.task_type as _parent_task_type",
             ]
         )
         sql_joins.extend(
@@ -269,14 +270,18 @@ async def get_entity_list_items(
                 f"""
                 INNER JOIN project_{project_name}.products AS pd
                 ON e.product_id = pd.id
-            """,
+                """,
                 f"""
                 INNER JOIN project_{project_name}.folders AS pf
                 ON pd.folder_id = pf.id
-            """,
+                """,
+                """
+                LEFT JOIN project_{project_name}.tasks AS pt
+                ON e.task_id = pt.id
+                """,
             ]
         )
-        allowed_parent_keys = ["folder_type", "product_type"]
+        allowed_parent_keys = ["folder_type", "product_type", "task_type"]
 
     # The rest of the entity types should work out of the box
 

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -130,6 +130,7 @@ async def get_entity_list_items(
     last: ARGLast = None,
     before: ARGBefore = None,
     sort_by: str | None = None,
+    filter: str | None = None,
     accessible_only: bool = False,
 ) -> EntityListItemsConnection:
     project_name = root.project_name
@@ -200,6 +201,11 @@ async def get_entity_list_items(
     )
     for col in cols:
         sql_columns.append(f"e.{col} as _entity_{col}")
+
+    # Unified attributes
+    # Create additions column
+    # if entity_type == "folder":
+    #     s
 
     # Special cases:
 
@@ -289,6 +295,10 @@ async def get_entity_list_items(
         {SQLTool.conditions(sql_conditions)}
         {ordering}
     """
+
+    from ayon_server.logging import logger
+
+    logger.debug(f"Entity list items query: {query}")
 
     return await resolve(
         EntityListItemsConnection,

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -217,7 +217,7 @@ async def get_entity_list_items(
             [
                 "px.attrib as _entity_inherited_attributes",
                 "pr.attrib as _entity_project_attributes",
-                "px.folder_type as _parent_folder_type",
+                "pf.folder_type as _parent_folder_type",
                 "hierarchy.path AS _entity_path",
             ]
         )

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -275,7 +275,7 @@ async def get_entity_list_items(
                 INNER JOIN project_{project_name}.folders AS pf
                 ON pd.folder_id = pf.id
                 """,
-                """
+                f"""
                 LEFT JOIN project_{project_name}.tasks AS pt
                 ON e.task_id = pt.id
                 """,

--- a/ayon_server/graphql/resolvers/entity_lists.py
+++ b/ayon_server/graphql/resolvers/entity_lists.py
@@ -32,7 +32,8 @@ SORT_OPTIONS = {
 FILTER_OPTIONS = [
     "label",
     "owner",
-    "entity_typeentity_list_type",
+    "entity_type",
+    "entity_list_type",
     "created_at",
     "updated_at",
     "count",

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -2,7 +2,7 @@ import json
 import re
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import StrictFloat, StrictInt, StrictStr, validator
+from pydantic import StrictBool, StrictFloat, StrictInt, StrictStr, validator
 
 from ayon_server.logging import logger
 from ayon_server.types import Field, OPModel
@@ -11,6 +11,7 @@ ValueType = (
     StrictStr
     | StrictInt
     | StrictFloat
+    | StrictBool
     | list[StrictStr]
     | list[StrictInt]
     | list[StrictFloat]
@@ -331,6 +332,10 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
         raise ValueError(f"Invalid value: {value}")
 
     if operator == "eq":
+        if type(value) is bool:
+            if value:
+                return f"coalesce({column}, 'false'::jsonb)::boolean"
+            return f"NOT coalesce({column}, 'false'::jsonb)::boolean"
         return f"{column} = {safe_value}"
     elif operator == "like":
         return f"{column} ILIKE {safe_value}"


### PR DESCRIPTION
This pull request introduces significant enhancements to the filtering and sorting capabilities of the `entity_list_items` query in the GraphQL API, along with related changes to improve maintainability and functionality. The most important updates include adding a new `filter` parameter to support advanced filtering, refactoring column naming conventions for consistency, and implementing unified attributes for sorting and filtering. 

### Unified attributes

For filtering and sorting `attrib` field unifies entity attributes with list items attributes:

Assuming we're loading a list of tasks:

```graphql
items(sortBy: "attrib.priority"){
  ...
}
```

Sorting will use the following fields to determine the actual value to sort by in this order:

- list item attribute (if the priority is set on the item level)
- task attribute
- folder attribute
- parent folder or project attribute

The same logic is applied for filtering

```graphql
items(filter:"{\"conditions\":[{\"key\": \"attrib.priority\", \"value\":\"high\"}]}){
  ...
}
```

### Entity fields

When filtering or sorting by entity fiels (such as `id`, `status`, `name`, `label`, etc. ). It is necessary to prefix the field with `entity_`. 
The algorithm normalizes snake/camel case variants of the fields, so the following variants will produce the same result.

```graphql
items(sortBy: "entity_created_at"){
  ...
}

items(sortBy: "entity_createdAt"){
  ...
}
```

It is possible to filter by all non-dynamic fields of an entity. That means you cannot use:

- `entity_parents` for folder lists
- `entity_name` for version lists

and similar (these fields are not stored in the database, but generated on the fly)


### Item fields

It is possible to sort by the following item fields, by default graphql sorts by `position`:

- `position`
- `label`
- `createdAt`
- `updatedAt`
- `createdBy`
- `updatedBy`
- `folderPath`

Again, both camelCase and snake_case variants are supported. This is unique to list_items and will be gradually adopted in other resolvers

Additionally, filtering accepts all fields as the sorter, plus the following ones:

- `id`
- `entityId`
- `entityListId`
- `data`
- `tags`

