### PR TITLE
GraphQL: Improved task sorting

### DIFF
--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -459,7 +459,6 @@ async def get_tasks(
                 "folders.updated_at AS _folder_updated_at",
                 "projects.attrib as _folder_project_attributes",
                 "pf_ex.attrib as _folder_inherited_attributes",
-                "pf_ex.path AS _folder_path",
             ]
         )
 

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -441,7 +441,12 @@ async def get_tasks(
     #
 
     # Do we need the parent folder data?
-    if use_folder_query or search or "folder" in fields:
+    if (
+        use_folder_query
+        or search
+        or "folder" in fields
+        or (sort_by and sort_by.startswith("attrib."))
+    ):
         sql_columns.extend(
             [
                 "folders.id AS _folder_id",
@@ -496,7 +501,7 @@ async def get_tasks(
             order_by = ["hierarchy.path", "tasks.name"]
         elif sort_by.startswith("attrib."):
             attr_name = sort_by[7:]
-            exp = "(pf.attrib || tasks.attrib)"
+            exp = "(pf_ex.attrib || tasks.attrib)"
             attr_case = await get_attrib_sort_case(attr_name, exp)
             order_by.insert(0, attr_case)
         else:

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -441,12 +441,7 @@ async def get_tasks(
     #
 
     # Do we need the parent folder data?
-    if (
-        use_folder_query
-        or search
-        or "folder" in fields
-        or (sort_by and sort_by.startswith("attrib."))
-    ):
+    if use_folder_query or search or "folder" in fields:
         sql_columns.extend(
             [
                 "folders.id AS _folder_id",
@@ -501,7 +496,7 @@ async def get_tasks(
             order_by = ["hierarchy.path", "tasks.name"]
         elif sort_by.startswith("attrib."):
             attr_name = sort_by[7:]
-            exp = "(pf_ex.attrib || tasks.attrib)"
+            exp = "(ex.attrib || tasks.attrib)"
             attr_case = await get_attrib_sort_case(attr_name, exp)
             order_by.insert(0, attr_case)
         else:

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -108,7 +108,6 @@ async def get_task_types_sort_case(project_name: str) -> str:
     if not task_type_names:
         return "tasks.task_type"
     case = "CASE"
-    i = 0
     for i, task_type_name in enumerate(task_type_names):
         case += f" WHEN tasks.task_type = '{task_type_name}' THEN {i}"
     case += f" ELSE {i+1}"


### PR DESCRIPTION
This pull request refactors and optimizes the SQL query logic in the `get_tasks` GraphQL resolver. The main improvements include more efficient SQL joins, enhanced sorting capabilities (notably by custom task type order), and improved handling of sorting stability. These changes make the resolver more performant and flexible, especially when handling large task datasets or complex queries.

* Added a new function `get_task_types_sort_case` to enable sorting tasks by their type in the order defined in the project's anatomy, supporting more user-friendly and project-specific task listings.
* Improved the logic for setting the `order_by` clause: now uses `tasks.creation_order` for stable default sorting, and adds a secondary sort by path/name when a single sort criterion is specified, ensuring predictable and consistent ordering in results.

**SQL Join and Column Optimization:**

* Refactored SQL joins to include only necessary tables and columns based on the requested fields, reducing unnecessary overhead and improving query performance. Notably, joins for folder and attribute data are now only included when required. 
* Updated and streamlined the selection of SQL columns, including more precise inclusion of folder and attribute data, and improved handling of parent folder attributes.