### PR TITLE
ACL for linked nodes

### DIFF
--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 import strawberry
 
@@ -29,7 +30,7 @@ class LinkEdge(BaseEdge):
     cursor: str | None = strawberry.field(default=None)
 
     @strawberry.field(description="Linked node")
-    async def node(self, info: Info) -> "BaseNode":
+    async def node(self, info: Info) -> Optional["BaseNode"]:
         if self.entity_type == "folder":
             loader = info.context["folder_loader"]
             parser = info.context["folder_from_record"]
@@ -54,7 +55,20 @@ class LinkEdge(BaseEdge):
             raise AyonException(msg)
 
         record = await loader.load((self.project_name, self.entity_id))
-        return await parser(self.project_name, record, info.context)
+
+        entity_node = await parser(self.project_name, record, info.context)
+        access_checker = info.context.get("access_checker")
+        if access_checker:
+            entity_folder_path = (entity_node._folder_path or "").strip("/")
+            if entity_folder_path not in access_checker.exact_paths:
+                # We don't handle partial errors in the frontend yet,
+                # but it would probably be a good idea to do so in the future.
+                #
+                # For now we just silently hide the linked entity if access is denied.
+                #
+                # raise ForbiddenException("Access to the linked entity denied")
+                return None
+        return entity_node
 
 
 @strawberry.type

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -40,6 +40,7 @@ class FolderNode(BaseNode):
     _project_attrib: strawberry.Private[dict[str, Any]]
     _inherited_attrib: strawberry.Private[dict[str, Any]]
     _user: strawberry.Private[UserEntity]
+    _folder_path: strawberry.Private[str | None] = None
 
     # GraphQL specifics
 
@@ -154,6 +155,7 @@ async def folder_from_record(
             relation=thumb_data.get("relation"),
         )
 
