### PR TITLE
Renaming anatomy presets

### DIFF
--- a/api/anatomy/__init__.py
+++ b/api/anatomy/__init__.py
@@ -136,43 +136,76 @@ async def set_primary_preset(preset_name: str, user: CurrentUser) -> EmptyRespon
     if not user.is_manager:
         raise ForbiddenException("Only managers can set primary preset.")
 
-    async with Postgres.acquire() as conn:
-        async with conn.transaction():
-            await conn.execute(
+    async with Postgres.transaction():
+        await Postgres.execute(
+            """
+            UPDATE anatomy_presets
+            SET is_primary = FALSE
+            WHERE is_primary = TRUE
+            """
+        )
+        if preset_name != "_":
+            await Postgres.execute(
                 """
                 UPDATE anatomy_presets
-                SET is_primary = FALSE
-                WHERE is_primary = TRUE
-                """
+                SET is_primary = TRUE
+                WHERE name = $1
+                """,
+                preset_name,
             )
-            if preset_name != "_":
-                await conn.execute(
-                    """
-                    UPDATE anatomy_presets
-                    SET is_primary = TRUE
-                    WHERE name = $1
-                    """,
-                    preset_name,
-                )
     return EmptyResponse()
 
 
+@router.delete("/presets/{preset_name}/primary", status_code=204)
 async def unset_primary_preset(preset_name: str, user: CurrentUser) -> EmptyResponse:
     """Unset the primary preset."""
 
     if not user.is_manager:
         raise ForbiddenException("Only managers can unset primary preset.")
 
-    async with Postgres.acquire() as conn:
-        async with conn.transaction():
-            await conn.execute(
-                """
-                UPDATE anatomy_presets
-                SET is_primary = FALSE
-                WHERE name = $1
-                """,
-                preset_name,
-            )
+    async with Postgres.transaction():
+        await Postgres.execute(
+            """
+            UPDATE anatomy_presets
+            SET is_primary = FALSE
+            WHERE name = $1
+            """,
+            preset_name,
+        )
+    return EmptyResponse()
+
+
+class RenamePresetModel(OPModel):
+    name: str = Field(
+        ...,
+        title="New name of the anatomy preset",
+        description="The new name of the anatomy preset.",
+    )
+
+
+@router.post("/presets/{preset_name}/rename", status_code=204)
+async def rename_anatomy_preset(
+    preset_name: str,
+    user: CurrentUser,
+    payload: RenamePresetModel,
+) -> EmptyResponse:
+    """Set the given preset as the primary preset."""
+
+    if not user.is_manager:
+        raise ForbiddenException("Only managers can set primary preset.")
+
+    query = """
+        UPDATE anatomy_presets
+        SET name = $1
+        WHERE name = $2
+        RETURNING *
+    """
+
+    res = await Postgres.fetch(query, payload.name, preset_name)
+
+    if not res:
+        raise NotFoundException(f"Anatomy preset {preset_name} not found.")
+
     return EmptyResponse()
 
 
@@ -183,14 +216,13 @@ async def delete_anatomy_preset(preset_name: str, user: CurrentUser) -> EmptyRes
     if not user.is_manager:
         raise ForbiddenException("Only managers can set primary preset.")
 
-    async with Postgres.acquire() as conn:
-        async with conn.transaction():
-            await conn.execute(
-                """
-                DELETE FROM anatomy_presets
-                WHERE name = $1
-                """,
-                preset_name,
-            )
+    async with Postgres.transaction():
+        await Postgres.execute(
+            """
+            DELETE FROM anatomy_presets
+            WHERE name = $1
+            """,
+            preset_name,
+        )
 
     return EmptyResponse()


### PR DESCRIPTION
This pull request introduces several updates to the `api/anatomy/__init__.py` file, primarily focusing on simplifying database transaction handling and adding a new feature for renaming anatomy presets. The most significant changes include replacing nested transaction handling with a streamlined approach, introducing a new endpoint for renaming presets, and ensuring consistency in permission checks.

This requires a frontend counterpart.