### PR TITLE
Maintenance: auto-remove inactive workers

### DIFF
--- a/maintenance/tasks/__init__.py
+++ b/maintenance/tasks/__init__.py
@@ -2,6 +2,7 @@ __all__ = ["task_sequence"]
 
 from .auto_update import AutoUpdate
 from .push_metrics import PushMetrics
+from .remove_inactive_workers import RemoveInactiveWorkers
 from .remove_old_action_configs import RemoveOldActionConfigs
 from .remove_old_events import RemoveOldEvents
 from .remove_old_logs import RemoveOldLogs
@@ -13,6 +14,7 @@ from .remove_unused_thumbnails import RemoveUnusedThumbnails
 
 task_sequence = [
     AutoUpdate,
+    RemoveInactiveWorkers,
     RemoveOldActionConfigs,
     RemoveOldLogs,
     RemoveOldEvents,

--- a/maintenance/tasks/remove_inactive_workers.py
+++ b/maintenance/tasks/remove_inactive_workers.py
@@ -1,0 +1,28 @@
+from ayon_server.lib.postgres import Postgres
+from ayon_server.logging import logger
+from maintenance.maintenance_task import StudioMaintenanceTask
+
+
+class RemoveInactiveWorkers(StudioMaintenanceTask):
+    description = "Removing inactive workers"
+
+    async def main(self):
+        query = """
+            SELECT h.name
+            FROM hosts h
+            WHERE h.last_seen < NOW() - INTERVAL '1 day'
+            AND NOT EXISTS (
+                SELECT 1
+                FROM services s
+                WHERE s.hostname = h.name
+            );
+        """
+
+        candidates = await Postgres.fetch(query)
+        if not candidates:
+            return
+
+        for row in candidates:
+            hostname = row["name"]
+            await Postgres.execute("DELETE FROM hosts WHERE name = $1", hostname)
+            logger.info(f"Removed inactive worker: {hostname}")


### PR DESCRIPTION
This pull request adds a new maintenance task to automatically remove inactive worker hosts from the database. The main changes are the introduction of the `RemoveInactiveWorkers` task and its integration into the maintenance task sequence.

* Added `RemoveInactiveWorkers` class in `remove_inactive_workers.py`, which identifies and deletes hosts that have not been seen for over a day and are not associated with any active service.
