### PR TITLE
Preflight validation of in/notin/any values in sqlfilters

### DIFF
--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -403,7 +403,7 @@ def build_filter(f: QueryFilter | None, **kwargs) -> str | None:
                     result.append("FALSE")
                 elif c.operator == "notin":
                     result.append("TRUE")
-
+                continue
             if r := build_condition(c, **kwargs):
                 result.append(r)
         else:

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -398,6 +398,12 @@ def build_filter(f: QueryFilter | None, **kwargs) -> str | None:
             if r := build_filter(c, **kwargs):
                 result.append(r)
         elif isinstance(c, QueryCondition):
+            if not c.value:
+                if c.operator in ("in", "any"):
+                    result.append("FALSE")
+                elif c.operator == "notin":
+                    result.append("TRUE")
+
             if r := build_condition(c, **kwargs):
                 result.append(r)
         else:


### PR DESCRIPTION
This pull request introduces an important update to the filter-building logic in `ayon_server/sqlfilter.py`. The main change is an enhancement to the handling of empty values in `QueryCondition` objects, ensuring that SQL filters behave correctly when encountering empty lists or values.

Improvements to filter logic:

* Updated `build_filter` to return `"FALSE"` for empty values when the operator is `"in"` or `"any"`, and `"TRUE"` when the operator is `"notin"`, preventing invalid or unintended SQL queries for these cases.