### PR TITLE
Sort folders by links count

### DIFF
--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -364,6 +364,34 @@ async def get_folders(
             order_by.insert(0, SORT_OPTIONS[sort_by])
         elif sort_by.startswith("attrib."):
             order_by.insert(0, f"folders.attrib->>'{sort_by[7:]}'")
+
+        elif sort_by.startswith("links."):
+            # sort by count of links
+            _, link_type, direction = sort_by.split(".")
+
+            direction = "out" if direction == "in" else "in"
+
+            sql_cte.append(
+                f"""
+                link_counts AS (
+                    SELECT COUNT(id) AS link_count, {direction}put_id AS link_entity_id
+                    FROM project_{project_name}.links
+                    WHERE link_type LIKE '{link_type}%'
+                    GROUP BY {direction}put_id
+                )
+                """
+            )
+
+            sql_joins.append(
+                """
+                LEFT JOIN link_counts
+                ON folders.id = link_counts.link_entity_id
+                """
+            )
+
+            order_by.insert(0, "COALESCE(link_counts.link_count, 0)")
+            sql_group_by.append("link_counts.link_count")
+
         else:
             raise ValueError(f"Invalid sort_by value: {sort_by}")
 


### PR DESCRIPTION
This pull request adds support for sorting folders by the count of related links in the `get_folders` resolver. The main change introduces logic to handle sorting by link counts, including updates to SQL common table expressions, joins, and ordering.

Sorting enhancements:

* Added support for sorting folders by the count of links of a specific type and direction in the `get_folders` resolver in `ayon_server/graphql/resolvers/folders.py`. This includes constructing a SQL CTE to count links, joining the results, and updating the order and group by clauses accordingly.

<img width="1025" height="833" alt="image" src="https://github.com/user-attachments/assets/039198cd-3948-471b-a1f0-34b52873ac93" />
