### PR TITLE
GraphQL: Add allAttrib and access fields to entity list node

### DIFF
--- a/ayon_server/graphql/nodes/entity_list.py
+++ b/ayon_server/graphql/nodes/entity_list.py
@@ -174,9 +174,8 @@ class EntityListNode:
     entity_type: str = strawberry.field()
     label: str = strawberry.field()
 
-    # TODO
-    # access
-    # attrib
+    access: str = strawberry.field(default="{}")  # JSON string of access dict
+    all_attrib: str = strawberry.field(default="{}")  # JSON string of all attrib keys
 
     tags: list[str] = strawberry.field(default_factory=list)
 
@@ -279,7 +278,8 @@ async def entity_list_from_record(
         entity_list_type=record["entity_list_type"],
         entity_type=record["entity_type"],
         label=record["label"],
-        # attrib
+        access=json_dumps(record.get("access") or {}),
+        all_attrib=json_dumps(record.get("attrib") or {}),
         tags=record["tags"] or [],
         owner=record["owner"],
         active=record["active"],


### PR DESCRIPTION
This pull request enhances the `EntityListNode` in the GraphQL schema by adding two new fields, `access` and `all_attrib`, to expose access permissions and attribute keys as JSON strings. These fields are now populated from the corresponding values in the database records.


<img width="1027" height="662" alt="image" src="https://github.com/user-attachments/assets/b440d25e-d72e-46c7-9bd1-0e02daaa6478" />