+    path = "/" + record.get("path", "").strip("/")
     return FolderNode(
         project_name=project_name,
         id=record["id"],
@@ -174,7 +176,8 @@ async def folder_from_record(
         task_count=record.get("task_count", 0),
         has_reviewables=has_reviewables,
         has_versions=record.get("has_versions", False),
-        path="/" + record.get("path", "").strip("/"),
+        path=path,
+        _folder_path=record.get("path", "").strip("/") or None,
         _attrib=record["attrib"] or {},
         _project_attrib=record["project_attributes"] or {},
         _inherited_attrib=record["inherited_attributes"] or {},

--- a/ayon_server/graphql/nodes/product.py
+++ b/ayon_server/graphql/nodes/product.py
@@ -51,6 +51,7 @@ class ProductNode(BaseNode):
 
     _attrib: strawberry.Private[dict[str, Any]]
     _user: strawberry.Private[UserEntity]
+    _folder_path: strawberry.Private[str | None] = None
 
     # GraphQL specifics
 
@@ -157,9 +158,10 @@ async def product_from_record(
     data = record.get("data", {})
 
     path = None
+    folder_path = None
     if record.get("_folder_path"):
-        folder_path = record["_folder_path"].strip("/")
-        path = f"/{folder_path}/{record['name']}"
+        folder_path = "/" + record["_folder_path"].strip("/")
+        path = f"{folder_path}/{record['name']}"
 
     return ProductNode(
         project_name=project_name,
@@ -176,6 +178,7 @@ async def product_from_record(
         version_list=vlist,
         path=path,
         _folder=folder,
+        _folder_path=folder_path,
         _attrib=record["attrib"] or {},
         _user=context["user"],
     )

--- a/ayon_server/graphql/nodes/representation.py
+++ b/ayon_server/graphql/nodes/representation.py
@@ -42,6 +42,7 @@ class RepresentationNode(BaseNode):
 
     _attrib: strawberry.Private[dict[str, Any]]
     _user: strawberry.Private[UserEntity]
+    _folder_path: strawberry.Private[str | None] = None
 
     # GraphQL specifics
 
@@ -117,12 +118,13 @@ async def representation_from_record(
     data = record.get("data") or {}
 
     path = None
+    folder_path = None
     if record.get("_folder_path"):
-        folder_path = record["_folder_path"].strip("/")
+        folder_path = "/" + record["_folder_path"].strip("/")
         product_name = record["_product_name"]
         version_number = record["_version_number"]
         version_name = f"v{version_number:03d}"
-        path = f"/{folder_path}/{product_name}/{version_name}/{record['name']}"
+        path = f"{folder_path}/{product_name}/{version_name}/{record['name']}"
 
     return RepresentationNode(
         project_name=project_name,
@@ -139,6 +141,7 @@ async def representation_from_record(
         files=parse_files(record.get("files", [])),
         traits=json_dumps(record["traits"]) if record["traits"] else None,
         path=path,
+        _folder_path=folder_path,
         _attrib=record["attrib"] or {},
         _user=context["user"],
     )

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -43,6 +43,7 @@ class TaskNode(BaseNode):
     _attrib: strawberry.Private[dict[str, Any]]
     _inherited_attrib: strawberry.Private[dict[str, Any]]
     _user: strawberry.Private[UserEntity]
+    _folder_path: strawberry.Private[str | None] = None
 
     # GraphQL specifics
 
@@ -161,9 +162,10 @@ async def task_from_record(
         )
 
     path = None
+    folder_path = None
     if record.get("_folder_path"):
-        folder_path = record["_folder_path"].strip("/")
-        path = f"/{folder_path}/{record['name']}"
+        folder_path = "/" + record["_folder_path"].strip("/")
+        path = f"{folder_path}/{record['name']}"
 
     return TaskNode(
         project_name=project_name,
@@ -187,6 +189,7 @@ async def task_from_record(
         _attrib=record["attrib"],
         _inherited_attrib=record["parent_folder_attrib"],
         _user=current_user,
+        _folder_path=folder_path,
     )
 
 

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -42,6 +42,7 @@ class VersionNode(BaseNode):
 
     _attrib: strawberry.Private[dict[str, Any]]
     _user: strawberry.Private[UserEntity]
+    _folder_path: strawberry.Private[str | None] = None
 
     # GraphQL specifics
 
@@ -135,10 +136,11 @@ async def version_from_record(
         )
 
     path = None
+    folder_path = None
     if record.get("_folder_path"):
-        folder_path = record["_folder_path"].strip("/")
+        folder_path = "/" + record["_folder_path"].strip("/")
         product_name = record["_product_name"]
-        path = f"/{folder_path}/{product_name}/{name}"
+        path = f"{folder_path}/{product_name}/{name}"
 
     return VersionNode(
         project_name=project_name,
@@ -158,6 +160,7 @@ async def version_from_record(
         data=json_dumps(data) if data else None,
         created_at=record["created_at"],
         updated_at=record["updated_at"],
+        _folder_path=folder_path,
         _attrib=record["attrib"] or {},
         _user=current_user,
     )

--- a/ayon_server/graphql/nodes/workfile.py
+++ b/ayon_server/graphql/nodes/workfile.py
@@ -36,6 +36,7 @@ class WorkfileNode(BaseNode):
     _attrib: strawberry.Private[dict[str, Any]]
     _user: strawberry.Private[UserEntity]
     _parents: list[str] | None = None
+    _folder_path: strawberry.Private[str | None] = None
 
     @strawberry.field(description="Parent task of the workfile")
     async def task(self, info: Info) -> TaskNode:
@@ -95,9 +96,10 @@ async def workfile_from_record(
         )
 
     parents: list[str] = []
-    if path := record.get("_folder_path"):
-        path = path.strip("/")
-        parents = path.split("/")[:-1] if path else []
+    folder_path = None
+    if folder_path := record.get("_folder_path"):
+        folder_path = "/" + folder_path.strip("/")
+        parents = folder_path.split("/")[:-1] if folder_path else []
         parents.append(record["_task_name"])
 
     return WorkfileNode(
@@ -119,6 +121,7 @@ async def workfile_from_record(
         _attrib=record["attrib"] or {},
         _user=context["user"],
         _parents=parents,
+        _folder_path=folder_path,
     )
 
 

--- a/ayon_server/graphql/resolvers/links.py
+++ b/ayon_server/graphql/resolvers/links.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+from ayon_server.access.utils import AccessChecker
 from ayon_server.graphql.nodes.common import LinkEdge, LinksConnection
 from ayon_server.graphql.types import Info, PageInfo
 from ayon_server.lib.postgres import Postgres
@@ -17,6 +18,12 @@ async def get_links(
     name_ex: str | None = None,
 ) -> LinksConnection:
     project_name = root.project_name
+    user = info.context["user"]
+    if not user.is_manager:
+        access_checker = AccessChecker()
+        await access_checker.load(user, project_name)
+        info.context["access_checker"] = access_checker
+        print(access_checker.exact_paths)
 
     edges: list[LinkEdge] = []
 


### PR DESCRIPTION
This pull request introduces access control for linked entities in the GraphQL API and standardizes how folder paths are handled across different node types. The main goal is to ensure that users only see linked entities they have permission to access, and to make folder path handling consistent in the codebase.

Access control for linked entities:

* Added an `AccessChecker` to the GraphQL context for non-manager users in `get_links`, which loads user permissions and stores them in the request context.
* Updated the `LinkEdge.node` resolver to check the user's access rights using the `AccessChecker`. If the user lacks access to the linked entity's folder path, the resolver returns `None` instead of the node, effectively hiding inaccessible links. 

Consistent folder path handling:

* Added a private `_folder_path` attribute to all relevant node types (`FolderNode`, `ProductNode`, `RepresentationNode`, `TaskNode`, `VersionNode`, `WorkfileNode`) and ensured that the folder path is consistently set (always prefixed with a `/` or set to `None` if missing) during node creation from database records
* Updated all node factory functions (`folder_from_record`, `product_from_record`, `representation_from_record`, `task_from_record`, `version_from_record`, `workfile_from_record`) to compute and assign the normalized `_folder_path` and use it for path construction. 
* Minor import and type annotation updates to support the above changes, such as importing `Optional` and updating type hints.

These changes improve security by enforcing access restrictions on linked entities and enhance code maintainability by standardizing path handling.