### PR TITLE
Actions: List actions endpoint allows to specify settings variant

### DIFF
--- a/api/actions/actions.py
+++ b/api/actions/actions.py
@@ -24,6 +24,7 @@ async def list_available_actions_for_context(
     context: ActionContext,
     user: CurrentUser,
     mode: ActionListMode = Query("simple", title="Action List Mode"),
+    variant: str | None = Query(None, title="Settings Variant"),
 ) -> AvailableActionsListModel:
     """Get available actions for a context.
 
@@ -45,15 +46,15 @@ async def list_available_actions_for_context(
     actions = []
 
     if mode == "simple":
-        r = await get_simple_actions(user, context)
+        r = await get_simple_actions(user, context, variant)
         actions.extend(r.actions)
     elif mode == "dynamic":
-        r = await get_dynamic_actions(user, context)
+        r = await get_dynamic_actions(user, context, variant)
         actions.extend(r.actions)
     elif mode == "all":
-        r1 = await get_simple_actions(user, context)
+        r1 = await get_simple_actions(user, context, variant)
         actions.extend(r1.actions)
-        r2 = await get_dynamic_actions(user, context)
+        r2 = await get_dynamic_actions(user, context, variant)
         actions.extend(r2.actions)
 
     for action in actions:

--- a/api/actions/listing.py
+++ b/api/actions/listing.py
@@ -29,14 +29,28 @@ class AvailableActionsListModel(OPModel):
 @aiocache.cached(ttl=60)
 async def _load_relevant_addons(
     user_name: str,
+    variant: str | None,
     is_developer: bool,
     user_last_modified: str,
 ) -> tuple[str, list[BaseServerAddon]]:
-    variant = None
     query: tuple[str] | tuple[str, str]
     _ = user_last_modified  # this is used just to invalidate the cache
 
-    if is_developer:
+    if variant == "production":
+        query = (
+            "SELECT name, data->'addons' as addons FROM bundles WHERE is_production",
+        )
+    elif variant == "staging":
+        query = (
+            "SELECT name, data->'addons' as addons FROM bundles WHERE is_staging",
+        )
+    elif variant:
+        query = (
+            "SELECT name, data->'addons' as addons FROM bundles WHERE name = $1",
+            variant,
+        )
+
+    elif is_developer:
         # get the list of addons from the development environment
         query = (
             """
@@ -49,7 +63,6 @@ async def _load_relevant_addons(
         query = (
             "SELECT name, data->'addons' as addons FROM bundles WHERE is_production",
         )
-        # we're in production mode
         variant = "production"
 
     res = await Postgres.fetch(*query)
@@ -74,7 +87,7 @@ async def _load_relevant_addons(
     return variant, result
 
 
-async def get_relevant_addons(user: UserEntity) -> tuple[str, list[BaseServerAddon]]:
+async def get_relevant_addons(variant: str | None, user: UserEntity) -> tuple[str, list[BaseServerAddon]]:
     """Get the list of addons that are relevant for the user.
 
     Normally it means addons in the production bundle,
@@ -88,6 +101,7 @@ async def get_relevant_addons(user: UserEntity) -> tuple[str, list[BaseServerAdd
 
     return await _load_relevant_addons(
         user.name,
+        variant,
         is_developer,
         user_last_modified,
     )
@@ -255,9 +269,10 @@ class SimpleActionCache:
 async def get_simple_actions(
     user: UserEntity,
     context: ActionContext,
+    variant: str | None,
 ) -> AvailableActionsListModel:
     actions = []
-    variant, addons = await get_relevant_addons(user)
+    variant, addons = await get_relevant_addons(variant, user)
     project_name = context.project_name
     for addon in addons:
         simple_actions = await SimpleActionCache.get(addon, project_name, variant)
@@ -279,6 +294,7 @@ async def get_simple_actions(
 async def get_dynamic_actions(
     user: UserEntity,
     context: ActionContext,
+    variant: str | None,
 ) -> AvailableActionsListModel:
     """Get a list of dynamic actions for a given context.
 
@@ -291,7 +307,7 @@ async def get_dynamic_actions(
     """
 
     actions = []
-    variant, addons = await get_relevant_addons(user)
+    variant, addons = await get_relevant_addons(variant, user)
     for addon in addons:
         actions.extend(await addon.get_dynamic_actions(context, variant))
     return AvailableActionsListModel(actions=actions)


### PR DESCRIPTION
## PR Checklist
-   [ ] `/api/actions/list` endpoint allows to explicitly define settings variant.

## Description of changes
It was not possible to receive actions for explicitly defined settings variant which is a big issue for pipeline purposes. There was no way how to get `staging` actions, or actions for specific dev bundle.

### Technical details
The endpoint is backwards compatible and still works as before until the `variant` query is passed to the endpoint.

Resolves https://github.com/ynput/ayon-backend/issues/651