### PR TITLE
Support shared CDN links

### DIFF
--- a/api/files/files.py
+++ b/api/files/files.py
@@ -138,6 +138,8 @@ async def get_file_headers(project_name: str, file_id: str) -> dict[str, str]:
         "Content-Type": data["mime"],
         "Content-Disposition": f'inline; filename="{data["filename"]}"',
     }
+    if data.get("ynputShared"):
+        headers["X-Ynput-Shared"] = "1"
     return headers
 
 
@@ -172,9 +174,10 @@ async def get_project_file(
 
     storage = await Storages.project(project_name)
     headers = await get_file_headers(project_name, file_id)
+    ynput_shared = bool(headers.get("X-Ynput-Shared"))
 
     if storage.cdn_resolver is not None:
-        return await storage.get_cdn_link(file_id)
+        return await storage.get_cdn_link(file_id, ynput_shared=ynput_shared)
 
     if storage.storage_type == "s3":
         url = await storage.get_signed_url(

--- a/ayon_server/files/project_storage.py
+++ b/ayon_server/files/project_storage.py
@@ -169,7 +169,12 @@ class ProjectStorage:
             )
         raise Exception("Signed URLs are only supported for S3 storage")
 
-    async def get_cdn_link(self, file_id: str) -> RedirectResponse:
+    async def get_cdn_link(
+        self,
+        file_id: str,
+        *,
+        ynput_shared: bool = False,
+    ) -> RedirectResponse:
         """Return a signed URL to access the file on the CDN over HTTP
 
         This method is only supported for CDN-enabled storages.
@@ -185,6 +190,7 @@ class ProjectStorage:
                 "projectName": self.project_name,
                 "projectTimestamp": project_timestamp,
                 "fileId": file_id,
+                "ynputShared": ynput_shared,
             }
 
             headers = await CloudUtils.get_api_headers()


### PR DESCRIPTION
This PR provides a mechanism to signal CDN that file is a part of YnputCloud shared space. This feature allows deploying demo projects with media files and it is not intended to be used by general audience.