### PR TITLE
Use explicit 'project' entityType for project-wide actions

### DIFF
--- a/api/actions/listing.py
+++ b/api/actions/listing.py
@@ -154,6 +154,10 @@ async def evaluate_simple_action(
         return False
 
     if context.entity_type:
+        if context.entity_type == "project" and context.project_name:
+            # Project level actions are always available for the project context
+            return True
+
         if not context.entity_ids:
             return False
 

--- a/ayon_server/actions/context.py
+++ b/ayon_server/actions/context.py
@@ -29,12 +29,12 @@ class ActionContext(OPModel):
     ] = None
 
     entity_type: Annotated[
-        ProjectLevelEntityType | Literal["list"] | None,
+        ProjectLevelEntityType | Literal["list"] | Literal["project"] | None,
         Field(
             title="Entity Type",
             description=(
                 "The type of the entity. Either a project level entity, 'list' "
-                "or None for project-wide actions. "
+                "or 'project' for project-wide actions. or None for global actions."
             ),
             example="folder",
         ),


### PR DESCRIPTION
This pull request introduces support for a new `project` entity type in the action evaluation logic, ensuring project-wide actions are properly handled. The changes include updates to the `ActionContext` model and the `evaluate_simple_action` function.

Extended the `entity_type` field in the `ActionContext` model to include the new `"project"` literal, clarifying its role in project-wide actions. Updated the field description to reflect this addition.

> [!WARNING]  
> This is a breaking change as originally the server expected `entity_type=None` for project-wide actions. 
> But since this is not yet used in any official addon in production, we can implement this change.

This PR requires https://github.com/ynput/ayon-frontend/pull/1195 to be merged at the same time.