### PR TITLE
Prevent nesting folders into themselves

### DIFF
--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -270,6 +270,26 @@ class FolderEntity(ProjectLevelEntity):
         )
 
     #
+    # Helper methods
+    #
+
+    async def get_folder_descendant_ids(self) -> set[str]:
+        query = f"""
+            WITH RECURSIVE descendants AS (
+                SELECT id, parent_id
+                FROM project_{self.project_name}.folders
+                WHERE parent_id = $1
+                UNION
+                SELECT f.id, f.parent_id
+                FROM project_{self.project_name}.folders f
+                INNER JOIN descendants d ON f.parent_id = d.id
+            )
+            SELECT id FROM descendants;
+        """
+        rows = await Postgres.fetch(query, self.id)
+        return {row["id"] for row in rows}
+
+    #
     # Properties
     #
 

--- a/ayon_server/operations/project_level/entity_create.py
+++ b/ayon_server/operations/project_level/entity_create.py
@@ -37,7 +37,7 @@ async def create_project_level_entity(
             payload_dict["updated_by"] = payload_dict["created_by"]
 
     elif operation.entity_type == "folder":
-        if payload_dict["id"] == payload_dict["parent_id"]:
+        if payload_dict["id"] == payload_dict.get("parent_id"):
             raise BadRequestException("Folder cannot be its own parent")
 
     #

--- a/ayon_server/operations/project_level/entity_create.py
+++ b/ayon_server/operations/project_level/entity_create.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from ayon_server.entities import UserEntity
 from ayon_server.entities.core import ProjectLevelEntity
-from ayon_server.exceptions import ForbiddenException
+from ayon_server.exceptions import BadRequestException, ForbiddenException
 
 from .models import OperationModel
 
@@ -35,6 +35,10 @@ async def create_project_level_entity(
             payload_dict["created_by"] = user.name
         if not payload_dict.get("updated_by"):
             payload_dict["updated_by"] = payload_dict["created_by"]
+
+    elif operation.entity_type == "folder":
+        if payload_dict["id"] == payload_dict["parent_id"]:
+            raise BadRequestException("Folder cannot be its own parent")
 
     #
     # Create the entity and events

--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -80,6 +80,16 @@ async def sanitize_folder_update(
                     f"Cannot change {key} of a folder with published versions"
                 )
 
+    if "parent_id" in update_payload_dict:
+        # Prevent setting parent_id to self or any of its descendants
+        new_parent_id = update_payload_dict["parent_id"]
+        if new_parent_id == entity.id:
+            raise ForbiddenException("Folder cannot be its own parent")
+
+        descendants = await folder_entity.get_folder_descendant_ids()
+        if new_parent_id in descendants:
+            raise ForbiddenException("Folder cannot be moved to one of its descendants")
+
 
 async def update_project_level_entity(
     entity_class: type[ProjectLevelEntity],

--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 from ayon_server.entities import FolderEntity, UserEntity
 from ayon_server.entities.core import ProjectLevelEntity
 from ayon_server.events.patch import build_pl_entity_change_events
-from ayon_server.exceptions import ForbiddenException
+from ayon_server.exceptions import BadRequestException, ForbiddenException
 from ayon_server.lib.postgres import Postgres
 
 from .models import OperationModel
@@ -84,11 +84,13 @@ async def sanitize_folder_update(
         # Prevent setting parent_id to self or any of its descendants
         new_parent_id = update_payload_dict["parent_id"]
         if new_parent_id == entity.id:
-            raise ForbiddenException("Folder cannot be its own parent")
+            raise BadRequestException("Folder cannot be its own parent")
 
         descendants = await folder_entity.get_folder_descendant_ids()
         if new_parent_id in descendants:
-            raise ForbiddenException("Folder cannot be moved to one of its descendants")
+            raise BadRequestException(
+                "Folder cannot be moved to one of its descendants"
+            )
 
 
 async def update_project_level_entity(


### PR DESCRIPTION
This pull request introduces important validation and helper logic to ensure folder hierarchy integrity during creation and updates. The main focus is preventing folders from being set as their own parent or as a parent to any of their descendants, which helps avoid circular references and maintains a valid tree structure.

* Added a check during folder creation to prevent a folder from being its own parent, raising a `BadRequestException` if attempted.
* During folder update, added logic to prevent setting `parent_id` to the folder itself or to any of its descendants
* Implemented `get_folder_descendant_ids` in `folder.py` to recursively fetch all descendant folder IDs, supporting the new validation logic.