### PR TITLE
Force update improvements in entity operations

### DIFF
--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -63,6 +63,8 @@ async def sanitize_folder_update(
 ) -> None:
     """
     Sanitize folder update operation to ensure that only allowed fields are updated.
+
+    Note: This function modifies the update_payload_dict in place!
     """
 
     folder_entity = cast(FolderEntity, entity)


### PR DESCRIPTION
Use `force` flag to allow changing folder name and parent even when it has published versions.

### Refactoring for code reusability:

* Added a new helper function `sanitize_folder_update` to encapsulate the logic for sanitizing folder update operations. This function ensures that only allowed fields are updated and raises a `ForbiddenException` if changes are attempted on restricted fields for folders with published versions.

* Replaced the inline folder sanitization logic in the `update_project_level_entity` function with a call to the newly introduced `sanitize_folder_update` function, streamlining the code and reducing duplication.