### PR TITLE
Unassign user from a dev bundle

### DIFF
--- a/api/bundles/bundles.py
+++ b/api/bundles/bundles.py
@@ -307,14 +307,13 @@ async def update_bundle(
 
         if bundle.is_dev:
             logger.debug(f"Updating dev bundle {bundle.name}")
-            if patch.active_user is not None:
-                # remove user from previously assigned bundles
-                # to avoid constraint violation
+            if "active_user" in patch.dict(exclude_unset=True, by_alias=False):
                 await Postgres.execute(
                     "UPDATE bundles SET active_user = NULL WHERE active_user = $1",
                     patch.active_user,
                 )
-                bundle.active_user = patch.active_user
+                if patch.active_user is None:
+                    bundle.active_user = patch.active_user
 
             if patch.addon_development is not None:
                 bundle.addon_development = patch.addon_development

--- a/api/bundles/bundles.py
+++ b/api/bundles/bundles.py
@@ -312,8 +312,7 @@ async def update_bundle(
                     "UPDATE bundles SET active_user = NULL WHERE active_user = $1",
                     patch.active_user,
                 )
-                if patch.active_user is None:
-                    bundle.active_user = patch.active_user
+                bundle.active_user = patch.active_user
 
             if patch.addon_development is not None:
                 bundle.addon_development = patch.addon_development


### PR DESCRIPTION
This pull request makes a targeted update to the logic for updating development bundles in `update_bundle`. The main change ensures that the code checks whether the `active_user` field is present in the patch payload, rather than simply checking if its value is not `None`. This makes unassigning user from a dev bundle possible.