### PR TITLE
Verbose password complexity error message

### DIFF
--- a/ayon_server/auth/password.py
+++ b/ayon_server/auth/password.py
@@ -6,8 +6,8 @@ from ayon_server.api.clientinfo import get_real_ip
 from ayon_server.auth.session import Session, SessionModel
 from ayon_server.auth.utils import (
     create_password,
-    ensure_password_complexity,
     hash_password,
+    validate_password,
 )
 from ayon_server.config import ayonconfig
 from ayon_server.entities import UserEntity
@@ -110,8 +110,7 @@ class PasswordAuth:
     @classmethod
     async def change_password(cls, name: str, password: str) -> None:
         """Change password for a user."""
-        if not ensure_password_complexity(password):
-            raise ValueError("Password does not meet complexity requirements")
+        validate_password(password)
 
         result = await Postgres.fetch(
             "SELECT data FROM public.users WHERE name = $1", name

--- a/ayon_server/auth/utils.py
+++ b/ayon_server/auth/utils.py
@@ -29,14 +29,6 @@ def validate_password(password: str) -> None:
             )
 
 
-def ensure_password_complexity(password: str) -> bool:
-    try:
-        validate_password(password)
-    except LowPasswordComplexityException:
-        return False
-    return True
-
-
 def hash_password(password: str, salt: str = "") -> str:
     """Create a hash string from a given password and salt,
     and pepper from the config.

--- a/ayon_server/auth/utils.py
+++ b/ayon_server/auth/utils.py
@@ -12,21 +12,29 @@ def validate_password(password: str) -> None:
     whether it contains letters, numbers and special characters.
 
     """
+    problems = []
+    misses = []
+
     if len(password) < ayonconfig.auth_pass_min_length:
-        raise LowPasswordComplexityException(
-            "Password must be at least "
-            f"{ayonconfig.auth_pass_min_length} characters long"
-        )
+        problems.append(f"be at least {ayonconfig.auth_pass_min_length} characters")
     if ayonconfig.auth_pass_complex:
         # Ensure password has digits, letters and special characters
         if not any(c.isalpha() for c in password):
-            raise LowPasswordComplexityException("Password must contain letters")
+            misses.append("letters")
         if not any(c.isdigit() for c in password):
-            raise LowPasswordComplexityException("Password must contain digits")
+            misses.append("digits")
         if not any(c in ".-!@#$%^&*()_+" for c in password):
-            raise LowPasswordComplexityException(
-                "Password must contain special characters"
-            )
+            misses.append("special characters")
+
+    if misses:
+        if len(misses) == 1:
+            problems.append(f"contain {misses[0]}")
+        else:
+            problems.append("contain " + ", ".join(misses[:-1]) + f" and {misses[-1]}")
+    if problems:
+        message = "Password must " + " and ".join(problems) + "."
+        raise LowPasswordComplexityException(message)
+    return
 
 
 def hash_password(password: str, salt: str = "") -> str:

--- a/ayon_server/entities/user.py
+++ b/ayon_server/entities/user.py
@@ -8,8 +8,8 @@ from ayon_server.access.access_groups import AccessGroups
 from ayon_server.access.permissions import Permissions
 from ayon_server.auth.utils import (
     create_password,
-    ensure_password_complexity,
     hash_password,
+    validate_password,
 )
 from ayon_server.constraints import Constraints
 from ayon_server.entities.core import TopLevelEntity, attribute_library
@@ -18,7 +18,6 @@ from ayon_server.entities.project import ProjectEntity
 from ayon_server.exceptions import (
     ConstraintViolationException,
     ForbiddenException,
-    LowPasswordComplexityException,
     NotFoundException,
     ServiceUnavailableException,
 )
@@ -375,8 +374,8 @@ class UserEntity(TopLevelEntity):
             self.data.pop("password", None)
             return
 
-        if complexity_check and not ensure_password_complexity(password):
-            raise LowPasswordComplexityException
+        if complexity_check:
+            validate_password(password)
         hashed_password = create_password(password)
         self.data["password"] = hashed_password
 


### PR DESCRIPTION
This pull request refactors the password complexity validation logic across the codebase to simplify and unify the approach. The main change is to use the `validate_password` function directly, replacing the previous pattern of calling `ensure_password_complexity` and handling its return value or exceptions. This results in more straightforward and consistent password validation.

```
>>> from ayon_server.auth.utils import validate_password


>>> validate_password("asdf")
ayon_server.exceptions.LowPasswordComplexityException: Password must be at least 8 characters and contain digits and special characters.

>>> validate_password("asdf123")
ayon_server.exceptions.LowPasswordComplexityException: Password must be at least 8 characters and contain special characters.

>>> validate_password("asdf13@")
ayon_server.exceptions.LowPasswordComplexityException: Password must be at least 8 characters.

>>> validate_password("asdf123@")
None
```