### PR TITLE
Show entity paths in entity events descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ BUILD_DATE
 venv/
 cspell*
 mise.toml
+test_*

--- a/ayon_server/entities/common.py
+++ b/ayon_server/entities/common.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+from ayon_server.exceptions import (
+    NotFoundException,
+    ServiceUnavailableException,
+)
+from ayon_server.lib.postgres import Postgres
+
+
+async def query_entity_data(query: str, entity_id: str) -> dict[str, Any]:
+    try:
+        record = await Postgres.fetchrow(query, entity_id)
+    except Postgres.UndefinedTableError as e:
+        raise NotFoundException("Project does not exist or is not initialized.") from e
+    except Postgres.LockNotAvailableError as e:
+        raise ServiceUnavailableException(
+            f"Entity {entity_id} is locked for update."
+        ) from e
+    if record is None:
+        raise NotFoundException(f"Entity {entity_id} not found")
+    return dict(record)

--- a/ayon_server/entities/core/projectlevel.py
+++ b/ayon_server/entities/core/projectlevel.py
@@ -5,12 +5,12 @@ from typing import Any
 from pydantic import BaseModel
 
 from ayon_server.access.utils import ensure_entity_access
+from ayon_server.entities.common import query_entity_data
 from ayon_server.entities.core.base import BaseEntity
 from ayon_server.exceptions import (
     AyonException,
     ConstraintViolationException,
     NotFoundException,
-    ServiceUnavailableException,
 )
 from ayon_server.helpers.entity_links import remove_entity_links
 from ayon_server.helpers.statuses import get_default_status_for_entity
@@ -174,21 +174,7 @@ class ProjectLevelEntity(BaseEntity):
             {'FOR UPDATE NOWAIT' if for_update else ''}
             """
 
-        try:
-            record = await Postgres.fetchrow(query, entity_id)
-        except Postgres.UndefinedTableError as e:
-            raise NotFoundException(
-                f"Project '{project_name}' does not exist or is not initialized."
-            ) from e
-        except Postgres.LockNotAvailableError as e:
-            raise ServiceUnavailableException(
-                f"Entity {cls.entity_type} {entity_id} is locked for update."
-            ) from e
-        if record is None:
-            raise NotFoundException(
-                f"{cls.entity_type.capitalize()} {entity_id} "
-                f"not found in project {project_name}"
-            )
+        record = await query_entity_data(query, entity_id)
         return cls.from_record(project_name, record)
 
     #

--- a/ayon_server/entities/core/projectlevel.py
+++ b/ayon_server/entities/core/projectlevel.py
@@ -357,6 +357,10 @@ class ProjectLevelEntity(BaseEntity):
     def tags(self, value: list[str]):
         self._payload.tags = value  # type: ignore
 
+    #
+    # Read only properties
+    #
+
     @property
     def entity_subtype(self) -> str | None:
         """Return the entity subtype.
