### PR TITLE
GraphQL: expose parents (and path) fields on all project level entity nodes

### DIFF
--- a/ayon_server/graphql/__init__.py
+++ b/ayon_server/graphql/__init__.py
@@ -21,6 +21,7 @@ from ayon_server.graphql.dataloaders import (
     folder_loader,
     latest_version_loader,
     product_loader,
+    representation_loader,
     task_loader,
     user_loader,
     version_loader,
@@ -72,6 +73,7 @@ async def graphql_get_context(user: CurrentUser) -> dict[str, Any]:
         "latest_version_loader": DataLoader(load_fn=latest_version_loader),
         "user_loader": DataLoader(load_fn=user_loader),
         "workfile_loader": DataLoader(load_fn=workfile_loader),
+        "representation_loader": DataLoader(load_fn=representation_loader),
         # Other
         "activities_resolver": get_activities,
         "links_resolver": get_links,

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -43,6 +43,9 @@ class LinkEdge(BaseEdge):
         elif self.entity_type == "representation":
             loader = info.context["representation_loader"]
             parser = info.context["representation_from_record"]
+        elif self.entity_type == "workfile":
+            loader = info.context["workfile_loader"]
+            parser = info.context["workfile_from_record"]
         else:
             raise ValueError
         record = await loader.load((self.project_name, self.entity_id))

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -118,3 +118,7 @@ class BaseNode:
             activity_types=activity_types,
             reference_types=reference_types,
         )
+
+    @strawberry.field()
+    def parents(self) -> list[str]:
+        return []

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -2,8 +2,10 @@ from datetime import datetime
 
 import strawberry
 
+from ayon_server.exceptions import AyonException
 from ayon_server.graphql.connections import ActivitiesConnection
 from ayon_server.graphql.types import BaseConnection, BaseEdge, Info
+from ayon_server.logging import logger
 
 
 @strawberry.type
@@ -47,7 +49,10 @@ class LinkEdge(BaseEdge):
             loader = info.context["workfile_loader"]
             parser = info.context["workfile_from_record"]
         else:
