### PR TITLE
Delete site endpoint

### DIFF
--- a/api/system/sites.py
+++ b/api/system/sites.py
@@ -1,6 +1,11 @@
-from fastapi import Query
+from typing import Annotated
+
+from fastapi import BackgroundTasks, Path, Query
 
 from ayon_server.api.dependencies import CurrentUser
+from ayon_server.api.responses import EmptyResponse
+from ayon_server.exceptions import ForbiddenException, NotFoundException
+from ayon_server.helpers.project_list import get_project_list
 from ayon_server.lib.postgres import Postgres
 from ayon_server.types import Field, OPModel, Platform
 
@@ -40,3 +45,61 @@ async def get_sites(
         result.append(site)
 
     return result
+
+
+async def _post_site_delete(site_id: str) -> None:
+    """Delete site-related data after site deletion"""
+
+    projects = await get_project_list()
+    for project in projects:
+        async with Postgres.transaction():
+            await Postgres.set_project_schema(project.name)
+            q = """
+                DELETE FROM project_site_settings
+                WHERE site_id = $1
+            """
+
+            await Postgres.execute(q, site_id)
+
+            q = """
+                DELETE FROM custom_roots
+                WHERE site_id = $1
+            """
+
+            await Postgres.execute(q, site_id)
+
+
+@router.delete("/system/sites/{site_id}")
+async def delete_site(
+    site_id: Annotated[
+        str,
+        Path(
+            ...,
+            title="Site identifier",
+            regex="^[a-zA-Z0-9_-]+$",
+        ),
+    ],
+    user: CurrentUser,
+    background_tasks: BackgroundTasks,
+) -> EmptyResponse:
+    """Unregister a site by its ID"""
+
+    if not user.is_admin:
+        raise ForbiddenException("Only administrators can delete sites")
+
+    query = """
+        WITH deleted AS (
+            DELETE FROM sites
+            WHERE id = $1
+            RETURNING id, data
+        )
+        SELECT id, data FROM deleted
+    """
+
+    row = await Postgres.fetchrow(query, site_id)
+    if not row:
+        raise NotFoundException("Site not found")
+
+    background_tasks.add_task(_post_site_delete, site_id)
+
+    return EmptyResponse()


### PR DESCRIPTION
This pull request adds a new endpoint to allow administrators to delete sites, along with all related data, and improves the handling of site deletion in the system. The main changes include introducing a `DELETE` route for sites, enforcing admin-only access, and ensuring all associated data is cleaned up asynchronously after a site is removed.

### New site deletion endpoint and related logic

* Added a `DELETE /system/sites/{site_id}` endpoint in `api/system/sites.py` to allow site removal, restricted to administrators.
* Implemented admin-only access control for site deletion by raising `ForbiddenException` if the current user is not an admin.
* Added asynchronous cleanup of related data (`project_site_settings` and `custom_roots`) from all projects after a site is deleted, using background tasks.