### PR TITLE
REST:  hasReviewables flag in list_folders endpoint

### DIFF
--- a/api/folders/list_folders.py
+++ b/api/folders/list_folders.py
@@ -76,6 +76,7 @@ class FolderListItem(OPModel):
     folder_type: str
     has_tasks: bool = False
     has_children: bool = False
+    has_reviewables: bool = False
     task_names: list[str] | None
     tags: list[str] | None
     status: str

--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -27,6 +27,7 @@ from ayon_server.activities.watchers.watcher_list import get_watcher_list
 from ayon_server.entities.core import ProjectLevelEntity
 from ayon_server.events.eventstream import EventStream
 from ayon_server.exceptions import BadRequestException, NotFoundException
+from ayon_server.helpers.hierarchy_cache import rebuild_hierarchy_cache
 from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import logger
 from ayon_server.utils import create_uuid
@@ -246,6 +247,11 @@ async def create_activity(
             timestamp,
             entity_id,
         )
+
+        # Publishing reviewables must invalidate the hierarchy cache
+
+        if activity_type == "reviewable":
+            await rebuild_hierarchy_cache(project_name)
 
     # Notify the front-end about the new activity
 

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -184,7 +184,7 @@ class FolderEntity(ProjectLevelEntity):
                 """
             )
             await rebuild_inherited_attributes(self.project_name, transaction=conn)
-            await rebuild_hierarchy_cache(self.project_name, transaction=conn)
+            await rebuild_hierarchy_cache(self.project_name)
 
         if transaction is not None:
             await _commit(transaction)
@@ -217,7 +217,7 @@ class FolderEntity(ProjectLevelEntity):
 
         res = await super().delete(transaction=transaction, **kwargs)
         if res:
-            await rebuild_hierarchy_cache(self.project_name, transaction=transaction)
+            await rebuild_hierarchy_cache(self.project_name)
         return res
 
     async def get_versions(self, transaction: Connection | None = None) -> list[str]:

--- a/ayon_server/entities/task.py
+++ b/ayon_server/entities/task.py
@@ -4,6 +4,7 @@ from ayon_server.access.utils import ensure_entity_access
 from ayon_server.entities.core import ProjectLevelEntity, attribute_library
 from ayon_server.entities.models import ModelSet
 from ayon_server.exceptions import AyonException, NotFoundException
+from ayon_server.helpers.hierarchy_cache import rebuild_hierarchy_cache
 from ayon_server.lib.postgres import Connection, Postgres
 from ayon_server.logging import logger
 from ayon_server.types import ProjectLevelEntityType
@@ -95,6 +96,9 @@ class TaskEntity(ProjectLevelEntity):
             self.folder_type = res[0]["name"]
 
         await super().save(transaction=transaction)
+
+    async def commit(self, transaction: Connection | None = None) -> None:
+        await rebuild_hierarchy_cache(self.project_name)
 
     async def ensure_create_access(self, user, **kwargs) -> None:
         if user.is_manager:

--- a/ayon_server/helpers/hierarchy_cache.py
+++ b/ayon_server/helpers/hierarchy_cache.py
@@ -1,18 +1,26 @@
 import time
 from typing import Any
 
-from ayon_server.lib.postgres import Connection, Postgres
+from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.logging import logger
 from ayon_server.utils import json_dumps
 
 
-async def rebuild_hierarchy_cache(
-    project_name: str,
-    transaction: Connection | None = None,
-) -> list[dict[str, Any]]:
+async def rebuild_hierarchy_cache(project_name: str) -> list[dict[str, Any]]:
     start_time = time.monotonic()
     query = f"""
+        WITH reviewables AS (
+            SELECT p.folder_id AS folder_id
+            FROM project_{project_name}.activity_feed af
+            INNER JOIN project_{project_name}.versions v
+            ON af.entity_id = v.id
+            AND af.entity_type = 'version'
+            AND  af.activity_type = 'reviewable'
+            INNER JOIN project_{project_name}.products p
+            ON p.id = v.product_id
+        )
+
         SELECT
             f.id,
             f.parent_id,
@@ -26,7 +34,8 @@ async def rebuild_hierarchy_cache(
             ea.attrib as all_attrib,
             ea.path as path,
             COUNT (tasks.id) AS task_count,
-            array_agg(tasks.name) AS task_names
+            array_agg(tasks.name) AS task_names,
+            EXISTS (SELECT 1 FROM reviewables WHERE folder_id = f.id) AS has_reviewables
         FROM
             project_{project_name}.folders f
         INNER JOIN
@@ -41,7 +50,7 @@ async def rebuild_hierarchy_cache(
 
     result = []
     ids_with_children = set()
-    async for row in Postgres.iterate(query, transaction=transaction):
+    async for row in Postgres.iterate(query):
         result.append(
             {
                 "id": row["id"],
@@ -57,6 +66,7 @@ async def rebuild_hierarchy_cache(
                 "attrib": row["all_attrib"],
                 "tags": row["tags"],
                 "own_attrib": list(row["attrib"].keys()),
+                "has_reviewables": row["has_reviewables"],
                 "updated_at": row["updated_at"],
             }
         )
@@ -71,6 +81,6 @@ async def rebuild_hierarchy_cache(
     logger.trace(
         f"Rebuilt hierarchy cache for {project_name} "
         f"with {len(result)} folders "
-        f"in {elapsed_time:.2f} s"
+        f"in {elapsed_time:.2f}s"
     )
     return result


### PR DESCRIPTION
This pull request introduces changes to support the concept of "reviewables" in the hierarchy cache and related functionality. Key updates include adding the `has_reviewables` attribute to folder entities, modifying the hierarchy cache logic to account for reviewables, and simplifying the `rebuild_hierarchy_cache` function by removing the `transaction` parameter. Below is a breakdown of the most important changes.

## Testing notes

It may be necessary to do at least some write operation in the project to invalidate the current hierarchy cache