### PR TITLE
Attributes: partial updates of attribute configuration using patch request

### DIFF
--- a/api/attributes/attributes.py
+++ b/api/attributes/attributes.py
@@ -193,8 +193,6 @@ async def patch_attribute_config(
     """Partially update attribute configuration"""
 
     attribute = await get_attribute_config(user, attribute_name)
-    if not user.is_admin:
-        raise ForbiddenException("Only administrators are allowed to modify attributes")
 
     patch_payload = payload.dict(exclude_unset=True)
     patch_data = patch_payload.pop("data", {})
@@ -219,6 +217,16 @@ async def patch_attribute_config(
         )
     ):
         requires_restart = True
+
+        if not user.is_admin:
+            raise ForbiddenException(
+                "Only administrators are allowed to modify attribute configuration"
+            )
+
+    if not user.is_manager:
+        raise ForbiddenException(
+            "Only managers are allowed to modify attribute metadata"
+        )
 
     for key, value in patch_payload.items():
         setattr(attribute, key, value)

--- a/api/attributes/attributes.py
+++ b/api/attributes/attributes.py
@@ -6,7 +6,11 @@ from pydantic import Field, ValidationError
 from ayon_server.api.dependencies import AttributeName, CurrentUser
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.api.system import require_server_restart
-from ayon_server.attributes.models import AttributeModel, AttributePutModel
+from ayon_server.attributes.models import (
+    AttributeModel,
+    AttributePatchModel,
+    AttributePutModel,
+)
 from ayon_server.attributes.validate_attribute_data import validate_attribute_data
 from ayon_server.entities import ProjectEntity
 from ayon_server.exceptions import ForbiddenException, NotFoundException
@@ -167,7 +171,9 @@ async def get_attribute_config(
 
 @router.put("/{attribute_name}", status_code=204)
 async def set_attribute_config(
-    payload: AttributePutModel, user: CurrentUser, attribute_name: AttributeName
+    payload: AttributePutModel,
+    user: CurrentUser,
+    attribute_name: AttributeName,
 ) -> EmptyResponse:
     """Update attribute configuration"""
     if not user.is_admin:
@@ -177,6 +183,55 @@ async def set_attribute_config(
     await require_server_restart(
         None, "Restart the server to apply the attribute changes."
     )
+    return EmptyResponse()
+
+
+@router.patch("/{attribute_name}", status_code=204)
+async def patch_attribute_config(
+    payload: AttributePatchModel, user: CurrentUser, attribute_name: AttributeName
+) -> EmptyResponse:
+    """Partially update attribute configuration"""
+
+    attribute = await get_attribute_config(user, attribute_name)
+    if not user.is_admin:
+        raise ForbiddenException("Only administrators are allowed to modify attributes")
+
+    patch_payload = payload.dict(exclude_unset=True)
+    patch_data = patch_payload.pop("data", {})
+
+    requires_restart = False
+
+    if "scope" in patch_payload or any(
+        k in patch_data
+        for k in (
+            "type",
+            "default",
+            "gt",
+            "ge",
+            "lt",
+            "le",
+            "regex",
+            "min_length",
+            "max_length",
+            "min_items",
+            "max_items",
+            "inherit",
+        )
+    ):
+        requires_restart = True
+
+    for key, value in patch_payload.items():
+        setattr(attribute, key, value)
+
+    for key, value in patch_data.items():
+        setattr(attribute.data, key, value)
+
+    await save_attribute(attribute)
+
+    if requires_restart:
+        await require_server_restart(
+            None, "Restart the server to apply the attribute changes."
+        )
     return EmptyResponse()
 
 

--- a/ayon_server/attributes/models.py
+++ b/ayon_server/attributes/models.py
@@ -158,7 +158,7 @@ class AttributePatchModel(OPModel):
     position: Annotated[
         int | None,
         Field(
-            title="Positon",
+            title="Position",
             description="Default order",
             example=12,
         ),

--- a/ayon_server/attributes/models.py
+++ b/ayon_server/attributes/models.py
@@ -151,6 +151,31 @@ class AttributePutModel(OPModel):
             example=["folder", "task"],
         ),
     ]
+    data: AttributeData
+
+
+class AttributePatchModel(OPModel):
+    position: Annotated[
+        int | None,
+        Field(
+            title="Positon",
+            description="Default order",
+            example=12,
+        ),
+    ] = None
+    scope: Annotated[
+        list[ProjectLevelEntityType | TopLevelEntityType | Literal["list"]] | None,
+        Field(
+            default=None,
+            title="Scope",
+            description="List of entity types the attribute is available on",
+            example=["folder", "task"],
+        ),
+    ] = None
+    data: AttributeData | None = None
+
+
+class AttributeModel(AttributePutModel, AttributeNameModel):
     builtin: Annotated[
         bool,
         Field(
@@ -158,8 +183,3 @@ class AttributePutModel(OPModel):
             description="Is attribute builtin. Built-in attributes cannot be removed.",
         ),
     ] = False
-    data: AttributeData
-
-
-class AttributeModel(AttributePutModel, AttributeNameModel):
-    pass

--- a/ayon_server/attributes/models.py
+++ b/ayon_server/attributes/models.py
@@ -166,7 +166,6 @@ class AttributePatchModel(OPModel):
     scope: Annotated[
         list[ProjectLevelEntityType | TopLevelEntityType | Literal["list"]] | None,
         Field(
-            default=None,
             title="Scope",
             description="List of entity types the attribute is available on",
             example=["folder", "task"],

--- a/ayon_server/attributes/models.py
+++ b/ayon_server/attributes/models.py
@@ -17,12 +17,11 @@ class AttributeData(OPModel):
     type: Annotated[
         AttributeType,
         Field(
-            ...,
             title="Type",
             description="Type of attribute value",
             example="string",
         ),
-    ]
+    ] = "string"
 
     title: Annotated[
         str | None,


### PR DESCRIPTION
This pull request introduces support for partial updates to attribute configurations by adding a new PATCH endpoint and the corresponding `AttributePatchModel`. The changes allow clients to update only specific fields of an attribute without sending the full configuration. Proper permission checks and server restart requirements are enforced for sensitive changes.


- Patching attribute configuration that does not affect schemas (enums, title, description...) no longer requires server restart
- Managers are now allowed to change non-sensitive attribute configuration