### PR TITLE
API: Add hasVersions flag to folders

### DIFF
--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -318,3 +318,8 @@ class FolderEntity(ProjectLevelEntity):
     @property
     def entity_subtype(self) -> str | None:
         return self.folder_type
+
+    @property
+    def has_versions(self) -> bool:
+        """Check if the folder has any versions."""
+        return self._payload.has_versions  # type: ignore

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -56,7 +56,13 @@ class FolderEntity(ProjectLevelEntity):
                 f.tags as tags,
                 h.path as path,
                 ia.attrib AS inherited_attrib,
-                p.attrib AS project_attrib
+                p.attrib AS project_attrib,
+                exists(
+                    select 1 from project_{project_name}.versions v
+                    inner join project_{project_name}.products p
+                    on p.id = v.product_id
+                    where p.folder_id = f.id
+                ) as has_versions
             FROM project_{project_name}.folders as f
             INNER JOIN
                 project_{project_name}.hierarchy as h

--- a/ayon_server/entities/models/fields.py
+++ b/ayon_server/entities/models/fields.py
@@ -148,6 +148,13 @@ folder_fields = [
         "example": "/assets/characters/xenomorph",
         "dynamic": True,
     },
+    {
+        "name": "has_versions",
+        "type": "boolean",
+        "title": "Has versions",
+        "example": True,
+        "dynamic": True,
+    },
 ]
 
 

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -46,6 +46,7 @@ class FolderNode(BaseNode):
     child_count: int = strawberry.field(default=0)
     product_count: int = strawberry.field(default=0)
     task_count: int = strawberry.field(default=0)
+    has_versions: bool = strawberry.field(default=False)
     has_reviewables: bool = strawberry.field(default=False)
 
     products: ProductsConnection = strawberry.field(
@@ -168,6 +169,7 @@ def folder_from_record(
         product_count=record.get("product_count", 0),
         task_count=record.get("task_count", 0),
         has_reviewables=has_reviewables,
+        has_versions=record.get("has_versions", False),
         path="/" + record.get("path", "").strip("/"),
         _attrib=record["attrib"] or {},
         _project_attrib=record["project_attributes"] or {},

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -206,12 +206,12 @@ async def get_folders(
     if fields.any_endswith("hasVersions"):
         sql_columns.append(
             f"""
-            EXISTS(
-                SELECT 1 FROM project_{project_name}.versions v
-                INNER JOIN project_{project_name}.products p
-                ON p.id = v.product_id
-                WHERE p.folder_id = folders.id
-            ) AS has_versions
+            exists(
+                select 1 from project_{project_name}.versions v
+                inner join project_{project_name}.products p
+                on p.id = v.product_id
+                where p.folder_id = folders.id
+            ) as has_versions
             """
         )
 

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -203,6 +203,18 @@ async def get_folders(
             """
         )
 
+    if fields.any_endswith("hasVersions"):
+        sql_columns.append(
+            f"""
+            EXISTS(
+                SELECT 1 FROM project_{project_name}.versions v
+                INNER JOIN project_{project_name}.products p
+                ON p.id = v.product_id
+                WHERE p.folder_id = folders.id
+            ) AS has_versions
+            """
+        )
+
     #
     # Conditions
     #

--- a/ayon_server/helpers/hierarchy_cache.py
+++ b/ayon_server/helpers/hierarchy_cache.py
@@ -35,7 +35,15 @@ async def rebuild_hierarchy_cache(project_name: str) -> list[dict[str, Any]]:
             ea.path as path,
             COUNT (tasks.id) AS task_count,
             array_agg(tasks.name) AS task_names,
-            EXISTS (SELECT 1 FROM reviewables WHERE folder_id = f.id) AS has_reviewables
+            EXISTS (
+                SELECT 1 FROM reviewables WHERE folder_id = f.id
+            ) AS has_reviewables,
+            EXISTS (
+                SELECT 1 from project_{project_name}.versions v
+                INNER join project_{project_name}.products p
+                ON p.id = v.product_id
+                WHERE p.folder_id = f.id
+            ) AS has_versions
         FROM
             project_{project_name}.folders f
         INNER JOIN
@@ -71,6 +79,7 @@ async def rebuild_hierarchy_cache(project_name: str) -> list[dict[str, Any]]:
                     "tags": row["tags"],
                     "own_attrib": list(row["attrib"].keys()),
                     "has_reviewables": row["has_reviewables"],
+                    "has_versions": row["has_versions"],
                     "updated_at": row["updated_at"],
                 }
             )

--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -68,7 +68,6 @@ async def sanitize_folder_update(
     """
 
     folder_entity = cast(FolderEntity, entity)
-    has_versions = bool(await folder_entity.get_versions())
     existing_folder_data = folder_entity.payload.dict(exclude_none=True)
     if not operation.force:
         for key in ("name", "folder_type", "parent_id"):
@@ -76,7 +75,7 @@ async def sanitize_folder_update(
                 continue
             old_value = existing_folder_data.get(key)
             new_value = update_payload_dict[key]
-            if has_versions and old_value != new_value:
+            if folder_entity.has_versions and old_value != new_value:
                 raise ForbiddenException(
                     f"Cannot change {key} of a folder with published versions"
                 )


### PR DESCRIPTION
This pull request introduces a new `has_versions` property to folder entities, enabling the system to efficiently determine whether a folder contains any published versions. This enhancement improves both backend logic and GraphQL API capabilities, allowing for more robust validation and querying of folder state.

* Added a SQL query to check if a folder has any associated versions in the `load` method of `folder.py`, and exposed this as the new `has_versions` property on the `FolderEntity` class.
* Updated the folder model field definitions to include the new `has_versions` boolean field, making it available for schema introspection and documentation.
* Added the `has_versions` field to the `FolderNode` GraphQL type and ensured it is populated from database records when resolving folders.
* Modified the folders resolver to include logic for selecting the `has_versions` value when requested via GraphQL queries.
* Added `has_versions` tracking to the hierarchy cache SQL and ensured it is included in the cached folder data. 
* Updated folder update validation logic to use the new `has_versions` property, preventing changes to key folder fields if published versions exist.