### PR TITLE
Avoid postgres.iterate when unnecessary

### DIFF
--- a/api/actions/listing.py
+++ b/api/actions/listing.py
@@ -41,9 +41,7 @@ async def _load_relevant_addons(
             "SELECT name, data->'addons' as addons FROM bundles WHERE is_production",
         )
     elif variant == "staging":
-        query = (
-            "SELECT name, data->'addons' as addons FROM bundles WHERE is_staging",
-        )
+        query = ("SELECT name, data->'addons' as addons FROM bundles WHERE is_staging",)
     elif variant:
         query = (
             "SELECT name, data->'addons' as addons FROM bundles WHERE name = $1",
@@ -87,7 +85,9 @@ async def _load_relevant_addons(
     return variant, result
 
 
-async def get_relevant_addons(variant: str | None, user: UserEntity) -> tuple[str, list[BaseServerAddon]]:
+async def get_relevant_addons(
+    variant: str | None, user: UserEntity
+) -> tuple[str, list[BaseServerAddon]]:
     """Get the list of addons that are relevant for the user.
 
     Normally it means addons in the production bundle,

--- a/ayon_server/activities/delete_activity.py
+++ b/ayon_server/activities/delete_activity.py
@@ -81,7 +81,7 @@ async def delete_activity(
         )
 
         # Delete the activity
-        await Postgres().execute(
+        await Postgres.execute(
             f"""
             DELETE FROM project_{project_name}.activities
             WHERE id = $1

--- a/ayon_server/activities/references.py
+++ b/ayon_server/activities/references.py
@@ -74,7 +74,6 @@ async def get_references_from_task(task: TaskEntity) -> set[ActivityReferenceMod
         )
 
     # Load a list of versions that belong to the task.
-
     query = f"SELECT id FROM project_{project_name}.versions WHERE task_id = $1"
     res = await Postgres.fetch(query, task.id)
     for row in res:

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -573,23 +573,19 @@ class BaseServerAddon:
             data = settings_cache.site or {}
 
         else:
-            data = {}
             query = """
                 SELECT data FROM public.site_settings
                 WHERE site_id = $1 AND addon_name = $2
                 AND addon_version = $3 AND user_name = $4
             """
-            async for row in Postgres.iterate(
-                query,
-                site_id,
-                self.name,
-                self.version,
-                user_name,
-            ):
-                data = row["data"]
-                break
-            else:
+            row = await Postgres.fetchrow(
+                query, site_id, self.name, self.version, user_name
+            )
+
+            # No site settings found, return None
+            if row is None:
                 return None
+            data = row["data"]
 
         return site_settings_model(**data).dict()
 

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -222,7 +222,10 @@ class FolderEntity(ProjectLevelEntity):
                 ON s.id = v.product_id
             WHERE s.folder_id = $1
             """
-        return [row["version_id"] async for row in Postgres.iterate(query, self.id)]
+        res = await Postgres.fetch(query, self.id)
+        if not res:
+            return []
+        return [row["version_id"] for row in res]
 
     async def ensure_create_access(self, user, **kwargs) -> None:
         """Check if the user has access to create a new entity.

--- a/ayon_server/events/eventstream.py
+++ b/ayon_server/events/eventstream.py
@@ -311,30 +311,26 @@ class EventStream:
     @classmethod
     async def get(cls, event_id: str) -> EventModel:
         query = "SELECT * FROM public.events WHERE id = $1", event_id
-        event: EventModel | None = None
-        async for record in Postgres.iterate(*query):
-            event = EventModel(
-                id=record["id"],
-                hash=record["hash"],
-                topic=record["topic"],
-                project=record["project_name"],
-                user=record["user_name"],
-                sender=record["sender"],
-                sender_type=record["sender_type"],
-                depends_on=record["depends_on"],
-                status=record["status"],
-                retries=record["retries"],
-                description=record["description"],
-                payload=record["payload"],
-                summary=record["summary"],
-                created_at=record["created_at"],
-                updated_at=record["updated_at"],
-            )
-            break
-
-        if event is None:
+        record = await Postgres.fetchrow(*query)
+        if record is None:
             raise NotFoundException("Event not found")
-        return event
+        return EventModel(
+            id=record["id"],
+            hash=record["hash"],
+            topic=record["topic"],
+            project=record["project_name"],
+            user=record["user_name"],
+            sender=record["sender"],
+            sender_type=record["sender_type"],
+            depends_on=record["depends_on"],
+            status=record["status"],
+            retries=record["retries"],
+            description=record["description"],
+            payload=record["payload"],
+            summary=record["summary"],
+            created_at=record["created_at"],
+            updated_at=record["updated_at"],
+        )
 
     @classmethod
     async def delete(cls, event_id: str) -> None:

--- a/ayon_server/graphql/__init__.py
+++ b/ayon_server/graphql/__init__.py
@@ -13,7 +13,6 @@ from ayon_server.exceptions import AyonException
 from ayon_server.graphql.connections import (
     ActivitiesConnection,
     EventsConnection,
-    # InboxConnection,
     KanbanConnection,
     ProjectsConnection,
     UsersConnection,


### PR DESCRIPTION
This pull request refactors database query handling across multiple files to improve code readability, maintainability, and performance. The changes primarily involve replacing `Postgres.iterate` with `Postgres.fetch` or `Postgres.fetchrow` for more efficient data retrieval and simplifying query formatting. Additionally, unused code is removed to streamline the codebase.

### Database Query Refactoring:
* Replaced `Postgres.iterate` with `Postgres.fetchrow` in functions like `get_anatomy_preset`, `password_reset_request`, and `get_site_settings` to improve query efficiency and handle single-row results more cleanly. Added checks for `None` results to handle empty queries gracefully. 
* Consolidated multi-line SQL query definitions into single-line strings where applicable, such as in `unset_primary_preset` and `delete_anatomy_preset`, to reduce redundancy and improve readability.
* Removed unnecessary loops and conditional breaks when processing query results, as seen in `get` in `eventstream.py`. 