### PR TITLE
Update list.access field atomically

### DIFF
--- a/api/entity_lists/lists.py
+++ b/api/entity_lists/lists.py
@@ -91,7 +91,7 @@ async def update_entity_list(
         for key, value in payload_dict.items():
             if not hasattr(entity_list.payload, key):
                 continue
-            if isinstance(value, dict):
+            if isinstance(value, dict) and key != "access":
                 nval = dict_patch(getattr(entity_list.payload, key), value)
                 setattr(entity_list.payload, key, nval)
             else:


### PR DESCRIPTION
This pull request makes a targeted change to the `update_entity_list` function to improve how dictionary-type fields are handled during updates. Specifically, it prevents the `"access"` field from being patched as a dictionary, ensuring that only non-"access" dictionary fields are processed with `dict_patch`.

- Prevented the `"access"` field from being treated as a dictionary during payload updates in `update_entity_list`,  to avoid unintended merging of access controls. Instead, patching the access list is performed atomically.
