### PR TITLE
Authentication settings: Disable password login prompt

### DIFF
--- a/api/system/info.py
+++ b/api/system/info.py
@@ -73,6 +73,12 @@ class InfoResponseModel(OPModel):
         description="If set, the changelog will not be shown to the user",
     )
 
+    hide_password_auth: bool | None = Field(
+        None,
+        title="Hide password authentication",
+        description="Password authentication will not be shown on the login page",
+    )
+
     password_recovery_available: bool | None = Field(None, title="Password recovery")
     user: UserEntity.model.main_model | None = Field(None, title="User information")  # type: ignore
     attributes: list[AttributeModel] | None = Field(None, title="List of attributes")
@@ -341,6 +347,9 @@ async def get_site_info(
             additional_info["login_page_brand"] = url
         elif ayonconfig.login_page_brand:  # Deprecated
             additional_info["login_page_brand"] = ayonconfig.login_page_brand
+
+        if server_config.authentication.hide_password_auth:
+            additional_info["hide_password_auth"] = True
 
     user_payload = current_user.payload if (current_user is not None) else None
     return InfoResponseModel(user=user_payload, **additional_info)

--- a/ayon_server/config/serverconfig.py
+++ b/ayon_server/config/serverconfig.py
@@ -44,14 +44,15 @@ class AuthenticationModel(BaseSettingsModel):
         ),
     ] = False
 
-    users_can_change_email: Annotated[
-        bool,
-        SettingsField(
-            title="Users Can Change Email",
-            description="If enabled, users can change their email address "
-            "in their profile settings.",
-        ),
-    ] = True
+    # TODO: For future use
+    # users_can_change_email: Annotated[
+    #     bool,
+    #     SettingsField(
+    #         title="Users Can Change Email",
+    #         description="If enabled, users can change their email address "
+    #         "in their profile settings.",
+    #     ),
+    # ] = True
 
 
 class ProjectOptionsModel(BaseSettingsModel):

--- a/ayon_server/config/serverconfig.py
+++ b/ayon_server/config/serverconfig.py
@@ -34,6 +34,26 @@ class CustomizationModel(BaseSettingsModel):
     ] = ""
 
 
+class AuthenticationModel(BaseSettingsModel):
+    hide_password_auth: Annotated[
+        bool,
+        SettingsField(
+            title="Hide Password Authentication",
+            description="If enabled, password authentication will be hidden "
+            "from the login page.",
+        ),
+    ] = False
+
+    users_can_change_email: Annotated[
+        bool,
+        SettingsField(
+            title="Users Can Change Email",
+            description="If enabled, users can change their email address "
+            "in their profile settings.",
+        ),
+    ] = True
+
+
 class ProjectOptionsModel(BaseSettingsModel):
     project_code_regex: Annotated[
         str,
@@ -74,6 +94,15 @@ class ServerConfigModel(BaseSettingsModel):
             title="Customization",
             description="Customization options for the login page",
             default_factory=CustomizationModel,
+        ),
+    ]
+
+    authentication: Annotated[
+        AuthenticationModel,
+        SettingsField(
+            title="Authentication",
+            description="Settings related to user authentication",
+            default_factory=AuthenticationModel,
         ),
     ]
 


### PR DESCRIPTION
This pull request introduces a new feature to hide password authentication on the login page, along with the necessary backend adjustments to support this functionality. 