### PR TITLE
Log activities in the event stream

### DIFF
--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -11,6 +11,7 @@ import datetime
 from typing import Any
 
 from ayon_server.activities.models import (
+    DO_NOT_TRACK_ACTIVITIES,
     ActivityReferenceModel,
     ActivityType,
 )
@@ -252,6 +253,9 @@ async def create_activity(
         "activity_type": activity_type,
         "references": summary_references,
     }
+    event_payload = {
+        "body": body,
+    }
 
     with logger.contextualize(activity_id=activity_id, activity_type=activity_type):
         await EventStream.dispatch(
@@ -259,10 +263,11 @@ async def create_activity(
             project=project_name,
             description=f"Created {activity_type} activity",
             summary=summary,
-            store=False,
+            store=activity_type not in DO_NOT_TRACK_ACTIVITIES,
             user=user_name,
             sender=sender,
             sender_type=sender_type,
+            payload=event_payload,
         )
 
         # Send inbox notifications

--- a/ayon_server/activities/delete_activity.py
+++ b/ayon_server/activities/delete_activity.py
@@ -4,6 +4,8 @@ from ayon_server.events.eventstream import EventStream
 from ayon_server.exceptions import ForbiddenException, NotFoundException
 from ayon_server.lib.postgres import Postgres
 
+from .models import DO_NOT_TRACK_ACTIVITIES
+
 __all__ = ["delete_activity"]
 
 
@@ -92,9 +94,9 @@ async def delete_activity(
     await EventStream.dispatch(
         "activity.deleted",
         project=project_name,
-        description="",
+        description=f"Deleted {activity_type} activity",
         summary=summary,
-        store=False,
+        store=activity_type not in DO_NOT_TRACK_ACTIVITIES,
         user=user_name,
         sender=sender,
     )

--- a/ayon_server/activities/models.py
+++ b/ayon_server/activities/models.py
@@ -35,6 +35,17 @@ ReferencedEntityType = Literal[
 
 EntityLinkTuple = tuple[ReferencedEntityType, str]
 
+# For the following activities activity.* events are not created
+# since they already originate from events. We only send the event
+# over websocket, but do not store them in the database.
+
+DO_NOT_TRACK_ACTIVITIES: set[ActivityType] = {
+    "status.change",
+    "assignee.add",
+    "assignee.remove",
+    "version.publish",
+}
+
 
 class ActivityReferenceModel(OPModel):
     id: str = Field(default_factory=create_uuid)

--- a/ayon_server/activities/update_activity.py
+++ b/ayon_server/activities/update_activity.py
@@ -1,7 +1,10 @@
 import re
 from typing import Any
 
-from ayon_server.activities.models import ActivityReferenceModel
+from ayon_server.activities.models import (
+    DO_NOT_TRACK_ACTIVITIES,
+    ActivityReferenceModel,
+)
 from ayon_server.activities.utils import (
     MAX_BODY_LENGTH,
     extract_mentions,
@@ -236,14 +239,18 @@ async def update_activity(
         "activity_type": activity_type,
         "references": summary_references,
     }
+    event_payload = {
+        "body": body,
+    }
 
     await EventStream.dispatch(
         "activity.updated",
         project=project_name,
-        description="",
+        description=f"Updated {activity_type} activity",
         summary=summary,
-        store=False,
+        store=activity_type not in DO_NOT_TRACK_ACTIVITIES,
         user=user_name,
         sender=sender,
         sender_type=sender_type,
+        payload=event_payload,
     )


### PR DESCRIPTION
This pull request introduces a mechanism to distinguish between activities that should or should not be stored in the database, along with updates to event dispatch logic in several activity-related functions. The key changes include adding a `DO_NOT_TRACK_ACTIVITIES` set to specify activities excluded from database storage, modifying event payloads, and updating descriptions for dispatched events.

This PR allows comments to be handled by services