### PR TITLE
Typing: FrontendScopes and FrontendModules models

### DIFF
--- a/api/addons/list_addons.py
+++ b/api/addons/list_addons.py
@@ -4,7 +4,7 @@ import semver
 from fastapi import Query, Request
 
 from ayon_server.addons import AddonLibrary
-from ayon_server.addons.models import SourceInfo, SourceInfoTypes
+from ayon_server.addons.models import FrontendScopes, SourceInfo, SourceInfoTypes
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.lib.redis import Redis
 from ayon_server.logging import logger
@@ -17,7 +17,7 @@ from .router import router
 class VersionInfo(OPModel):
     has_settings: bool = Field(default=False)
     has_site_settings: bool = Field(default=False)
-    frontend_scopes: dict[str, Any] = Field(default_factory=dict)
+    frontend_scopes: FrontendScopes = Field(default_factory=dict)
     client_pyproject: dict[str, Any] | None = Field(None)
     client_source_info: list[SourceInfo] | None = Field(None)
     services: dict[str, Any] | None = Field(None)

--- a/api/system/frontend_modules.py
+++ b/api/system/frontend_modules.py
@@ -1,4 +1,5 @@
 from ayon_server.addons.library import AddonLibrary
+from ayon_server.addons.models import FrontendModules
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.types import OPModel
 
@@ -8,7 +9,7 @@ from .router import router
 class FrontendModuleListItem(OPModel):
     addon_name: str
     addon_version: str
-    modules: dict[str, list[str]]
+    modules: FrontendModules
 
 
 @router.get("/frontendModules")

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -17,7 +17,13 @@ from ayon_server.actions.manifest import (
     DynamicActionManifest,
     SimpleActionManifest,
 )
-from ayon_server.addons.models import ServerSourceInfo, SourceInfo, SSOOption
+from ayon_server.addons.models import (
+    FrontendModules,
+    FrontendScopes,
+    ServerSourceInfo,
+    SourceInfo,
+    SSOOption,
+)
 from ayon_server.addons.settings_caching import AddonSettingsCache
 from ayon_server.exceptions import AyonException, BadRequestException, NotFoundException
 from ayon_server.lib.postgres import Postgres
@@ -69,8 +75,8 @@ class BaseServerAddon:
     settings_model: type[BaseSettingsModel] | None = None
     site_settings_model: type[BaseSettingsModel] | None = None
     app_host_name: str | None = None
-    frontend_scopes: dict[str, Any] = {}
-    frontend_modules: dict[str, Any] = {}
+    frontend_scopes: FrontendScopes = {}
+    frontend_modules: FrontendModules = {}
 
     compatibility: AddonCompatibilityModel | None = None
 
@@ -214,10 +220,10 @@ class BaseServerAddon:
             }
         )
 
-    async def get_frontend_scopes(self) -> dict[str, Any]:
+    async def get_frontend_scopes(self) -> FrontendScopes:
         return self.frontend_scopes
 
-    async def get_frontend_modules(self) -> dict[str, Any]:
+    async def get_frontend_modules(self) -> FrontendModules:
         return self.frontend_modules
 
     #

--- a/ayon_server/addons/models.py
+++ b/ayon_server/addons/models.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, NotRequired, TypedDict
 
 from ayon_server.types import Field, OPModel
 
@@ -47,3 +47,16 @@ class SSOOption(OPModel):
 
 SourceInfo = FilesystemSourceInfo | ServerSourceInfo | HttpSourceInfo
 SourceInfoTypes = (FilesystemSourceInfo, ServerSourceInfo, HttpSourceInfo)
+
+
+FrontendScope = Literal["settings", "project", "dashboard"]
+
+
+class FrontendScopeSettings(TypedDict):
+    admin: NotRequired[bool]  # Available for admin users only
+    manager: NotRequired[bool]  # Available for manager users only
+    sidebar: NotRequired[str]  # Sidebar name
+
+
+FrontendScopes = dict[FrontendScope, FrontendScopeSettings]
+FrontendModules = dict[str, list[str]]

--- a/ayon_server/addons/models.py
+++ b/ayon_server/addons/models.py
@@ -58,5 +58,7 @@ class FrontendScopeSettings(TypedDict):
     sidebar: NotRequired[str]  # Sidebar name
 
 
+# FrontendScopes is a dictionary that maps frontend scope names (e.g., "settings", "project", "dashboard")
+# to their respective settings, which define access and display properties for different user roles.
 FrontendScopes = dict[FrontendScope, FrontendScopeSettings]
 FrontendModules = dict[str, list[str]]


### PR DESCRIPTION
This pull request introduces new type definitions for `FrontendScopes` and `FrontendModules` in the `ayon_server.addons.models` module and updates their usage across several files to improve type safety and consistency. The changes primarily focus on replacing generic dictionary types with these new type definitions.

![image](https://github.com/user-attachments/assets/1e951326-949f-4d3b-9635-dc3a7bff0a00)
