### PR TITLE
Background entity operations

### DIFF
--- a/api/operations/operations.py
+++ b/api/operations/operations.py
@@ -1,11 +1,17 @@
+from typing import Literal
+
+from fastapi import BackgroundTasks
+
 from ayon_server.api.dependencies import CurrentUser, ProjectName, Sender, SenderType
 from ayon_server.exceptions import ForbiddenException
+from ayon_server.lib.redis import Redis
 from ayon_server.operations.project_level import (
     OperationModel,
     OperationsResponseModel,
     ProjectLevelOperations,
 )
 from ayon_server.types import Field, OPModel
+from ayon_server.utils.hashing import create_uuid
 
 from .router import router
 
@@ -78,3 +84,80 @@ async def operations(
         raise_on_error=raise_on_error,
         wait_for_events=payload.wait_for_events,
     )
+
+
+#
+# Background tasks variant
+#
+
+
+class BackgroundOperationsResponseModel(OPModel):
+    id: str
+    status: Literal["pending", "in_progress", "completed"] = "pending"
+    result: OperationsResponseModel | None = None
+
+
+async def _execute_background_operations(
+    task_id: str,
+    ops: ProjectLevelOperations,
+    *,
+    can_fail: bool,
+) -> None:
+    await Redis.set_json("background-operations", task_id, {"status": "in_progress"})
+    response = await ops.process(
+        can_fail=can_fail,
+        raise_on_error=False,
+        wait_for_events=True,
+    )
+    await Redis.set_json(
+        "background-operations",
+        task_id,
+        {"status": "completed", "result": response.dict()},
+    )
+
+
+@router.post(
+    "/projects/{project_name}/operations",
+    response_model=OperationsResponseModel,
+)
+async def background_operations(
+    payload: OperationsRequestModel,
+    project_name: ProjectName,
+    user: CurrentUser,
+    sender: Sender,
+    sender_type: SenderType,
+    background_tasks: BackgroundTasks,
+):
+    """
+    The same as `POST /projects/{project_name}/operations` but runs in the background.
+    The response is returned immediately and contains a task ID that can be used to
+    query the status of the task.
+    """
+
+    ops = ProjectLevelOperations(
+        project_name,
+        user=user,
+        sender=sender,
+        sender_type=sender_type,
+    )
+
+    for operation in payload.operations:
+        if operation.as_user:
+            is_different_user = operation.as_user != user.name
+            if is_different_user and not user.is_service:
+                msg = "You are not allowed to perform operations as another user"
+                raise ForbiddenException(msg)
+        ops.append(operation)
+
+    task_id = create_uuid()
+
+    background_tasks.add_task(
+        _execute_background_operations,
+        task_id,
+        ops,
+        can_fail=payload.can_fail,
+    )
+
+    await Redis.set_json("background-operations", task_id, {"status": "pending"})
+
+    return BackgroundOperationsResponseModel(id=task_id)

--- a/api/operations/operations.py
+++ b/api/operations/operations.py
@@ -15,6 +15,8 @@ from ayon_server.utils.hashing import create_uuid
 
 from .router import router
 
+BACKGROUND_OPS_TTL = 600  # 10 minutes
+
 
 class OperationsRequestModel(OPModel):
     operations: list[OperationModel] = Field(default_factory=list)
@@ -107,7 +109,7 @@ async def _execute_background_operations(
         "background-operations",
         task_id,
         {"status": "in_progress"},
-        ttl=600,
+        ttl=BACKGROUND_OPS_TTL,
     )
     response = await ops.process(
         can_fail=can_fail,
@@ -118,7 +120,7 @@ async def _execute_background_operations(
         "background-operations",
         task_id,
         {"status": "completed", "result": response.dict()},
-        ttl=600,
+        ttl=BACKGROUND_OPS_TTL,
     )
 
 
@@ -165,7 +167,7 @@ async def background_operations(
         "background-operations",
         task_id,
         {"status": "pending"},
-        ttl=600,
+        ttl=BACKGROUND_OPS_TTL,
     )
     return BackgroundOperationsResponseModel(id=task_id)
 

--- a/ayon_server/operations/project_level/models.py
+++ b/ayon_server/operations/project_level/models.py
@@ -49,4 +49,4 @@ class OperationResponseModel(OPModel):
 
 class OperationsResponseModel(OPModel):
     operations: Annotated[list[OperationResponseModel], Field(default_factory=list)]
-    success: Annotated[bool, Field(title="Overall success")]
+    success: Annotated[bool, Field(title="Overall success")] = False


### PR DESCRIPTION
This pull request introduces a new background operations API for project-level operations, allowing clients to execute operations asynchronously and query their status. Additionally, it makes a minor improvement to the default value handling in the operations response model.

**New background operations API:**

* Added a new `POST /projects/{project_name}/operations/background` endpoint to run project-level operations in the background. The endpoint returns a task ID immediately, which can be used to check the status of the operation.
* Implemented a background task execution function (`_execute_background_operations`) that updates the status of the operation in Redis and stores the result upon completion.
* Added a new `GET /projects/{project_name}/operations/background/{task_id}` endpoint to query the status and result of a background operation using its task ID.
* Introduced a new response model `BackgroundOperationsResponseModel` to standardize the response for background operations, including status and result fields.

**Model improvement:**

* Set a default value of `False` for the `success` field in `OperationsResponseModel` to ensure consistent behavior when the field is not explicitly set.