### PR TITLE
Fixed root folders propagation to entity lists

### DIFF
--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -218,20 +218,20 @@ async def get_entity_list_items(
         # ... yeah. and also the hierarchy path
         sql_columns.extend(
             [
-                "px.attrib as _entity_inherited_attributes",
-                "pr.attrib as _entity_project_attributes",
-                "pf.folder_type as _parent_folder_type",
+                "px.attrib AS _entity_inherited_attributes",
+                "pr.attrib AS _entity_project_attributes",
+                "pf.folder_type AS _parent_folder_type",
                 "hierarchy.path AS _entity_path",
             ]
         )
         sql_joins.extend(
             [
                 f"""
-                INNER JOIN project_{project_name}.exported_attributes AS px
+                LEFT JOIN project_{project_name}.exported_attributes AS px
                 ON e.parent_id = px.folder_id
                 """,
                 f"""
-                INNER JOIN project_{project_name}.folders AS pf
+                LEFT JOIN project_{project_name}.folders AS pf
                 ON e.parent_id = pf.id
                 """,
                 f"""
@@ -314,10 +314,12 @@ async def get_entity_list_items(
 
     if entity_type == "folder":
         sql_columns.append(
-            "(pr.attrib || px.attrib || e.attrib || i.attrib) as _all_attrib"
+            "(pr.attrib || COALESCE(px.attrib, '{}'::JSONB) || e.attrib || i.attrib) as _all_attrib"  # noqa: E501
         )
     elif entity_type == "task":
-        sql_columns.append("(px.attrib || e.attrib || i.attrib) as _all_attrib")
+        sql_columns.append(
+            "(COALESCE(px.attrib, '{}'::JSONB) || e.attrib || i.attrib) as _all_attrib"
+        )  # noqa: E501
     else:
         sql_columns.append("(e.attrib || i.attrib) as _all_attrib")
 


### PR DESCRIPTION
This pull request updates the SQL query logic in the `get_entity_list_items` function to improve robustness and handle potential null values more effectively. Key changes include switching join types and using `COALESCE` to provide default values for JSONB columns.

### SQL Query Improvements:
* Changed `INNER JOIN` to `LEFT JOIN` for `project_{project_name}.exported_attributes` and `project_{project_name}.folders` to ensure that rows are included even if there are no matching entries in the joined tables.
* Added `COALESCE` to handle potential null values in `px.attrib` for both "folder" and "task" entity types, ensuring that empty JSONB objects (`'{}'::JSONB`) are used as defaults.

These changes enhance the query's resilience and ensure data consistency when dealing with optional attributes.