@@ -365,3 +369,7 @@ class ProjectLevelEntity(BaseEntity):
         For other entities this is None.
         """
         return None
+
+    @property
+    def path(self) -> str:
+        return ""

--- a/ayon_server/entities/models/fields.py
+++ b/ayon_server/entities/models/fields.py
@@ -201,7 +201,7 @@ task_fields = [
         "name": "path",
         "type": "string",
         "title": "Path",
-        "example": "/assets/characters/xenomorph/rigging",
+        "example": "/assets/characters/xenomorph/modeling",
         "dynamic": True,
     },
 ]
@@ -233,6 +233,13 @@ product_fields = [
         "description": "Product ",
         "regex": NAME_REGEX,
         "example": "model",
+    },
+    {
+        "name": "path",
+        "type": "string",
+        "title": "Path",
+        "example": "/assets/characters/xenomorph/modelMain",
+        "dynamic": True,
     },
 ]
 
@@ -325,6 +332,13 @@ representation_fields = [
             },
             "ayon.2d.Image.v1": {},
         },
+    },
+    {
+        "name": "path",
+        "type": "string",
+        "title": "Path",
+        "example": "/assets/characters/xenomorph/modelMain/v003/ma",
+        "dynamic": True,
     },
 ]
 

--- a/ayon_server/entities/models/fields.py
+++ b/ayon_server/entities/models/fields.py
@@ -197,6 +197,13 @@ task_fields = [
         "regex": ENTITY_ID_REGEX,
         "example": ENTITY_ID_EXAMPLE,
     },
+    {
+        "name": "path",
+        "type": "string",
+        "title": "Path",
+        "example": "/assets/characters/xenomorph/rigging",
+        "dynamic": True,
+    },
 ]
 
 

--- a/ayon_server/entities/models/fields.py
+++ b/ayon_server/entities/models/fields.py
@@ -271,6 +271,13 @@ version_fields = [
         "regex": USER_NAME_REGEX,
         "example": "john_doe",
     },
+    {
+        "name": "path",
+        "type": "string",
+        "title": "Path",
+        "example": "/assets/characters/xenomorph/modelMain/v003",
+        "dynamic": True,
+    },
 ]
 
 

--- a/ayon_server/entities/product.py
+++ b/ayon_server/entities/product.py
@@ -4,13 +4,52 @@ from ayon_server.entities.models import ModelSet
 from ayon_server.lib.postgres import Postgres
 from ayon_server.types import ProjectLevelEntityType
 
+from .common import query_entity_data
+
 
 class ProductEntity(ProjectLevelEntity):
     entity_type: ProjectLevelEntityType = "product"
     model = ModelSet("product", attribute_library["product"])
 
+    @classmethod
+    async def load(
+        cls,
+        project_name: str,
+        entity_id: str,
+        for_update: bool = False,
+        **kwargs,
+    ):
+        query = f"""
+            SELECT
+                p.id as id,
+                p.name as name,
+                p.folder_id as folder_id,
+                p.product_type as product_type,
+                p.attrib as attrib,
+                p.data as data,
+                p.active as active,
+                p.status as status,
+                p.tags as tags,
+                p.created_at as created_at,
+                p.updated_at as updated_at,
+                h.path as folder_path
+            FROM project_{project_name}.products p
+            JOIN project_{project_name}.hierarchy h ON p.folder_id = h.id
+            WHERE p.id=$1
+            {'FOR UPDATE NOWAIT' if for_update else ''}
+            """
+
+        record = await query_entity_data(query, entity_id)
+
+        hierarchy_path = record.pop("folder_path", None)
+        if hierarchy_path:
+            hierarchy_path = hierarchy_path.strip("/")
+            record["path"] = f"/{hierarchy_path}/{record['name']}"
+
+        return cls.from_record(project_name, record)
+
     #
-    # Properties
+    # Access Control
     #
 
     async def pre_save(self, insert: bool) -> None:
@@ -47,6 +86,10 @@ class ProductEntity(ProjectLevelEntity):
             self.folder_id,
             "publish",
         )
+
+    #
+    # Properties
+    #
 
     @property
     def folder_id(self) -> str:

--- a/ayon_server/entities/representation.py
+++ b/ayon_server/entities/representation.py
@@ -1,12 +1,78 @@
 from ayon_server.access.utils import ensure_entity_access
 from ayon_server.entities.core import ProjectLevelEntity, attribute_library
 from ayon_server.entities.models import ModelSet
+from ayon_server.exceptions import NotFoundException, ServiceUnavailableException
+from ayon_server.lib.postgres import Postgres
 from ayon_server.types import ProjectLevelEntityType
+
+from .version import version_name
 
 
 class RepresentationEntity(ProjectLevelEntity):
     entity_type: ProjectLevelEntityType = "representation"
     model = ModelSet("representation", attribute_library["representation"])
+
+    @classmethod
+    async def load(
+        cls,
+        project_name: str,
+        entity_id: str,
+        for_update: bool = False,
+        **kwargs,
+    ):
+        query = f"""
+            SELECT
+                r.id as id,
+                r.name as name,
+                r.version_id as version_id,
+                r.files as files,
+                r.attrib as attrib,
+                r.data as data,
+                r.traits as traits,
+                r.active as active,
+                r.status as status,
+                r.tags as tags,
+                r.created_at as created_at,
+                r.updated_at as updated_at,
+
+                v.version as version,
+                p.name as product_name,
+                h.path as folder_path
+
+            FROM project_{project_name}.representations r
+            JOIN project_{project_name}.versions v ON r.version_id = v.id
+            JOIN project_{project_name}.products p ON v.product_id = p.id
+            JOIN project_{project_name}.hierarchy h ON p.folder_id = h.id
+            WHERE r.id=$1
+            {'FOR UPDATE NOWAIT' if for_update else ''}
+            """
+
+        try:
+            record = await Postgres.fetchrow(query, entity_id)
+        except Postgres.UndefinedTableError as e:
+            raise NotFoundException(
+                f"Project '{project_name}' does not exist or is not initialized."
+            ) from e
+        except Postgres.LockNotAvailableError as e:
+            raise ServiceUnavailableException(
+                f"Entity {cls.entity_type} {entity_id} is locked for update."
+            ) from e
+        if record is None:
+            raise NotFoundException(
+                f"{cls.entity_type.capitalize()} {entity_id} "
+                f"not found in project {project_name}"
+            )
+
+        record = dict(record)
+        hierarchy_path = record.pop("folder_path", None)
+        product_name = record.pop("product_name", None)
+        if hierarchy_path and product_name:
+            hierarchy_path = hierarchy_path.strip("/")
+            vname = version_name(record["version"])
+            rname = record["name"]
+            record["path"] = f"/{hierarchy_path}/{product_name}/{vname}/{rname}"
+
+        return cls.from_record(project_name, record)
 
     async def ensure_create_access(self, user, **kwargs) -> None:
         if user.is_manager:

--- a/ayon_server/entities/representation.py
+++ b/ayon_server/entities/representation.py
@@ -1,8 +1,7 @@
 from ayon_server.access.utils import ensure_entity_access
+from ayon_server.entities.common import query_entity_data
 from ayon_server.entities.core import ProjectLevelEntity, attribute_library
 from ayon_server.entities.models import ModelSet
-from ayon_server.exceptions import NotFoundException, ServiceUnavailableException
-from ayon_server.lib.postgres import Postgres
 from ayon_server.types import ProjectLevelEntityType
 
 from .version import version_name
@@ -47,23 +46,8 @@ class RepresentationEntity(ProjectLevelEntity):
             {'FOR UPDATE NOWAIT' if for_update else ''}
             """
 
