### PR TITLE
Add overview row height to view data model

### DIFF
--- a/ayon_server/views/models.py
+++ b/ayon_server/views/models.py
@@ -140,6 +140,7 @@ class TaskProgressSettings(OPModel):
 
 
 class ListsSettings(OPModel):
+    row_height: int | None = None
     sort_by: str | None = None
     sort_desc: bool = False
     filter: QueryFilter | None = None


### PR DESCRIPTION
This pull request introduces a minor update to the `OverviewSettings` model in `ayon_server/views/models.py`. The change adds an optional `row_height` field to allow configuration of row height in the overview settings.