### PR TITLE
Provide current user's access level in entity list objects

### DIFF
--- a/ayon_server/entity_lists/models.py
+++ b/ayon_server/entity_lists/models.py
@@ -175,6 +175,9 @@ class EntityListModel(OPModel):
     created_at: Annotated[datetime, FCreatedAt]
     updated_at: Annotated[datetime, FUpdatedAt]
     active: Annotated[bool, FListActive]
+    access_level: Annotated[
+        ListAccessLevel, Field(title="Current user's access level")
+    ] = ListAccessLevel.MANAGE
 
 
 class EntityListPostModel(OPModel):


### PR DESCRIPTION
This pull request enhances access control for entity lists in the GraphQL API by introducing a new `access_level` field on EntityList node and supporting infrastructure. 