### PR TITLE
Use pydantic strict types for simple form values

### DIFF
--- a/ayon_server/forms/simple_form.py
+++ b/ayon_server/forms/simple_form.py
@@ -1,5 +1,7 @@
 from typing import Any, Literal, NotRequired, TypedDict
 
+from pydantic import StrictBool, StrictFloat, StrictInt, StrictStr
+
 SimpleFormFieldType = Literal[
     "text",
     "boolean",
@@ -25,12 +27,23 @@ class FormSelectOption(TypedDict):
     color: NotRequired[str]
 
 
+ValueType = (
+    StrictStr
+    | StrictInt
+    | StrictFloat
+    | StrictBool
+    | list[StrictStr]
+    | list[StrictInt]
+    | list[StrictFloat]
+)
+
+
 class SimpleFormField(TypedDict):
     type: SimpleFormFieldType
     name: str
     label: NotRequired[str]
     placeholder: NotRequired[Any]
-    value: NotRequired[str | int | float | bool | list[str]]
+    value: NotRequired[ValueType]
     regex: NotRequired[str]
     multiline: NotRequired[bool]
     syntax: NotRequired[str]


### PR DESCRIPTION
This pull request refactors the `SimpleFormField` class in `ayon_server/forms/simple_form.py` to improve type safety and maintainability by introducing stricter type definitions using Pydantic's `Strict*` types. The most important changes include the addition of a new `ValueType` union and the replacement of the `value` field's type with this new definition.