### PR TITLE
Shell: dbshell tool

### DIFF
--- a/dbshell
+++ b/dbshell
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+url="${AYON_POSTGRES_URL}"
+if [[ -z "$url" ]]; then
+  url=postgres://ayon:ayon@postgres/ayon
+fi
+
+# Remove scheme (postgres://)
+url="${url#postgres://}"
+
+# Extract user and host parts
+userpass="${url%@*}"
+hostdb="${url#*@}"
+
+# Extract user and password
+user="${userpass%%:*}"
+pass="${userpass#*:}"
+
+# Extract host and db
+hostport="${hostdb%%/*}"
+dbname="${hostdb#*/}"
+
+# Split host and optional port
+host="${hostport%%:*}"
+port="${hostport#*:}"
+# if no port specified, default to 5432
+[[ "$host" == "$port" ]] && port="5432"  
+
+PGPASSWORD="${pass}" psql -U "${user}" -h "${host}" -p "${port}" "${dbname}"


### PR DESCRIPTION
This pull request introduces a new `dbshell` script to simplify connecting to a PostgreSQL database by parsing the connection URL and using `psql`. The script includes logic to handle default values for the connection URL and port if they are not explicitly provided.

### Key changes:

* Added a Bash script (`dbshell`) that extracts and parses components from the `AYON_POSTGRES_URL` environment variable or defaults to `postgres://ayon:ayon@postgres/ayon` if the variable is not set.