### PR TITLE
List actions

### DIFF
--- a/api/actions/listing.py
+++ b/api/actions/listing.py
@@ -170,10 +170,9 @@ async def evaluate_simple_action(
                     context.entity_subtypes,
                 )
 
-            else:
-                # Normal project level entities. Just a simple subtype match
-                if not set(action.entity_subtypes) & set(context.entity_subtypes):
-                    return False
+            # Normal project level entities. Just a simple subtype match:
+            # if we have an overlapping subtype, we can run the action
+            return bool(set(action.entity_subtypes) & set(context.entity_subtypes))
 
     return True
 

--- a/ayon_server/actions/context.py
+++ b/ayon_server/actions/context.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from pydantic import validator
 
@@ -29,13 +29,12 @@ class ActionContext(OPModel):
     ] = None
 
     entity_type: Annotated[
-        ProjectLevelEntityType | None,
+        ProjectLevelEntityType | Literal["list"] | None,
         Field(
             title="Entity Type",
             description=(
-                "The type of the entity. "
-                "If not specified, project-lever "
-                "or global actions are used."
+                "The type of the entity. Either a project level entity, 'list' "
+                "or None for project-wide actions. "
             ),
             example="folder",
         ),
@@ -105,6 +104,7 @@ class ActionContext(OPModel):
             self.project_name is None
             or self.entity_type is None
             or self.entity_ids is None
+            or self.entity_type == "list"
         ):
             return []
 

--- a/ayon_server/entity_lists/entity_list.py
+++ b/ayon_server/entity_lists/entity_list.py
@@ -53,6 +53,14 @@ class EntityList:
     def items(self) -> list[EntityListItemModel]:
         return self._payload.items
 
+    @property
+    def entity_type(self) -> ProjectLevelEntityType:
+        return self._payload.entity_type
+
+    @property
+    def entity_list_type(self) -> str:
+        return self._payload.entity_list_type
+
     async def ensure_access_level(
         self, user: UserEntity | None = None, level: int = 0
     ) -> None:


### PR DESCRIPTION
This pull request updates the `ActionContext` class in `ayon_server/actions/context.py` to include support for a new entity type, `"list"`. It also adjusts the logic in the `get_entities` method to account for this addition.


## List matching

### action.entity_subtypes

- always includes the contained entity type (version, folder, etc.)
- optionally includes the list type: "version:review-session"

### context.entity_subtypes

always includes both parts: "version:review-session"

### Matching Rules

An action_subtype matches a context_subtype if:

- The contained type matches (version == version)
- If action_subtype includes a list type, it must also match (review-session)
- If action_subtype doesn't include a list type,  it's considered a wildcard (matches all list types  of that entity type)

### Example

manifest subtype | context subtype | Match?
-- | -- | --
`version` | `version:review-session` | ✅
`version:review-session` | `version:review-session` | ✅
`version:some-other` | `version:review-session` | ❌
`folder` | `version:review-session` | ❌

