### PR TITLE
Fix: Project folder cache is correctly invalidated upon project deletion

### DIFF
--- a/api/folders/list_folders.py
+++ b/api/folders/list_folders.py
@@ -126,7 +126,7 @@ class FolderListLoader:
         def process_record(record: dict[str, Any]) -> dict[str, Any]:
             return {camelize_memoized(k): v for k, v in record.items()}
 
-        entities_data = await Redis.get("project.folders", project_name)
+        entities_data = await Redis.get("project-folders", project_name)
         if entities_data is None:
             folder_list = await rebuild_hierarchy_cache(project_name)
         else:

--- a/ayon_server/entities/project.py
+++ b/ayon_server/entities/project.py
@@ -244,6 +244,7 @@ class ProjectEntity(TopLevelEntity):
             finally:
                 await Redis.delete("project-anatomy", self.name)
                 await Redis.delete("project-data", self.name)
+                await Redis.delete("project-folders", self.name)
                 await build_project_list()
         return True
 

--- a/ayon_server/helpers/hierarchy_cache.py
+++ b/ayon_server/helpers/hierarchy_cache.py
@@ -80,7 +80,7 @@ async def rebuild_hierarchy_cache(project_name: str) -> list[dict[str, Any]]:
     for folder in result:
         folder["has_children"] = folder["id"] in ids_with_children
 
-    await Redis.set("project.folders", project_name, json_dumps(result), 3600)
+    await Redis.set("project-folders", project_name, json_dumps(result), 3600)
     elapsed_time = time.monotonic() - start_time
     logger.trace(
         f"Rebuilt hierarchy cache for {project_name} "


### PR DESCRIPTION
This pull request updates the way folder hierarchy data is cached and managed in Redis by standardizing the cache key format from `project.folders` to `project-folders`. It also ensures that the cache is properly invalidated when a project is deleted.

**Redis cache key standardization:**

* Updated all Redis operations to use the `project-folders` key instead of `project.folders` for storing and retrieving folder hierarchy data.
* Added a step to delete the `project-folders` cache key when a project is deleted, ensuring stale cache data does not persist.