### PR TITLE
GraphQL: Advanced filtering in entity resolvers

### DIFF
--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -1,3 +1,4 @@
+import json
 from typing import Annotated
 
 from ayon_server.access.utils import folder_access_list
@@ -20,6 +21,7 @@ from ayon_server.graphql.resolvers.common import (
 )
 from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
+from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import (
     validate_name_list,
     validate_status_list,
@@ -64,6 +66,7 @@ async def get_products(
     ] = None,
     tags: Annotated[list[str] | None, argdesc("List of tags to filter by")] = None,
     has_links: ARGHasLinks = None,
+    filter: Annotated[str | None, argdesc("Filter tasks using QueryFilter")] = None,
     sort_by: Annotated[str | None, sortdesc(SORT_OPTIONS)] = None,
 ) -> ProductsConnection:
     """Return a list of products."""
@@ -245,6 +248,33 @@ async def get_products(
                 ON products.id = version_list.product_id
             """
         )
+
+    #
+    # Filter
+    #
+
+    if filter:
+        column_whitelist = [
+            "id",
+            "name",
+            "folder_id",
+            "product_type",
+            "attrib",
+            "data",
+            "active",
+            "status",
+            "tags",
+            "created_at",
+            "updated_at",
+        ]
+        fdata = json.loads(filter)
+        fq = QueryFilter(**fdata)
+        if fcond := build_filter(
+            fq,
+            column_whitelist=column_whitelist,
+            table_prefix="products",
+        ):
+            sql_conditions.append(fcond)
 
     #
     # Pagination

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -148,9 +148,11 @@ async def get_representations(
             "version_id",
             "files",
             "attrib",
+            "data",
             "traits",
             "status",
             "tags",
+            "active",
             "created_at",
             "updated_at",
         ]

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -209,7 +209,7 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
                 else:
                     raise ValueError("Invalid value type in list")
 
-        if operator in ("like"):
+        if operator == "like":
             # JSON Field is a string, so we need to cast it to text
             if isinstance(value, str):
                 safe_value = value.replace("'", "''")


### PR DESCRIPTION
This pull request introduces a filtering mechanism across multiple GraphQL resolvers (`folders.py`, `products.py`, `representations.py`, and `versions.py`) to enable advanced querying capabilities using `QueryFilter`. 

It enables filtering by attribute using various fields, operators and nested conditions:

### SQLFilter

SQLFilter syntax is described here 
- https://github.com/ynput/ayon-backend/pull/507
- https://github.com/ynput/ayon-backend/pull/568

### Examples

Filter representations by a partial path

```graphql
query q {
  project(name:"AY_CG_demo"){
    representations(filter:"{\"conditions\":[{\"key\": \"attrib.path\", \"operator\":\"like\", \"value\":\"%cg_pigeon_model%\"}]}"){
      edges{
        node{
          name
          attrib {
            path
          }
        }
      }
    }
  }
}
```

Get versions with version number higher than 2

```graphql
query q {
  project(name:"AY_CG_demo"){
    versions(filter:"{\"conditions\":[{\"key\": \"version\", \"operator\":\"gt\", \"value\":2}]}"){
      edges{
        node{
          name
        }
      }
    }
  }
}
```