### PR TITLE
Option to disable password login

### DIFF
--- a/api/users/users.py
+++ b/api/users/users.py
@@ -253,6 +253,7 @@ async def patch_user(
     if not user.is_manager:
         # Non-managers cannot change any user's manager status
         payload.data.pop("isManager", None)
+        payload.data.pop("disablePasswordLogin", None)
     elif target_user.name == user.name:
         # Managers cannot demote themselves
         payload.data.pop("isManager", None)

--- a/ayon_server/auth/password.py
+++ b/ayon_server/auth/password.py
@@ -93,6 +93,9 @@ class PasswordAuth:
         if "password" not in user.data:
             raise ForbiddenException("Password login is not enabled for this user")
 
+        if user.data.get("disablePasswordLogin", False):
+            raise ForbiddenException("Password login is disabled")
+
         pass_hash, pass_salt = user.data["password"].split(":")
 
         if pass_hash != hash_password(password, pass_salt):

--- a/ayon_server/graphql/nodes/user.py
+++ b/ayon_server/graphql/nodes/user.py
@@ -42,6 +42,7 @@ class UserNode:
     is_guest: bool
     is_developer: bool
     has_password: bool
+    disable_password_login: bool = False
     user_pool: str | None = None
     apiKeyPreview: str | None = None
     deleted: bool = False
@@ -78,6 +79,7 @@ def user_from_record(
     is_manager = data.get("isManager", False)
     is_guest = data.get("isGuest", False)
     user_pool = data.get("userPool")
+    disable_password_login = data.get("disablePasswordLogin", False)
 
     name = record["name"]
     attrib = record.get("attrib", {})
@@ -110,6 +112,7 @@ def user_from_record(
         user_pool=user_pool,
         has_password=bool(data.get("password")),
         default_access_groups=data.get("defaultAccessGroups", []),
+        disable_password_login=disable_password_login,
         apiKeyPreview=data.get("apiKeyPreview"),
         deleted=record.get("deleted", False),
         _attrib=attrib,


### PR DESCRIPTION
This pull request introduces a new feature to support disabling password login for users, along with updates to ensure proper handling of this functionality across the codebase. The key changes include adding a `disable_password_login` attribute to the `UserNode` class, updating logic in user authentication and mutation methods, and ensuring the attribute is correctly populated from user records.

Disabling password login is useful when a more secure SSO is required for user authentication