### PR TITLE
Support 'syntax' argument for settings field

### DIFF
--- a/ayon_server/settings/settings_field.py
+++ b/ayon_server/settings/settings_field.py
@@ -43,6 +43,7 @@ def SettingsField(
     required_items: list[str] | None = None,
     section: str | None = None,
     widget: str | None = None,
+    syntax: str | None = None,
     layout: str | None = None,
     tags: list[str] | None = None,
     scope: list[str] | None = None,
@@ -102,6 +103,11 @@ def SettingsField(
         extra["scope"] = scope
     if disabled is not None:
         extra["disabled"] = disabled
+    if syntax is not None:
+        if widget != "textarea":
+            m = "SettingsField: syntax is only supported for textarea widget"
+            logger.debug(m)
+        extra["syntax"] = syntax.lower()
 
     # construct FieldInfo
 


### PR DESCRIPTION
This pull request introduces a new `syntax` parameter to the `SettingsField` function in the `ayon_server/settings/settings_field.py` file. The changes ensure that the `syntax` parameter is only applicable when the `widget` type is set to "textarea" and logs a debug message if used incorrectly.