### PR TITLE
Support for entity top level fields in permissions model

### DIFF
--- a/ayon_server/access/permissions.py
+++ b/ayon_server/access/permissions.py
@@ -22,7 +22,7 @@ async def attr_enum():
     ]
 
 
-def top_level_fields_enum():
+def top_level_fields_enum() -> list[dict[str, str]]:
     return [
         {"value": "name", "label": "Entity name"},
         {"value": "label", "label": "Entity label"},

--- a/ayon_server/access/permissions.py
+++ b/ayon_server/access/permissions.py
@@ -22,6 +22,22 @@ async def attr_enum():
     ]
 
 
+def top_level_fields_enum():
+    return [
+        {"value": "name", "label": "Entity name"},
+        {"value": "label", "label": "Entity label"},
+        {"value": "status", "label": "Entity status"},
+        {"value": "tags", "label": "Entity tags"},
+        {"value": "active", "label": "Entity active state"},
+        {"value": "parent_id", "label": "Folder parent ID"},
+        {"value": "folder_type", "label": "Folder type"},
+        {"value": "task_type", "label": "Task type"},
+        {"value": "assignees", "label": "Task assignees"},
+        {"value": "product_type", "label": "Product type"},
+        {"value": "author", "label": "Version author"},
+    ]
+
+
 class FolderAccess(BaseSettingsModel):
     """FolderAccess model defines a single whitelist item on accessing a folder."""
 
@@ -69,6 +85,15 @@ class FolderAccessList(BasePermissionsModel):
 
 
 class AttributeReadAccessList(BasePermissionsModel):
+    # We cannot restrict reading top-level fields for now
+    # as they are not nullable and we need to return at least something
+    # Keeping this here for the future reference
+    # fields: list[str] = SettingsField(
+    #     title="Readable fields",
+    #     default_factory=list,
+    #     enum_resolver=top_level_fields_enum,
+    # )
+
     attributes: list[str] = SettingsField(
         title="Readable attributes",
         default_factory=list,
@@ -77,6 +102,11 @@ class AttributeReadAccessList(BasePermissionsModel):
 
 
 class AttributeWriteAccessList(BasePermissionsModel):
+    fields: list[str] = SettingsField(
+        title="Writable fields",
+        default_factory=list,
+        enum_resolver=top_level_fields_enum,
+    )
     attributes: list[str] = SettingsField(
         title="Writable attributes",
         default_factory=list,

--- a/ayon_server/entities/core/base.py
+++ b/ayon_server/entities/core/base.py
@@ -85,7 +85,7 @@ class BaseEntity:
                             )
 
                     for field_name, val in pdata.items():
-                        if getattr(self._payload, field_name) == val:
+                        if getattr(self._payload, field_name, None) == val:
                             continue
                         if field_name not in perms.attrib_write.fields:
                             raise ForbiddenException(

--- a/ayon_server/entities/core/base.py
+++ b/ayon_server/entities/core/base.py
@@ -60,7 +60,8 @@ class BaseEntity:
     def patch(self, patch_data: BaseModel, user: Optional["UserEntity"] = None) -> None:
         """Apply a patch to the entity."""
 
-        pattr = patch_data.dict(exclude_unset=True).get("attrib", {})
+        pdata = patch_data.dict(exclude_unset=True)
+        pattr = pdata.pop("attrib", {})
 
         if user is not None and hasattr(self, "project_name"):
             if not (user.is_manager):
@@ -81,6 +82,15 @@ class BaseEntity:
                             raise ForbiddenException(
                                 f"You are not allowed to modify {attr}"
                                 f" attribute in {self.project_name}"
+                            )
+
+                    for field_name, val in pdata.items():
+                        if getattr(self._payload, field_name) == val:
+                            continue
+                        if field_name not in perms.attrib_write.fields:
+                            raise ForbiddenException(
+                                f"You are not allowed to modify {field_name}"
+                                f" field in {self.project_name}"
                             )
 
         if pattr:

--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -136,7 +136,7 @@ async def update_project_level_entity(
     # pre_save method of the entity, that expects the payload to be
     # updated (that covers various entity-specific logic, validtion, etc.).
 
-    entity.patch(payload)
+    entity.patch(payload, user=user)
 
     # Add the following fields directly to update_payload_dict
     # They don't affect the events created, so they don't need to be


### PR DESCRIPTION
This pull request introduces improvements to permission handling and attribute management in the AYON server, particularly for entity patching and access control. It is now possible to restrict / allow entity top field update access - not just attributes, so a certain access group can update entity status, but cannot change the entity name, type or task assignees. 

> [!WARNING]  
> This might be considered a breaking change, as the access groups that were previously restricted from writing attributes now cannot change the top level fields and the access group needs to be updated! This PR should therefore be merged before next minor bump. This is however in most cases a desired outcome.

<img width="902" height="673" alt="image" src="https://github.com/user-attachments/assets/403766cd-0edd-414c-b9d2-5adb62fae610" />
