### PR TITLE
Respect comment categories in inbox

### DIFF
--- a/ayon_server/graphql/nodes/activity.py
+++ b/ayon_server/graphql/nodes/activity.py
@@ -7,7 +7,6 @@ from strawberry import LazyType
 from ayon_server.activities.activity_categories import ActivityCategories
 from ayon_server.exceptions import ForbiddenException
 from ayon_server.graphql.types import Info
-from ayon_server.logging import logger
 from ayon_server.utils import json_dumps, json_loads, slugify
 
 if TYPE_CHECKING:
@@ -259,7 +258,6 @@ async def activity_from_record(
                     context["user"], project_name=project_name
                 )
             if category_name not in accessible_cats[project_name]:
-                logger.trace(f"Skipping inaccessible activity category {category_name}")
                 raise ForbiddenException()
 
     origin_data = activity_data.get("origin")

--- a/ayon_server/graphql/resolvers/inbox.py
+++ b/ayon_server/graphql/resolvers/inbox.py
@@ -32,6 +32,11 @@ async def get_inbox(
     user = info.context["user"]
     if user.is_guest:
         return ActivitiesConnection(edges=[])
+    elif not user.is_manager:
+        # create a map, of {project_name: list of accessible categories}
+        # that will be populated (and used) in the resolve function
+        # to filter out inaccessible activities
+        info.context["inboxAccessibleCategories"] = {}
 
     sql_conditions = []
     subquery_conds = []


### PR DESCRIPTION
This pull request introduces access control for activity categories, ensuring that users only receive notifications and see activities for categories they have access to. The changes primarily affect how activities are filtered and delivered to users, both in the backend activity creation logic and in the GraphQL API layer.
