### PR TITLE
Configurable authentication for openapi endpoints

### DIFF
--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -15,7 +15,7 @@ from fastapi.websockets import WebSocket, WebSocketDisconnect
 
 # okay. now the rest
 from ayon_server.api.auth import AuthMiddleware
-from ayon_server.api.dependencies import CurrentUser
+from ayon_server.api.dependencies import CurrentUserOptional
 from ayon_server.api.lifespan import lifespan
 from ayon_server.api.logging import LoggingMiddleware
 from ayon_server.api.messaging import messaging
@@ -54,13 +54,18 @@ app.add_middleware(AuthMiddleware)
 
 
 @app.get("/openapi.json", include_in_schema=False)
-async def openapi(user: CurrentUser) -> dict[str, Any]:
+async def openapi(user: CurrentUserOptional) -> dict[str, Any]:
     """Return OpenAPI schema"""
-    if not user.is_manager:
-        raise ForbiddenException("You are not allowed to access OpenAPI schema")
 
     if ayonconfig.disable_rest_docs:
         raise ForbiddenException("OpenAPI documentation is disabled")
+
+    if ayonconfig.openapi_require_authentication:
+        if user is None:
+            raise ForbiddenException("You must be logged in to access OpenAPI schema")
+
+        if not user.is_manager:
+            raise ForbiddenException("You are not allowed to access OpenAPI schema")
 
     return get_openapi(
         title=app_meta["title"],
@@ -71,13 +76,19 @@ async def openapi(user: CurrentUser) -> dict[str, Any]:
 
 
 @app.get("/docs", include_in_schema=False)
-async def docs(user: CurrentUser) -> HTMLResponse:
+async def docs(user: CurrentUserOptional) -> HTMLResponse:
     """Return the OpenAPI documentation page"""
-    if not user.is_manager:
-        raise ForbiddenException("You are not allowed to access the API documentation")
 
     if ayonconfig.disable_rest_docs:
         raise ForbiddenException("OpenAPI documentation is disabled")
+
+    if ayonconfig.openapi_require_authentication:
+        if user is None:
+            raise ForbiddenException("You must be logged in to access OpenAPI schema")
+
+        if not user.is_manager:
+            raise ForbiddenException("You are not allowed to access OpenAPI schema")
+
     return get_redoc_html(
         openapi_url="/openapi.json",
         title=app_meta["title"],

--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -87,7 +87,7 @@ async def docs(user: CurrentUserOptional) -> HTMLResponse:
             raise ForbiddenException("You must be logged in to access API documentation")
 
         if not user.is_manager:
-            raise ForbiddenException("You are not allowed to access OpenAPI schema")
+            raise ForbiddenException("You are not allowed to access API documentation")
 
     return get_redoc_html(
         openapi_url="/openapi.json",

--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -84,7 +84,7 @@ async def docs(user: CurrentUserOptional) -> HTMLResponse:
 
     if ayonconfig.openapi_require_authentication:
         if user is None:
-            raise ForbiddenException("You must be logged in to access OpenAPI schema")
+            raise ForbiddenException("You must be logged in to access API documentation")
 
         if not user.is_manager:
             raise ForbiddenException("You are not allowed to access OpenAPI schema")

--- a/ayon_server/config/ayonconfig.py
+++ b/ayon_server/config/ayonconfig.py
@@ -188,8 +188,14 @@ class AyonConfig(BaseModel):
         description="Include addon endpoints in the OpenAPI schema",
     )
 
+    openapi_require_authentication: bool = Field(
+        default=True,
+        description="Require authentication for OpenAPI schema access",
+    )
+
     use_git_suffix_for_addons: bool = Field(
-        default=True, description="Use git suffix for addon versions. "
+        default=True,
+        description="Use git suffix for addon versions. ",
     )
 
     log_retention_days: int = Field(


### PR DESCRIPTION
This pull request introduces changes to enhance security and flexibility in accessing OpenAPI documentation by requiring authentication under certain conditions. It also updates the `ayon_server` configuration to include a new setting for this behavior. The most important changes are listed below:

### Security and authentication updates:

* Introduced `openapi_require_authentication` as a configurable field to toggle authentication requirements for accessing OpenAPI schema and documentation using `AYON_OPENAPI_REQUIRE_AUTHENTICATION` (default is True)
* Replaced `CurrentUser` with `CurrentUserOptional` in the `openapi` and `docs` endpoints to allow unauthenticated access when authentication is not required.
*  Updated the `openapi` endpoints to check if authentication is required (`ayonconfig.openapi_require_authentication`) and enforce login and manager permissions accordingly.
