### PR TITLE
Fix path caching in exported attributes table

### DIFF
--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -196,8 +196,8 @@ class FolderEntity(ProjectLevelEntity):
         """Refresh hierarchy materialized view on folder save."""
         logger.trace(f"Refreshing folder views for project {project_name}")
 
-        await rebuild_inherited_attributes(project_name)
         await rebuild_hierarchy_cache(project_name)
+        await rebuild_inherited_attributes(project_name)
 
     async def delete(self, *args, auto_commit: bool = True, **kwargs) -> bool:
         async with Postgres.transaction():

--- a/ayon_server/helpers/hierarchy_cache.py
+++ b/ayon_server/helpers/hierarchy_cache.py
@@ -75,6 +75,11 @@ async def rebuild_hierarchy_cache(project_name: str) -> list[dict[str, Any]]:
     result = []
     ids_with_children = set()
     async with Postgres.transaction():
+        # Ensure the hierarchy view is up to date
+        await Postgres.execute(
+            f"REFRESH MATERIALIZED VIEW project_{project_name}.hierarchy"
+        )
+
         stmt = await Postgres.prepare(query)
         async for row in stmt.cursor():
             result.append(
@@ -101,10 +106,6 @@ async def rebuild_hierarchy_cache(project_name: str) -> list[dict[str, Any]]:
             )
             if row["parent_id"] is not None:
                 ids_with_children.add(row["parent_id"])
-
-        await Postgres.execute(
-            f"REFRESH MATERIALIZED VIEW project_{project_name}.hierarchy"
-        )
 
     for folder in result:
         folder["has_children"] = folder["id"] in ids_with_children


### PR DESCRIPTION
This pull request makes several improvements to how hierarchy and inherited attributes are refreshed and rebuilt in the project. The main focus is on ensuring that materialized views are refreshed at the correct times, improving the accuracy of inherited attribute propagation, and optimizing the order of database updates.


* The `rebuild_hierarchy_cache` function now refreshes the hierarchy materialized view at the start of the transaction to ensure the cache is always built from up-to-date data.
* The `refresh_views` method in `folder.py` now refreshes the hierarchy cache before rebuilding inherited attributes, ensuring attribute propagation is based on the latest hierarchy.
* The query in `_rebuild_from` now selects both `exported` attributes and their corresponding `exported_path`, allowing for more precise detection of changes.
* The comparison logic for updating exported attributes now checks both the attribute value and the path, ensuring updates occur if either changes.
* The SQL update statement for inherited attributes now updates the path before the attribute value for better consistency.