-            raise ValueError
+            msg = f"Unsupported entity type '{self.entity_type}' for link node"
+            logger.error(msg)
+            raise AyonException(msg)
+
         record = await loader.load((self.project_name, self.entity_id))
         return parser(self.project_name, record, info.context)
 

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -140,7 +140,7 @@ def folder_from_record(
         has_reviewables = False
 
     thumbnail = None
-    if record["thumbnail_id"]:
+    if record.get("thumbnail_id"):
         thumb_data = data.get("thumbnailInfo", {})
         thumbnail = ThumbnailInfo(
             id=record["thumbnail_id"],

--- a/ayon_server/graphql/nodes/product.py
+++ b/ayon_server/graphql/nodes/product.py
@@ -129,18 +129,19 @@ def product_from_record(
                 key = key.removeprefix("_folder_")
                 folder_data[key] = value
 
-        try:
-            cfun = context["folder_from_record"]
-            folder = (
-                cfun(project_name, folder_data, context=context)
-                if folder_data
-                else None
-            )
-        except KeyError:
-            # If the folder loader is not available,
-            # we can still create the node without it
-            # (dataloaders will handle it later)
-            folder = None
+        if folder_data.get("id"):
+            try:
+                cfun = context["folder_from_record"]
+                folder = (
+                    cfun(project_name, folder_data, context=context)
+                    if folder_data
+                    else None
+                )
+            except KeyError:
+                # If the folder loader is not available,
+                # we can still create the node without it
+                # (dataloaders will handle it later)
+                folder = None
     else:
         folder = None
 

--- a/ayon_server/graphql/nodes/product.py
+++ b/ayon_server/graphql/nodes/product.py
@@ -122,6 +122,7 @@ def product_from_record(
 ) -> ProductNode:
     """Construct a product node from a DB row."""
 
+    folder = None
     if context:
         folder_data = {}
         for key, value in record.items():
@@ -138,12 +139,7 @@ def product_from_record(
                     else None
                 )
             except KeyError:
-                # If the folder loader is not available,
-                # we can still create the node without it
-                # (dataloaders will handle it later)
-                folder = None
-    else:
-        folder = None
+                pass
 
     vlist = []
     version_ids = record.get("version_ids", [])

--- a/ayon_server/graphql/nodes/product.py
+++ b/ayon_server/graphql/nodes/product.py
@@ -129,11 +129,18 @@ def product_from_record(
                 key = key.removeprefix("_folder_")
                 folder_data[key] = value
 
-        folder = (
-            context["folder_from_record"](project_name, folder_data, context=context)
-            if folder_data
-            else None
-        )
+        try:
+            cfun = context["folder_from_record"]
+            folder = (
+                cfun(project_name, folder_data, context=context)
+                if folder_data
+                else None
+            )
+        except KeyError:
+            # If the folder loader is not available,
+            # we can still create the node without it
+            # (dataloaders will handle it later)
+            folder = None
     else:
         folder = None
 

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -117,11 +117,16 @@ def task_from_record(
                 key = key.removeprefix("_folder_")
                 folder_data[key] = value
 
-        folder = (
-            context["folder_from_record"](project_name, folder_data, context=context)
-            if folder_data
-            else None
-        )
+        if folder_data.get("id"):
+            cfun = context["folder_from_record"]
+            try:
+                folder = (
+                    cfun(project_name, folder_data, context=context)
+                    if folder_data
+                    else None
+                )
+            except KeyError:
+                folder = None
     else:
         folder = None
 

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -110,6 +110,8 @@ def task_from_record(
     project_name: str, record: dict[str, Any], context: dict[str, Any]
 ) -> TaskNode:
     """Construct a task node from a DB row."""
+
+    folder = None
     if context:
         folder_data = {}
         for key, value in record.items():
@@ -126,9 +128,7 @@ def task_from_record(
                     else None
                 )
             except KeyError:
-                folder = None
-    else:
-        folder = None
+                pass
 
     current_user = context["user"]
     assignees: list[str] = []

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -38,6 +38,7 @@ class TaskNode(BaseNode):
     has_reviewables: bool
     tags: list[str]
     data: str | None
+    path: str | None = None
 
     _attrib: strawberry.Private[dict[str, Any]]
     _inherited_attrib: strawberry.Private[dict[str, Any]]
@@ -97,6 +98,13 @@ class TaskNode(BaseNode):
         """Return a list of attributes that are defined on the task."""
         return list(self._attrib.keys())
 
+    @strawberry.field()
+    def parents(self) -> list[str]:
+        if not self.path:
+            return []
+        path = self.path.strip("/")
+        return path.split("/")[:-1] if path else []
+
 
 def task_from_record(
     project_name: str, record: dict[str, Any], context: dict[str, Any]
@@ -145,6 +153,11 @@ def task_from_record(
             relation=thumb_data.get("relation"),
         )
 
+    path = None
+    if record.get("_folder_path"):
+        folder_path = record["_folder_path"].strip("/")
+        path = f"/{folder_path}/{record['name']}"
+
     return TaskNode(
         project_name=project_name,
         id=record["id"],
@@ -160,6 +173,7 @@ def task_from_record(
         tags=record["tags"],
         data=json_dumps(data) if data else None,
         active=record["active"],
+        path=path,
         created_at=record["created_at"],
         updated_at=record["updated_at"],
         _folder=folder,

--- a/ayon_server/graphql/nodes/workfile.py
+++ b/ayon_server/graphql/nodes/workfile.py
@@ -82,7 +82,7 @@ def workfile_from_record(
             relation=thumb_data.get("relation"),
         )
 
-    parents = []
+    parents: list[str] = []
     if record["_folder_path"]:
         path = record["_folder_path"].strip("/")
         parents = path.split("/")[:-1] if path else []

--- a/ayon_server/graphql/nodes/workfile.py
+++ b/ayon_server/graphql/nodes/workfile.py
@@ -32,10 +32,10 @@ class WorkfileNode(BaseNode):
     status: str
     data: str | None
     tags: list[str]
-    parents: list[str] | None = None
 
     _attrib: strawberry.Private[dict[str, Any]]
     _user: strawberry.Private[UserEntity]
+    _parents: list[str] | None = None
 
     @strawberry.field(description="Parent task of the workfile")
     async def task(self, info: Info) -> TaskNode:
@@ -56,6 +56,10 @@ class WorkfileNode(BaseNode):
     @strawberry.field
     def all_attrib(self) -> str:
         return json_dumps(self._attrib)
+
+    @strawberry.field()
+    def parents(self) -> list[str]:
+        return self._parents or []
 
 
 #
@@ -101,12 +105,12 @@ def workfile_from_record(
         active=record["active"],
         status=record["status"],
         tags=record["tags"],
-        parents=parents,
         data=json_dumps(data) if data else None,
         created_at=record["created_at"],
         updated_at=record["updated_at"],
         _attrib=record["attrib"] or {},
         _user=context["user"],
+        _parents=parents,
     )
 
 

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -173,6 +173,8 @@ async def get_products(
         or (access_list is not None)
         or (path_ex is not None)
         or search
+        or fields.any_endswith("parents")
+        or fields.any_endswith("path")
     ):
         sql_columns.extend(
             [

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -357,6 +357,8 @@ async def get_tasks(
         or search
         or sort_by == "path"
         or "folder" in fields
+        or fields.any_endswith("path")
+        or fields.any_endswith("parents")
     ):
         sql_columns.extend(
             [

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -232,7 +232,13 @@ async def get_versions(
             condition = " OR ".join(sub_conditions)
             sql_conditions.append(f"({condition})")
 
+    if fields.any_endswith("path") or fields.any_endswith("parents"):
+        needs_hierarchy = True
+
     if needs_hierarchy:
+        sql_columns.append("hierarchy.path AS _folder_path")
+        sql_columns.append("products.name AS _product_name")
+
         sql_joins.append(
             f"""
             INNER JOIN project_{project_name}.products AS products

--- a/ayon_server/graphql/resolvers/workfiles.py
+++ b/ayon_server/graphql/resolvers/workfiles.py
@@ -86,25 +86,25 @@ async def get_workfiles(
     if ids is not None:
         if not ids:
             return WorkfilesConnection()
-        sql_conditions.append(f"id IN {SQLTool.id_array(ids)}")
+        sql_conditions.append(f"workfiles.id IN {SQLTool.id_array(ids)}")
 
     if task_ids is not None:
         if not task_ids:
             return WorkfilesConnection()
         sql_conditions.append(f"task_id IN {SQLTool.id_array(task_ids)}")
     elif root.__class__.__name__ == "TaskNode":
-        sql_conditions.append(f"task_id = '{root.id}'")
+        sql_conditions.append(f"workfiles.task_id = '{root.id}'")
 
     if paths is not None:
         if not paths:
             return WorkfilesConnection()
         paths = [r.replace("'", "''") for r in paths]
-        sql_conditions.append(f"path IN {SQLTool.array(paths)}")
+        sql_conditions.append(f"workfiles.path IN {SQLTool.array(paths)}")
 
     if path_ex:
         # TODO: is this safe?
         path_ex = path_ex.replace("'", "''").replace("\\", "\\\\")
-        sql_conditions.append(f"path ~ '{path_ex}'")
+        sql_conditions.append(f"workfiles.path ~ '{path_ex}'")
 
     if has_links is not None:
         sql_conditions.extend(
@@ -115,12 +115,12 @@ async def get_workfiles(
         if not statuses:
             return WorkfilesConnection()
         validate_status_list(statuses)
-        sql_conditions.append(f"status IN {SQLTool.array(statuses)}")
+        sql_conditions.append(f"workfiles.status IN {SQLTool.array(statuses)}")
     if tags is not None:
         if not tags:
             return WorkfilesConnection()
         validate_name_list(tags)
-        sql_conditions.append(f"tags @> {SQLTool.array(tags, curly=True)}")
+        sql_conditions.append(f"workfiles.tags @> {SQLTool.array(tags, curly=True)}")
 
     access_list = await create_folder_access_list(root, info)
     if access_list is not None or search or fields.any_endswith("parents"):


### PR DESCRIPTION
Added a `path` field to `ProductNode`, `RepresentationNode`, `TaskNode`, `VersionNode`, and `WorkfileNode` to store hierarchical path information. Introduced a `parents` field to compute parent elements based on the path.

This pull request enhances the GraphQL data loading and node structure in the `ayon_server` project by adding support for hierarchical paths and parent relationships. These changes improve data querying capabilities and enable more detailed representations of entities like products, tasks, versions, and workfiles. Key updates include modifications to data loaders, node definitions, and resolvers.