### PR TITLE
Fix: Update thumbnail ID with restricted attributes

### DIFF
--- a/ayon_server/access/utils.py
+++ b/ayon_server/access/utils.py
@@ -242,8 +242,9 @@ async def ensure_entity_access(
         {SQLTool.conditions(conditions)}
     """
 
-    async for _ in Postgres.iterate(query):
+    if await Postgres.fetchrow(query):
         return True
+
     raise ForbiddenException("Entity access denied")
 
 

--- a/ayon_server/entities/core/base.py
+++ b/ayon_server/entities/core/base.py
@@ -11,8 +11,8 @@ from ayon_server.exceptions import ForbiddenException
 if TYPE_CHECKING:
     from ayon_server.entities.user import UserEntity
 
-ALWAYS_WRITABLE_ATTRS = []
-ALWAYS_WRITABLE_FIELDS = ["thumbnail_id"]
+ALWAYS_WRITABLE_ATTRS: list[str] = []
+ALWAYS_WRITABLE_FIELDS: list[str] = ["thumbnail_id"]
 
 
 class BaseEntity:

--- a/ayon_server/entities/core/base.py
+++ b/ayon_server/entities/core/base.py
@@ -11,6 +11,9 @@ from ayon_server.exceptions import ForbiddenException
 if TYPE_CHECKING:
     from ayon_server.entities.user import UserEntity
 
+ALWAYS_WRITABLE_ATTRS = []
+ALWAYS_WRITABLE_FIELDS = ["thumbnail_id"]
+
 
 class BaseEntity:
     entity_type: str
@@ -75,10 +78,15 @@ class BaseEntity:
                     patch_data.attrib.developerMode = None  # type: ignore
 
                 if perms.attrib_write.enabled:
+                    writable_attrs = (
+                        perms.attrib_write.attributes + ALWAYS_WRITABLE_ATTRS
+                    )
+                    writable_fields = perms.attrib_write.fields + ALWAYS_WRITABLE_FIELDS
+
                     for attr, val in pattr.items():
                         if getattr(self.attrib, attr) == val:
                             continue
-                        if attr not in perms.attrib_write.attributes:
+                        if attr not in writable_attrs:
                             raise ForbiddenException(
                                 f"You are not allowed to modify {attr}"
                                 f" attribute in {self.project_name}"
@@ -87,7 +95,7 @@ class BaseEntity:
                     for field_name, val in pdata.items():
                         if getattr(self._payload, field_name, None) == val:
                             continue
-                        if field_name not in perms.attrib_write.fields:
+                        if field_name not in writable_fields:
                             raise ForbiddenException(
                                 f"You are not allowed to modify {field_name}"
                                 f" field in {self.project_name}"

--- a/ayon_server/operations/project_level/__init__.py
+++ b/ayon_server/operations/project_level/__init__.py
@@ -465,7 +465,7 @@ class ProjectLevelOperations:
                         raise RollbackException()
 
                 except RollbackException:
-                    logger.trace("[OPS] Operations rolled back")
+                    logger.debug("[OPS] Operations rolled back")
                     break
 
                 except ServiceUnavailableException:


### PR DESCRIPTION
Fixes the following:

- Users that are allowed to publish, but their attribute write access is restricted can now update thumbnail id
- entity access check is now performed in the same transaction as operations, so the access control list is up-to-date when multiple hierarchical items are created in the same operations batch