-        try:
-            record = await Postgres.fetchrow(query, entity_id)
-        except Postgres.UndefinedTableError as e:
-            raise NotFoundException(
-                f"Project '{project_name}' does not exist or is not initialized."
-            ) from e
-        except Postgres.LockNotAvailableError as e:
-            raise ServiceUnavailableException(
-                f"Entity {cls.entity_type} {entity_id} is locked for update."
-            ) from e
-        if record is None:
-            raise NotFoundException(
-                f"{cls.entity_type.capitalize()} {entity_id} "
-                f"not found in project {project_name}"
-            )
+        record = await query_entity_data(query, entity_id)
 
-        record = dict(record)
         hierarchy_path = record.pop("folder_path", None)
         product_name = record.pop("product_name", None)
         if hierarchy_path and product_name:

--- a/ayon_server/entities/version.py
+++ b/ayon_server/entities/version.py
@@ -3,14 +3,94 @@ from typing import NoReturn
 from ayon_server.access.utils import ensure_entity_access
 from ayon_server.entities.core import ProjectLevelEntity, attribute_library
 from ayon_server.entities.models import ModelSet
-from ayon_server.exceptions import ConstraintViolationException
+from ayon_server.exceptions import (
+    ConstraintViolationException,
+    NotFoundException,
+    ServiceUnavailableException,
+)
 from ayon_server.lib.postgres import Postgres
 from ayon_server.types import ProjectLevelEntityType
+
+
+def version_name(version: int) -> str:
+    if version < 0:
+        return "HERO"
+    return f"v{version:03d}"
 
 
 class VersionEntity(ProjectLevelEntity):
     entity_type: ProjectLevelEntityType = "version"
     model = ModelSet("version", attribute_library["version"])
