### PR TITLE
Normalize project name helper

### DIFF
--- a/api/access/utils.py
+++ b/api/access/utils.py
@@ -4,6 +4,7 @@ from fastapi import Query
 
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.helpers.entity_access import EntityAccessHelper, ShareOption
+from ayon_server.helpers.project_list import normalize_project_name
 from ayon_server.types import PROJECT_NAME_REGEX, OPModel
 
 from .router import router
@@ -18,6 +19,9 @@ async def get_share_options(
     user: CurrentUser,
     project_name: Annotated[str | None, Query(regex=PROJECT_NAME_REGEX)] = None,
 ) -> ShareOptions:
+    if project_name is not None:
+        project_name = await normalize_project_name(project_name)
+
     opts = await EntityAccessHelper.get_share_options(
         user,
         project_name=project_name,

--- a/ayon_server/helpers/project_list.py
+++ b/ayon_server/helpers/project_list.py
@@ -65,3 +65,12 @@ async def get_project_info(project_name: str) -> ProjectListItem:
         if project.name == project_name:
             return project
     raise NotFoundException(f"Project {project_name} not found")
+
+
+async def normalize_project_name(project_name: str) -> str:
+    """Return a normalized project name (case-sensitive)"""
+    project_list = await get_project_list()
+    for project in project_list:
+        if project.name.lower() == project_name.lower():
+            return project.name
+    raise NotFoundException(f"Project {project_name} not found")

--- a/ayon_server/helpers/project_list.py
+++ b/ayon_server/helpers/project_list.py
@@ -62,15 +62,11 @@ async def get_project_info(project_name: str) -> ProjectListItem:
     """Return a single project info"""
     project_list = await get_project_list()
     for project in project_list:
-        if project.name == project_name:
+        if project.name.lower() == project_name.lower():
             return project
     raise NotFoundException(f"Project {project_name} not found")
 
 
 async def normalize_project_name(project_name: str) -> str:
-    """Return a normalized project name (case-sensitive)"""
-    project_list = await get_project_list()
-    for project in project_list:
-        if project.name.lower() == project_name.lower():
-            return project.name
-    raise NotFoundException(f"Project {project_name} not found")
+    """Return the canonical project name matching the input case-insensitively."""
+    return (await get_project_info(project_name)).name

--- a/ayon_server/helpers/project_list.py
+++ b/ayon_server/helpers/project_list.py
@@ -61,8 +61,9 @@ async def get_project_list() -> list[ProjectListItem]:
 async def get_project_info(project_name: str) -> ProjectListItem:
     """Return a single project info"""
     project_list = await get_project_list()
+    project_name = project_name.lower()
     for project in project_list:
-        if project.name.lower() == project_name.lower():
+        if project.name.lower() == project_name:
             return project
     raise NotFoundException(f"Project {project_name} not found")
 


### PR DESCRIPTION
* Added a new async function `normalize_project_name` in `ayon_server/helpers/project_list.py` to standardize project names by matching case-insensitively and returning the canonical case-sensitive name.
* Updated the `get_share_options` function in `api/access/utils.py` to use `normalize_project_name` before fetching share options, ensuring consistent project name handling.