### PR TITLE
Prevent deadlocks while patching the same attribute at the same time

### DIFF
--- a/ayon_server/exceptions.py
+++ b/ayon_server/exceptions.py
@@ -128,3 +128,10 @@ class ServiceUnavailableException(AyonException):
 
     detail: str = "Service unavailable"
     status: int = 503
+
+
+class DeadlockException(AyonException):
+    """Exception raised when a database deadlock is detected."""
+
+    detail: str = "Database deadlock detected"
+    status: int = 503

--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -80,12 +80,15 @@ async def sanitize_folder_update(
                     f"Cannot change {key} of a folder with published versions"
                 )
 
+    # Make sure the hierarchy is acyclic
+
     if "parent_id" in update_payload_dict:
-        # Prevent setting parent_id to self or any of its descendants
+        # parent_id must be different than the folder id
         new_parent_id = update_payload_dict["parent_id"]
         if new_parent_id == entity.id:
             raise BadRequestException("Folder cannot be its own parent")
 
+        # parent_id cannot be one of the folder's descendants
         descendants = await folder_entity.get_folder_descendant_ids()
         if new_parent_id in descendants:
             raise BadRequestException(


### PR DESCRIPTION
This pull request introduces improved handling for database deadlocks during project-level operations. The main change is the addition of a custom `DeadlockException` to provide clearer error reporting when a deadlock is detected, along with updates to ensure that view refreshes are robust against deadlocks. The code now catches deadlock errors and responds appropriately, improving reliability during concurrent operations.

* Moved the logic for refreshing entity views to after event dispatch, and wrapped it in a try/except block to skip refresh if a deadlock is detected, logging a debug message instead of failing.
* Removed the previous view refresh logic from the end of `_process_operations`, consolidating it in the new location, outside the main transaction