+
+    @classmethod
+    async def load(
+        cls,
+        project_name: str,
+        entity_id: str,
+        for_update: bool = False,
+        **kwargs,
+    ):
+        """Return an entity instance based on its ID and a project name.
+
+        Raise ValueError if project_name or base_id is not valid.
+        Raise KeyError if the folder does not exists.
+
+        Set for_update=True and pass a transaction to lock the row
+        for update.
+        """
+
+        query = f"""
+            SELECT
+                v.id as id,
+                v.version as version,
+                v.product_id as product_id,
+                v.task_id as task_id,
+                v.thumbnail_id as thumbnail_id,
+                v.author as author,
+
+                v.attrib as attrib,
+                v.data as data,
+                v.active as active,
+                v.status as status,
+                v.tags as tags,
+                v.created_at as created_at,
+                v.updated_at as updated_at,
+
+                p.name as product_name,
+                h.path as folder_path
+
+            FROM project_{project_name}.versions v
+            JOIN project_{project_name}.products p ON v.product_id = p.id
+            JOIN project_{project_name}.hierarchy h ON p.folder_id = h.id
+            WHERE v.id=$1
+            {'FOR UPDATE NOWAIT' if for_update else ''}
+            """
+
+        try:
+            record = await Postgres.fetchrow(query, entity_id)
+        except Postgres.UndefinedTableError as e:
+            raise NotFoundException(
+                f"Project '{project_name}' does not exist or is not initialized."
+            ) from e
+        except Postgres.LockNotAvailableError as e:
+            raise ServiceUnavailableException(
+                f"Entity {cls.entity_type} {entity_id} is locked for update."
+            ) from e
+        if record is None:
+            raise NotFoundException(
+                f"{cls.entity_type.capitalize()} {entity_id} "
+                f"not found in project {project_name}"
+            )
+
+        record = dict(record)
+        hierarchy_path = record.pop("folder_path", None)
+        product_name = record.pop("product_name", None)
+        if hierarchy_path and product_name:
+            hierarchy_path = hierarchy_path.strip("/")
+            vname = version_name(record["version"])
+            record["path"] = f"/{hierarchy_path}/{product_name}/{vname}"
+
+        return cls.from_record(project_name, record)
 
     async def pre_save(self, insert: bool) -> None:
         if self.version < 0:
@@ -82,9 +162,7 @@ class VersionEntity(ProjectLevelEntity):
 
     @property
     def name(self) -> str:
-        if self.version < 0:
-            return "HERO"
-        return f"v{self.version:03d}"
+        return version_name(self.version)
 
     @name.setter
     def name(self, value: str) -> NoReturn:

--- a/ayon_server/entities/version.py
+++ b/ayon_server/entities/version.py
@@ -30,15 +30,6 @@ class VersionEntity(ProjectLevelEntity):
         for_update: bool = False,
         **kwargs,
     ):
