### PR TITLE
Populate default product base types in get project endpoint

### DIFF
--- a/api/projects/projects.py
+++ b/api/projects/projects.py
@@ -22,6 +22,8 @@ from ayon_server.helpers.project_list import get_project_list
 from ayon_server.lib.postgres import Postgres
 from ayon_server.settings.anatomy.folder_types import FolderType
 from ayon_server.settings.anatomy.product_base_types import (
+    DefaultProductBaseType,
+    ProductBaseType,
     default_product_type_definitions,
 )
 from ayon_server.settings.anatomy.statuses import Status
@@ -77,9 +79,7 @@ class ProjectPatchModel(ProjectEntity.model.patch_model):  # type: ignore
     tags: TAGS_FIELD
 
 
-default_pt_definitions = [
-    p.dict(exclude_unset=True) for p in default_product_type_definitions
-]
+default_pt_definitions = [p.dict() for p in default_product_type_definitions]
 
 
 @router.get(
@@ -97,6 +97,23 @@ async def get_project(
     await user.ensure_project_access(project_name)
     coalesce = RequestCoalescer()
     project = await coalesce(ProjectEntity.load, project_name)
+
+    product_base_types_config = project.config.get("productBaseTypes", {})
+
+    product_base_types_config["default"] = DefaultProductBaseType(
+        **product_base_types_config.get("default", {})
+    ).dict()
+
+    if "definitions" not in product_base_types_config:
+        product_base_types_config["definitions"] = default_pt_definitions
+    else:
+        product_base_types_config["definitions"] = [
+            ProductBaseType(**pt).dict()
+            for pt in product_base_types_config["definitions"]
+        ]
+
+    project.config["productBaseTypes"] = product_base_types_config
+    project.config.pop("productTypes", None)  # legacy
 
     return cast(ProjectModel, project.as_user(user))
 

--- a/ayon_server/entities/project.py
+++ b/ayon_server/entities/project.py
@@ -167,6 +167,8 @@ class ProjectEntity(TopLevelEntity):
         assert self.task_types, "Project must have at least one task type"
         assert self.statuses, "Project must have at least one status"
 
+        self.config.pop("productTypes", None)  # legacy
+
         project_name = self.name
         if self.exists:
             fields = dict_exclude(


### PR DESCRIPTION
This pull request updates how product base types are handled in project configurations, ensuring consistency and removing legacy fields. The changes focus on normalizing the structure of `productBaseTypes` in project configs and cleaning up legacy `productTypes` usage.

Key changes include:

**Product Base Types Normalization:**

* When loading a project, the `productBaseTypes` config is now normalized: the `"default"` entry is always present and validated using `DefaultProductBaseType`, and the `"definitions"` entry is ensured to exist and is validated using `ProductBaseType`. If `"definitions"` is missing, it defaults to the standard definitions. 
* The legacy `productTypes` field is now removed from the project config both when loading a project and when saving it, ensuring that only the new `productBaseTypes` structure is used