### PR TITLE
GraphQL: Support for parents/path for list items entities

### DIFF
--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -220,7 +220,7 @@ async def get_entity_list_items(
         # as well because of the inheritance
         sql_columns.append("px.attrib as _entity_parent_folder_attrib")
         sql_columns.append("pf.folder_type as _parent_folder_type")
-        sql_columns.append("hierarchy.path AS _entity___folder_path")
+        sql_columns.append("hierarchy.path AS _entity__folder_path")
         sql_joins.extend(
             [
                 f"""

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -307,13 +307,13 @@ async def get_entity_list_items(
         sql_joins.extend(
             [
                 f"""
-            INNER JOIN project_{project_name}.folders AS pf
-            ON e.folder_id = pf.id
-            """,
+                INNER JOIN project_{project_name}.folders AS pf
+                ON e.folder_id = pf.id
+                """,
                 f"""
-            INNER JOIN project_{project_name}.hierarchy AS hierarchy
-            ON e.folder_id = hierarchy.id
-            """,
+                INNER JOIN project_{project_name}.hierarchy AS hierarchy
+                ON e.folder_id = hierarchy.id
+                """,
             ]
         )
         allowed_parent_keys = ["folder_type"]

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -220,6 +220,7 @@ async def get_entity_list_items(
         # as well because of the inheritance
         sql_columns.append("px.attrib as _entity_parent_folder_attrib")
         sql_columns.append("pf.folder_type as _parent_folder_type")
+        sql_columns.append("hierarchy.path AS _entity___folder_path")
         sql_joins.extend(
             [
                 f"""
@@ -229,6 +230,10 @@ async def get_entity_list_items(
                 f"""
                 INNER JOIN project_{project_name}.folders AS pf
                 ON e.folder_id = pf.id
+                """,
+                f"""
+                INNER JOIN project_{project_name}.hierarchy AS hierarchy
+                ON e.folder_id = hierarchy.id
                 """,
             ]
         )
@@ -296,13 +301,20 @@ async def get_entity_list_items(
         sql_columns.extend(
             [
                 "pf.folder_type as _parent_folder_type",
+                "hierarchy.path AS _entity__folder_path",
             ]
         )
-        sql_joins.append(
-            f"""
+        sql_joins.extend(
+            [
+                f"""
             INNER JOIN project_{project_name}.folders AS pf
             ON e.folder_id = pf.id
-            """
+            """,
+                f"""
+            INNER JOIN project_{project_name}.hierarchy AS hierarchy
+            ON e.folder_id = hierarchy.id
+            """,
+            ]
         )
         allowed_parent_keys = ["folder_type"]
 
@@ -312,6 +324,8 @@ async def get_entity_list_items(
                 "pf.folder_type as _parent_folder_type",
                 "pd.product_type as _parent_product_type",
                 "pt.task_type as _parent_task_type",
+                "hierarchy.path AS _entity__folder_path",
+                "pd.name AS _entity__product_name",
             ]
         )
         sql_joins.extend(
@@ -327,6 +341,10 @@ async def get_entity_list_items(
                 f"""
                 LEFT JOIN project_{project_name}.tasks AS pt
                 ON e.task_id = pt.id
+                """,
+                f"""
+                INNER JOIN project_{project_name}.hierarchy AS hierarchy
+                ON pd.folder_id = hierarchy.id
                 """,
             ]
         )
@@ -351,8 +369,6 @@ async def get_entity_list_items(
                 ) AS _entity_has_reviewables
                 """
             )
-
-    # The rest of the entity types should work out of the box
 
     # Unified attributes
     # Create additions column _all_attrib that contains all attributes


### PR DESCRIPTION
`path` and `parents attribute is now available on entity nodes accessed via entitylist.items


This pull request enhances the `get_entity_list_items` resolver in `ayon_server/graphql/resolvers/entity_list_items.py` to include additional hierarchy data in the SQL queries. The changes focus on extending the SQL columns and joins to provide more detailed information about folder paths and product names.

<img width="958" height="669" alt="image" src="https://github.com/user-attachments/assets/ef6084f2-cb90-4a61-8483-2316a16d571e" />

<img width="897" height="770" alt="image" src="https://github.com/user-attachments/assets/fdb84e2e-1367-4e6f-b854-a33f6fb9209d" />