-        """Return an entity instance based on its ID and a project name.
-
-        Raise ValueError if project_name or base_id is not valid.
-        Raise KeyError if the folder does not exists.
-
-        Set for_update=True and pass a transaction to lock the row
-        for update.
-        """
-
         query = f"""
             SELECT
                 v.id as id,

--- a/ayon_server/entities/version.py
+++ b/ayon_server/entities/version.py
@@ -208,3 +208,11 @@ class VersionEntity(ProjectLevelEntity):
     @property
     def author(self) -> str:
         return self._payload.author  # type: ignore
+
+    #
+    # Read only properties
+    #
+
+    @property
+    def path(self) -> str:
+        return self._payload.path  # type: ignore

--- a/ayon_server/events/patch.py
+++ b/ayon_server/events/patch.py
@@ -95,13 +95,17 @@ def build_pl_entity_change_events(
     result: list[EventData] = []
     common_data = {
         "project": original_entity.project_name,
-        "summary": {"entityId": original_entity.id, "parentId": parent_id},
+        "summary": {
+            "entityId": original_entity.id,
+            "parentId": parent_id,
+            "entityPath": original_entity.path,
+        },
     }
 
     if (new_name := patch_data.get("name")) is not None:
         if new_name != original_entity.name:
             description = (
-                f"Renamed {entity_type} {original_entity.name} to {patch.name}"  # type: ignore
+                f"Renamed {entity_type} {original_entity.path} to {patch.name}"  # type: ignore
             )
             result.append(
                 {
@@ -120,7 +124,7 @@ def build_pl_entity_change_events(
     if (new_status := patch_data.get("status")) is not None:
         if new_status != original_entity.status:
             description = (
-                f"Changed {entity_type} {original_entity.name} status to {patch.status}"  # type: ignore
+                f"Changed {entity_type} {original_entity.path} status to {patch.status}"  # type: ignore
             )
             result.append(
                 {
@@ -139,7 +143,7 @@ def build_pl_entity_change_events(
     if (new_tags := patch_data.get("tags")) is not None:
         if new_tags != original_entity.tags:
             description = get_tags_description(
-                f"{entity_type} {original_entity.name}",
+                f"{entity_type} {original_entity.path}",
                 original_entity.tags,
                 patch.tags,  # type: ignore
             )
@@ -182,7 +186,7 @@ def build_pl_entity_change_events(
         if new_attributes:
             attr_list = ", ".join(new_attributes.keys())
             evt["description"] = (
-                f"Changed {entity_type} {original_entity.name} attributes: {attr_list}"
+                f"Changed {entity_type} {original_entity.path} attributes: {attr_list}"
             )
             result.append(evt)
 
@@ -196,15 +200,18 @@ def build_pl_entity_change_events(
         if getattr(original_entity, column_name) == patch_data.get(column_name):
             continue
 
-        description = f"Changed {entity_type} {original_entity.name} {column_name}"
+        description = f"Changed {entity_type} {original_entity.path} {column_name}"
+        desc_nval = str(patch_data[column_name])
+        if len(desc_nval) < 30:
+            description += f" to {desc_nval}"
         if column_name == "active":
             if patch_data.get("active"):
                 description = (
-                    f"{entity_type.capitalize()} {original_entity.name} activated"
+                    f"{entity_type.capitalize()} {original_entity.path} activated"
                 )
             else:
                 description = (
-                    f"{entity_type.capitalize()} {original_entity.name} deactivated"
+                    f"{entity_type.capitalize()} {original_entity.path} deactivated"
                 )
 
         result.append(

--- a/ayon_server/operations/project_level/entity_delete.py
+++ b/ayon_server/operations/project_level/entity_delete.py
@@ -31,7 +31,7 @@ async def delete_project_level_entity(
     # Create events and delete the entity
     #
 
-    description = f"{operation.entity_type.capitalize()} {entity.name} deleted"
+    description = f"{operation.entity_type.capitalize()} {entity.path} deleted"
     events = [
         {
             "topic": f"entity.{operation.entity_type}.deleted",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ plugins = [
 
 check_untyped_defs = true
 disallow_any_generics = true
-exclude = "tests/|venv/|tool/"
+exclude = "tests/|venv/|tool/|test_"
 explicit_package_bases = true
 no_implicit_reexport = true
 strict_optional = true


### PR DESCRIPTION
This pull request refactors entity loading logic across several core entity types to centralize error handling and data retrieval, and introduces a standardized `path` property for entities. The changes improve code maintainability, consistency, add richer metadata to entity models and provides feature parity with GraphQL resolvers. Entity `path` attribute is now exposed on all project level entities and is used in relevant event descriptions.

* Added a new helper function `query_entity_data` in `common.py` to centralize entity data fetching and error handling for all entities. All entity `load` methods now use this helper, reducing code duplication and ensuring consistent exception handling. 
* Implemented a computed `path` property for `Product`, `Version`, `Representation`, and `Task` entities, which constructs a hierarchical path string representing the entity's location. This property is now included in entity records and exposed via a read-only property. 
* Added the `path` field to the model definitions for all relevant entity types, marking it as a dynamic string field and providing example values. This ensures the `path` property is documented and available in the entity schemas. 


<img width="1464" height="242" alt="image" src="https://github.com/user-attachments/assets/9dc38f8d-1e9a-4646-b54a-adea748a4781" />
