### PR TITLE
GraphQL: Additional anatomy-related fields for project node

### DIFF
--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -62,15 +62,26 @@ else:
 @strawberry.type
 class TaskType:
     name: str
+    icon: str | None = None
+    short_name: str | None = None
+    color: str | None = None
 
 
 @strawberry.type
 class FolderType:
     name: str
+    icon: str | None = None
+    short_name: str | None = None
 
-    @strawberry.field
-    def icon(self) -> str:
-        return self.name.lower()
+
+@strawberry.type
+class LinkType:
+    name: str
+    link_type: str
+    input_type: str
+    output_type: str
+    color: str | None = None
+    style: str = "solid"
 
 
 @strawberry.type
@@ -191,36 +202,81 @@ class ProjectNode:
 
     @strawberry.field(description="List of project's task types")
     async def task_types(self, active_only: bool = False) -> list[TaskType]:
+        cond = ""
         if active_only:
-            query = f"""
-                SELECT DISTINCT(task_type) AS task_type
-                FROM project_{self.project_name}.tasks
+            cond = f"""
+                WHERE name IN (SELECT DISTINCT(task_type)
+                FROM project_{self.project_name}.tasks)
             """
-        else:
-            query = f"""
-                SELECT name AS task_type
-                FROM project_{self.project_name}.task_types
-                ORDER BY position
-            """
+        query = f"""
+            SELECT name, data
+            FROM project_{self.project_name}.task_types
+            {cond}
+            ORDER BY position
+        """
+        res = await Postgres.fetch(query)
         return [
-            TaskType(name=row["task_type"]) async for row in Postgres.iterate(query)
+            TaskType(
+                name=row["name"],
+                short_name=row["data"].get("shortName"),
+                icon=row["data"].get("icon"),
+                color=row["data"].get("color"),
+            )
+            for row in res
         ]
 
     @strawberry.field(description="List of project's folder types")
     async def folder_types(self, active_only: bool = False) -> list[FolderType]:
+        cond = ""
         if active_only:
-            query = f"""
-                SELECT DISTINCT(folder_type) AS folder_type
-                FROM project_{self.project_name}.folders
+            cond = f"""
+                WHERE name IN (SELECT DISTINCT(folder_type)
+                FROM project_{self.project_name}.folders)
             """
-        else:
-            query = f"""
-                SELECT name AS folder_type
-                FROM project_{self.project_name}.folder_types
-                ORDER BY position
-            """
+
+        query = f"""
+            SELECT name, data
+            FROM project_{self.project_name}.folder_types
+            {cond}
+            ORDER BY position
+        """
+        res = await Postgres.fetch(query)
         return [
-            FolderType(name=row["folder_type"]) async for row in Postgres.iterate(query)
+            FolderType(
+                name=row["name"],
+                short_name=row["data"].get("shortName"),
+                icon=row["data"].get("icon"),
+            )
+            for row in res
+        ]
+
+    @strawberry.field(description="List of project's link types")
+    async def link_types(self, active_only: bool = False) -> list[LinkType]:
+        cond = ""
+        if active_only:
+            cond = f"""
+                WHERE name IN (SELECT DISTINCT(link_type)
+                FROM project_{self.project_name}.links)
+            """
+
+        query = f"""
+            SELECT name, link_type, input_type, output_type, data
+            FROM project_{self.project_name}.link_types
+            {cond}
+            ORDER BY name
+        """
+
+        res = await Postgres.fetch(query)
+        return [
+            LinkType(
+                name=row["name"],
+                link_type=row["link_type"],
+                input_type=row["input_type"],
+                output_type=row["output_type"],
+                color=row["data"].get("color"),
+                style=row["data"].get("style", "solid"),
+            )
+            for row in res
         ]
 
     @strawberry.field(description="List of project's product types")

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -95,6 +95,12 @@ class Status:
 
 
 @strawberry.type
+class Tag:
+    name: str
+    color: str | None = None
+
+
+@strawberry.type
 class ProjectBundleType:
     production: str | None = None
     staging: str | None = None
@@ -325,6 +331,22 @@ class ProjectNode:
                 color=row["data"].get("color"),
                 state=row["data"].get("state"),
                 scope=row["data"].get("scope", []),
+            )
+            for row in res
+        ]
+
+    @strawberry.field(description="List of tags in the project")
+    async def tags(self) -> list[Tag]:
+        query = f"""
+            SELECT name, data
+            FROM project_{self.project_name}.tags
+            ORDER BY position
+        """
+        res = await Postgres.fetch(query)
+        return [
+            Tag(
+                name=row["name"],
+                color=row["data"].get("color"),
             )
             for row in res
         ]

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -85,6 +85,16 @@ class LinkType:
 
 
 @strawberry.type
+class Status:
+    name: str
+    short_name: str | None = None
+    icon: str | None = None
+    color: str | None = None
+    state: str | None = None
+    scope: list[str] | None = None
+
+
+@strawberry.type
 class ProjectBundleType:
     production: str | None = None
     staging: str | None = None
@@ -297,6 +307,26 @@ class ProjectNode:
                 ORDER BY name ASC
             """
             )
+        ]
+
+    @strawberry.field(description="List of project's statuses")
+    async def statuses(self) -> list[Status]:
+        query = f"""
+            SELECT name, data
+            FROM project_{self.project_name}.statuses
+            ORDER BY position
+        """
+        res = await Postgres.fetch(query)
+        return [
+            Status(
+                name=row["name"],
+                short_name=row["data"].get("shortName"),
+                icon=row["data"].get("icon"),
+                color=row["data"].get("color"),
+                state=row["data"].get("state"),
+                scope=row["data"].get("scope", []),
+            )
+            for row in res
         ]
 
     @strawberry.field(description="List of tags used in the project")


### PR DESCRIPTION
This pull request introduces several enhancements to the `ayon_server/graphql/nodes/project.py` file to improve the GraphQL schema and query logic. The changes include adding new fields to existing types, creating a new type (`LinkType`), and updating query methods to handle additional data attributes. These updates enhance the flexibility and functionality of the project schema.

* Added optional fields `icon`, `short_name`, and `color` to `TaskType` and `FolderType`, allowing for richer metadata representation.
* Introduced a new `LinkType` with fields such as `name`, `link_type`, `input_type`, `output_type`, `color`, and `style`, expanding the schema to support link-related data.
* Updated the `task_types` and `folder_types` methods to include additional attributes (`short_name`, `icon`, `color`) from the `data` field in their respective database tables.
* Added a new `link_types` method to retrieve and process `LinkType` data from the database, including support for filtering by active types.

![image](https://github.com/user-attachments/assets/c5ef199f-907c-472f-96ba-f7c3dc81e1ad)
