### PR TITLE
Provide production dependency packages information in metrics

### DIFF
--- a/ayon_server/metrics/bundles.py
+++ b/ayon_server/metrics/bundles.py
@@ -18,6 +18,15 @@ class ProductionBundle(OPModel):
         title="Launcher version",
         example="1.0.0",
     )
+    dependency_packages: dict[str, str] = Field(
+        default_factory=dict,
+        title="Dependency packages",
+        example={
+            "windows": "ayon_2502101448_windows.zip",
+            "darwin": "ayon_2502101448_darwin.zip",
+            "linux": "ayon_2502101448_linux.zip",
+        },
+    )
 
 
 async def get_production_bundle(
@@ -48,6 +57,7 @@ async def get_production_bundle(
     return ProductionBundle(
         addons=addons,
         launcher_version=bundle_data.get("installer_version", ""),
+        dependency_packages=bundle_data.get("dependency_packages", {}),
     )
 
 


### PR DESCRIPTION
This pull request extends the `ProductionBundle` model in `ayon_server/metrics/bundles.py` to include information about dependency packages, and updates the function that constructs this model to populate the new field.


<img width="551" height="405" alt="image" src="https://github.com/user-attachments/assets/c3974dc0-f439-4412-ba3e-28e901ada5ef" />
