### PR TITLE
Fix: Resolver can now handle workfiles URIs

### DIFF
--- a/api/resolve/__init__.py
+++ b/api/resolve/__init__.py
@@ -216,7 +216,7 @@ async def resolve_entities(
         if req.workfile_name is not None:
             cols.append("w.id as workfile_id")
             joins.append("INNER JOIN workfiles AS w ON t.id = w.task_id")
-            conds.append(f"w.name = '{req.workfile_name}'")
+            conds.append(f"w.path LIKE '%/{req.workfile_name}'")
             target_entity_type = "workfile"
 
         conds.extend(get_path_conditions(req.path))


### PR DESCRIPTION
This pull request updates the SQL condition for resolving entities in the `resolve_entities` function to improve flexibility when matching workfile names. Since workfiles do not have `name` fireld, the condition now uses a `LIKE` clause to allow partial matches based on the file path.

<img width="1140" height="797" alt="image" src="https://github.com/user-attachments/assets/14745c09-b56b-4e26-9c51-d11cd4d08d6e" />
