### PR TITLE
Fixed workfiles resolver

### DIFF
--- a/ayon_server/graphql/nodes/workfile.py
+++ b/ayon_server/graphql/nodes/workfile.py
@@ -87,8 +87,8 @@ def workfile_from_record(
         )
 
     parents: list[str] = []
-    if record["_folder_path"]:
-        path = record["_folder_path"].strip("/")
+    if path := record.get("_folder_path"):
+        path = path.strip("/")
         parents = path.split("/")[:-1] if path else []
         parents.append(record["_task_name"])
 


### PR DESCRIPTION
This pull request includes a bugfix o the `workfile_from_record` function in `ayon_server/graphql/nodes/workfile.py`. The change simplifies the code by using the walrus operator (`:=`) to streamline the conditional assignment and processing of the `_folder_path` field. 

The previous logic caused the resolver to crash when path or parents field was not specified.