### PR TITLE
Respect anatomy order when sorting by folderType and status

### DIFF
--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -55,6 +55,8 @@ class LinkEdge(BaseEdge):
             raise AyonException(msg)
 
         record = await loader.load((self.project_name, self.entity_id))
+        if not record:
+            return None
 
         entity_node = await parser(self.project_name, record, info.context)
         access_checker = info.context.get("access_checker")

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -22,7 +22,11 @@ from ayon_server.graphql.nodes.entity_list import (
     EntityListItemsConnection,
     EntityListNode,
 )
-from ayon_server.graphql.resolvers.common import (
+from ayon_server.graphql.types import Info
+from ayon_server.sqlfilter import QueryFilter, build_filter
+from ayon_server.utils import SQLTool
+
+from .common import (
     ARGAfter,
     ARGBefore,
     ARGFirst,
@@ -31,13 +35,8 @@ from ayon_server.graphql.resolvers.common import (
     create_folder_access_list,
     resolve,
 )
-from ayon_server.graphql.resolvers.pagination import (
-    create_pagination,
-    get_attrib_sort_case,
-)
-from ayon_server.graphql.types import Info
-from ayon_server.sqlfilter import QueryFilter, build_filter
-from ayon_server.utils import SQLTool
+from .pagination import create_pagination
+from .sorting import get_attrib_sort_case
 
 COLS_ITEMS = [
     "id",

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -429,7 +429,7 @@ async def get_folders(
     if not order_by:
         # If no sorting specified, use creation order to have stable sorting
         # as the requester doesn't care about the order in this case.
-        order_by.append("tasks.creation_order")
+        order_by.append("folders.creation_order")
 
     elif len(order_by) < 2:
         # If a single sort criteria is specified, add a secondary sort by name

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -2,28 +2,8 @@ import re
 from base64 import b64decode, b64encode
 from typing import Any
 
-from ayon_server.entities.core.attrib import attribute_library
-from ayon_server.exceptions import BadRequestException
 from ayon_server.logging import logger
 from ayon_server.utils import json_dumps, json_loads
-
-
-async def get_attrib_sort_case(attr: str, exp: str) -> str:
-    try:
-        attr_data = attribute_library.by_name(attr)
-    except KeyError:
-        raise BadRequestException(f"Invalid attribute {attr}")
-    enum = attr_data.get("enum", [])
-    if not enum:
-        return f"{exp}->'{attr}'"
-    case = "CASE"
-    i = 0
-    for i, eval in enumerate(enum):
-        e = eval["value"]
-        case += f" WHEN {exp}->>'{attr}' = '{e}' THEN {i}"
-    case += f" ELSE {i+1}"
-    case += " END"
-    return case
 
 
 def decode_cursor(cursor: str | None) -> tuple[list[str], list[str]]:

--- a/ayon_server/graphql/resolvers/sorting.py
+++ b/ayon_server/graphql/resolvers/sorting.py
@@ -1,0 +1,72 @@
+from ayon_server.entities import ProjectEntity
+from ayon_server.entities.core.attrib import attribute_library
+from ayon_server.exceptions import BadRequestException
+
+
+def get_task_types_sort_case(project: ProjectEntity) -> str:
+    """
+    Get a SQL CASE expression to sort by task types
+    in the order they are defined in the project anatomy.
+    """
+
+    task_type_names = [r["name"] for r in project.task_types]
+    if not task_type_names:
+        return "tasks.task_type"
+    case = "CASE"
+    for i, task_type_name in enumerate(task_type_names):
+        case += f" WHEN tasks.task_type = '{task_type_name}' THEN {i}"
+    case += f" ELSE {i+1}"
+    case += " END"
+    return case
+
+
+def get_folder_types_sort_case(project: ProjectEntity) -> str:
+    """
+    Get a SQL CASE expression to sort by folder types
+    in the order they are defined in the project anatomy.
+    """
+
+    folder_type_names = [r["name"] for r in project.folder_types]
+    if not folder_type_names:
+        return "folders.folder_type"
+    case = "CASE"
+    for i, folder_type_name in enumerate(folder_type_names):
+        case += f" WHEN folders.folder_type = '{folder_type_name}' THEN {i}"
+    case += f" ELSE {i+1}"
+    case += " END"
+    return case
+
+
+def get_status_sort_case(project: ProjectEntity, exp: str) -> str:
+    """
+    Get a SQL CASE expression to sort by statuses
+    in the order they are defined in the project anatomy.
+    """
+
+    status_names = [r["name"] for r in project.statuses]
+    if not status_names:
+        return "tasks.status"
+    case = "CASE"
+    for i, status_name in enumerate(status_names):
+        case += f" WHEN {exp} = '{status_name}' THEN {i}"
+    case += f" ELSE {i+1}"
+    case += " END"
+    return case
+
+
+async def get_attrib_sort_case(attr: str, exp: str) -> str:
+    try:
+        attr_data = attribute_library.by_name(attr)
+    except KeyError:
+        raise BadRequestException(f"Invalid attribute {attr}")
+    enum = attr_data.get("enum", [])
+    if not enum:
+        return f"{exp}->'{attr}'"
+    case = "CASE"
+    i = 0
+    for i, eval in enumerate(enum):
+        e = eval["value"]
+        case += f" WHEN {exp}->>'{attr}' = '{e}' THEN {i}"
+    case += f" ELSE {i+1}"
+    case += " END"
+    return case

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -24,10 +24,6 @@ from ayon_server.graphql.resolvers.common import (
     resolve,
     sortdesc,
 )
-from ayon_server.graphql.resolvers.pagination import (
-    create_pagination,
-    get_attrib_sort_case,
-)
 from ayon_server.graphql.types import Info
 from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import (
@@ -38,6 +34,13 @@ from ayon_server.types import (
     validate_user_name_list,
 )
 from ayon_server.utils import SQLTool, slugify
+
+from .pagination import create_pagination
+from .sorting import (
+    get_attrib_sort_case,
+    get_status_sort_case,
+    get_task_types_sort_case,
+)
 
 SORT_OPTIONS = {
     "name": "tasks.name",
@@ -93,27 +96,6 @@ async def create_task_acl(
                 full_access.add(p)
 
     return full_access, assigned_access
-
-
-async def get_task_types_sort_case(project_name: str) -> str:
-    """
-    Get a SQL CASE expression to sort by task types
-    in the order they are defined in the project anatomy.
-    """
-
-    # Load task types to create a sorter
-    # this is fast as ProjectEntity is cached
-    task_type_names = [
-        r["name"] for r in (await ProjectEntity.load(project_name)).task_types
-    ]
-    if not task_type_names:
-        return "tasks.task_type"
-    case = "CASE"
-    for i, task_type_name in enumerate(task_type_names):
-        case += f" WHEN tasks.task_type = '{task_type_name}' THEN {i}"
-    case += f" ELSE {i+1}"
-    case += " END"
-    return case
 
 
 async def get_tasks(
@@ -189,6 +171,7 @@ async def get_tasks(
         return TasksConnection(edges=[])
 
     project_name = root.project_name
+    project = await ProjectEntity.load(project_name)
     fields = FieldInfo(info, ["tasks.edges.node", "task"])
     use_folder_query = False
 
@@ -490,8 +473,11 @@ async def get_tasks(
     order_by = []
     if sort_by is not None:
         if sort_by == "taskType":
-            task_type_case = await get_task_types_sort_case(project_name)
+            task_type_case = get_task_types_sort_case(project)
             order_by.append(task_type_case)
+        elif sort_by == "status":
+            status_type_case = get_status_sort_case(project, "tasks.status")
+            order_by.append(status_type_case)
         elif sort_by in SORT_OPTIONS:
             order_by.insert(0, SORT_OPTIONS[sort_by])
         elif sort_by == "path":


### PR DESCRIPTION
This pull request refactors and improves the sorting logic for GraphQL resolvers in the codebase, especially for folders and tasks. The main changes involve moving sorting helper functions to a new dedicated module, enhancing sorting flexibility (including sorting by folder type, task type, and status according to project anatomy), and cleaning up imports for better code organization.
