### PR TITLE
hasReviewables node on version entity list items

### DIFF
--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -73,11 +73,13 @@ class FieldInfo:
             name: str | None = None,
         ) -> Generator[str, None, None]:
             for field in fields:
-                if not hasattr(field, "name"):
-                    continue
-                fname = name + "." + field.name if name else field.name
-                yield fname
-                yield from parse_fields(field.selections, fname)
+                if hasattr(field, "name"):
+                    fname = name + "." + field.name if name else field.name
+                    yield fname
+                    yield from parse_fields(field.selections, fname)
+
+                elif hasattr(field, "selections"):
+                    yield from parse_fields(field.selections, None)
 
         self.fields: list[str] = []
         for field in parse_fields(info.selected_fields):

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -287,8 +287,6 @@ async def get_entity_list_items(
         allowed_parent_keys = ["folder_type", "product_type", "task_type"]
 
         # For versions, we also need hasReviewables
-        for field in fields:
-            print(field)
         if fields.any_endswith("hasReviewables"):
             sql_cte.append(
                 f"""

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -27,6 +27,7 @@ from ayon_server.graphql.resolvers.common import (
     ARGBefore,
     ARGFirst,
     ARGLast,
+    FieldInfo,
     create_folder_access_list,
     resolve,
 )
@@ -132,11 +133,13 @@ async def get_entity_list_items(
             )
     else:
         info.context["entity_type"] = entity_type
+    fields = FieldInfo(info, None)
 
     #
     # entity_list_items columns
     #
 
+    sql_cte = []
     sql_joins = []
     sql_columns = [f"i.{col} {col}" for col in COLS_ITEMS]
     sql_conditions = [f"entity_list_id = '{root.id}'"]
@@ -283,6 +286,28 @@ async def get_entity_list_items(
         )
         allowed_parent_keys = ["folder_type", "product_type", "task_type"]
 
+        # For versions, we also need hasReviewables
+        for field in fields:
+            print(field)
+        if fields.any_endswith("hasReviewables"):
+            sql_cte.append(
+                f"""
+                reviewables AS (
+                    SELECT entity_id FROM project_{project_name}.activity_feed
+                    WHERE entity_type = 'version'
+                    AND   activity_type = 'reviewable'
+                )
+                """
+            )
+
+            sql_columns.append(
+                """
+                EXISTS (
+                SELECT 1 FROM reviewables WHERE entity_id = e.id
+                ) AS _entity_has_reviewables
+                """
+            )
+
     # The rest of the entity types should work out of the box
 
     # Unified attributes
@@ -388,9 +413,15 @@ async def get_entity_list_items(
 
     #
     # Construct the query
-    #
+
+    if sql_cte:
+        cte = ", ".join(sql_cte)
+        cte = f"WITH {cte}"
+    else:
+        cte = ""
 
     query = f"""
+        {cte}
         SELECT {cursor}, * FROM (
             SELECT
             {", ".join(sql_columns)}


### PR DESCRIPTION
hasReviewables flag on fragments was not populated in version entity list. this is now fixed, so it is possible to get this information per entity list item.

![image](https://github.com/user-attachments/assets/4f42fce2-85c6-4cc2-ad18-1f97dd7cd73f)
