### PR TITLE
Fixed attribute emtpy enums handling

### DIFF
--- a/ayon_server/attributes/models.py
+++ b/ayon_server/attributes/models.py
@@ -117,7 +117,7 @@ class AttributeData(OPModel):
     def validate_enum(
         cls, value: list[AttributeEnumItem] | None
     ) -> list[AttributeEnumItem] | None:
-        if not value and isinstance(value, list):
+        if value == []:
             return None
         return value
 

--- a/ayon_server/attributes/models.py
+++ b/ayon_server/attributes/models.py
@@ -1,5 +1,7 @@
 from typing import Annotated, Any, Literal
 
+from pydantic import validator
+
 from ayon_server.types import (
     ATTRIBUTE_NAME_REGEX,
     AttributeEnumItem,
@@ -110,6 +112,14 @@ class AttributeData(OPModel):
             description="Inherit the attribute value from the parent entity.",
         ),
     ] = True
+
+    @validator("enum")
+    def validate_enum(
+        cls, value: list[AttributeEnumItem] | None
+    ) -> list[AttributeEnumItem] | None:
+        if not value and isinstance(value, list):
+            return None
+        return value
 
 
 class AttributeNameModel(OPModel):


### PR DESCRIPTION
This pull request introduces a validation method for the `enum` field in the `AttributeData` model to ensure proper handling of its values: Added the `validate_enum` method to validate the `enum` field, ensuring it returns `None` if the value is empty or not a list.