### PR TITLE
Generic view models

### DIFF
--- a/api/views/models.py
+++ b/api/views/models.py
@@ -12,8 +12,10 @@ from ayon_server.views.models import (
     FViewWorking,
     ListsSettings,
     OverviewSettings,
+    PlannerSettings,
     ReportsSettings,
     ReviewsSettings,
+    SchedulerSettings,
     TaskProgressSettings,
     VersionsSettings,
     ViewSettingsModel,
@@ -93,6 +95,20 @@ class ReportsViewModel(BaseViewModel):
     settings: ReportsSettings
 
 
+class SchedulerViewModel(BaseViewModel):
+    """Scheduler view model."""
+
+    view_type: Literal["scheduler"] = "scheduler"
+    settings: SchedulerSettings
+
+
+class PlannerViewModel(BaseViewModel):
+    """Planner view model."""
+
+    view_type: Literal["planner"] = "planner"
+    settings: PlannerSettings
+
+
 #
 # POST REST API models
 #
@@ -145,6 +161,20 @@ class ReportsViewPostModel(BaseViewPostModel):
 
     _view_type: Literal["reports"] = "reports"
     settings: ReportsSettings
+
+
+class SchedulerViewPostModel(BaseViewPostModel):
+    """Scheduler view post model."""
+
+    _view_type: Literal["scheduler"] = "scheduler"
+    settings: SchedulerSettings
+
+
+class PlannerViewPostModel(BaseViewPostModel):
+    """Planner view post model."""
+
+    _view_type: Literal["planner"] = "planner"
+    settings: PlannerSettings
 
 
 #
@@ -200,6 +230,20 @@ class ReportsViewPatchModel(BaseViewPatchModel):
     settings: ReportsSettings | None = None
 
 
+class SchedulerViewPatchModel(BaseViewPatchModel):
+    """Scheduler view post model."""
+
+    _view_type: Literal["scheduler"] = "scheduler"
+    settings: SchedulerSettings | None = None
+
+
+class PlannerViewPatchModel(BaseViewPatchModel):
+    """Planner view post model."""
+
+    _view_type: Literal["planner"] = "planner"
+    settings: PlannerSettings | None = None
+
+
 #
 # Compound models
 #
@@ -211,7 +255,9 @@ ViewModel = Annotated[
     | ListsViewModel
     | ReviewsViewModel
     | VersionsViewModel
-    | ReportsViewModel,
+    | ReportsViewModel
+    | SchedulerViewModel
+    | PlannerViewModel,
     Field(
         discriminator="_view_type",
         title="View model",
@@ -224,7 +270,9 @@ ViewPostModel = Annotated[
     | ListsViewPostModel
     | ReviewsViewPostModel
     | VersionsViewPostModel
-    | ReportsViewPostModel,
+    | ReportsViewPostModel
+    | SchedulerViewPostModel
+    | PlannerViewPostModel,
     Field(
         discriminator="_view_type",
         title="View post model",
@@ -237,7 +285,9 @@ ViewPatchModel = Annotated[
     | ListsViewPatchModel
     | ReviewsViewPatchModel
     | VersionsViewPatchModel
-    | ReportsViewPatchModel,
+    | ReportsViewPatchModel
+    | SchedulerViewPatchModel
+    | PlannerViewPatchModel,
     Field(
         discriminator="_view_type",
         title="View model",
@@ -258,6 +308,10 @@ def construct_view_model(**data: Any) -> ViewModel:
         return VersionsViewModel(**data)
     elif data.get("view_type") == "reports":
         return ReportsViewModel(**data)
+    elif data.get("view_type") == "scheduler":
+        return SchedulerViewModel(**data)
+    elif data.get("view_type") == "planner":
+        return PlannerViewModel(**data)
     raise ValueError("Invalid view type provided")
 
 
@@ -274,6 +328,10 @@ def get_post_model_class(view_type: str) -> type[ViewPostModel]:
         return VersionsViewPostModel
     elif view_type == "reports":
         return ReportsViewPostModel
+    elif view_type == "scheduler":
+        return SchedulerViewPostModel
+    elif view_type == "planner":
+        return PlannerViewPostModel
     raise ValueError("Invalid view type provided")
 
 
@@ -290,4 +348,8 @@ def get_patch_model_class(view_type: str) -> type[ViewPatchModel]:
         return VersionsViewPatchModel
     elif view_type == "reports":
         return ReportsViewPatchModel
+    elif view_type == "scheduler":
+        return SchedulerViewPatchModel
+    elif view_type == "planner":
+        return PlannerViewPatchModel
     raise ValueError("Invalid view type provided")

--- a/api/views/models.py
+++ b/api/views/models.py
@@ -12,10 +12,7 @@ from ayon_server.views.models import (
     FViewWorking,
     ListsSettings,
     OverviewSettings,
-    PlannerSettings,
-    ReportsSettings,
     ReviewsSettings,
-    SchedulerSettings,
     TaskProgressSettings,
     VersionsSettings,
     ViewSettingsModel,
@@ -88,25 +85,11 @@ class VersionsViewModel(BaseViewModel):
     settings: VersionsSettings
 
 
-class ReportsViewModel(BaseViewModel):
+class GenericViewModel(BaseViewModel):
     """Reports view model."""
 
     view_type: Literal["reports"] = "reports"
-    settings: ReportsSettings
-
-
-class SchedulerViewModel(BaseViewModel):
-    """Scheduler view model."""
-
-    view_type: Literal["scheduler"] = "scheduler"
-    settings: SchedulerSettings
-
-
-class PlannerViewModel(BaseViewModel):
-    """Planner view model."""
-
-    view_type: Literal["planner"] = "planner"
-    settings: PlannerSettings
+    settings: dict[str, Any]
 
 
 #
@@ -156,25 +139,9 @@ class VersionsViewPostModel(BaseViewPostModel):
     settings: VersionsSettings
 
 
-class ReportsViewPostModel(BaseViewPostModel):
-    """Reports view post model."""
-
+class GenericViewPostModel(BaseViewPostModel):
     _view_type: Literal["reports"] = "reports"
-    settings: ReportsSettings
-
-
-class SchedulerViewPostModel(BaseViewPostModel):
-    """Scheduler view post model."""
-
-    _view_type: Literal["scheduler"] = "scheduler"
-    settings: SchedulerSettings
-
-
-class PlannerViewPostModel(BaseViewPostModel):
-    """Planner view post model."""
-
-    _view_type: Literal["planner"] = "planner"
-    settings: PlannerSettings
+    settings: dict[str, Any]
 
 
 #
@@ -223,25 +190,11 @@ class VersionsViewPatchModel(BaseViewPatchModel):
     settings: VersionsSettings | None = None
 
 
-class ReportsViewPatchModel(BaseViewPatchModel):
+class GenericViewPatchModel(BaseViewPatchModel):
     """Reports view post model."""
 
     _view_type: Literal["reports"] = "reports"
-    settings: ReportsSettings | None = None
-
-
-class SchedulerViewPatchModel(BaseViewPatchModel):
-    """Scheduler view post model."""
-
-    _view_type: Literal["scheduler"] = "scheduler"
-    settings: SchedulerSettings | None = None
-
-
-class PlannerViewPatchModel(BaseViewPatchModel):
-    """Planner view post model."""
-
-    _view_type: Literal["planner"] = "planner"
-    settings: PlannerSettings | None = None
+    settings: dict[str, Any] | None = None
 
 
 #
@@ -255,9 +208,7 @@ ViewModel = Annotated[
     | ListsViewModel
     | ReviewsViewModel
     | VersionsViewModel
-    | ReportsViewModel
-    | SchedulerViewModel
-    | PlannerViewModel,
+    | GenericViewModel,
     Field(
         discriminator="_view_type",
         title="View model",
@@ -270,9 +221,7 @@ ViewPostModel = Annotated[
     | ListsViewPostModel
     | ReviewsViewPostModel
     | VersionsViewPostModel
-    | ReportsViewPostModel
-    | SchedulerViewPostModel
-    | PlannerViewPostModel,
+    | GenericViewPostModel,
     Field(
         discriminator="_view_type",
         title="View post model",
@@ -285,9 +234,7 @@ ViewPatchModel = Annotated[
     | ListsViewPatchModel
     | ReviewsViewPatchModel
     | VersionsViewPatchModel
-    | ReportsViewPatchModel
-    | SchedulerViewPatchModel
-    | PlannerViewPatchModel,
+    | GenericViewPatchModel,
     Field(
         discriminator="_view_type",
         title="View model",
@@ -306,13 +253,8 @@ def construct_view_model(**data: Any) -> ViewModel:
         return ReviewsViewModel(**data)
     elif data.get("view_type") == "versions":
         return VersionsViewModel(**data)
-    elif data.get("view_type") == "reports":
-        return ReportsViewModel(**data)
-    elif data.get("view_type") == "scheduler":
-        return SchedulerViewModel(**data)
-    elif data.get("view_type") == "planner":
-        return PlannerViewModel(**data)
-    raise ValueError("Invalid view type provided")
+    else:
+        return GenericViewModel(**data)
 
 
 def get_post_model_class(view_type: str) -> type[ViewPostModel]:
@@ -326,13 +268,8 @@ def get_post_model_class(view_type: str) -> type[ViewPostModel]:
         return ReviewsViewPostModel
     elif view_type == "versions":
         return VersionsViewPostModel
-    elif view_type == "reports":
-        return ReportsViewPostModel
-    elif view_type == "scheduler":
-        return SchedulerViewPostModel
-    elif view_type == "planner":
-        return PlannerViewPostModel
-    raise ValueError("Invalid view type provided")
+    else:
+        return GenericViewPostModel
 
 
 def get_patch_model_class(view_type: str) -> type[ViewPatchModel]:
@@ -346,10 +283,5 @@ def get_patch_model_class(view_type: str) -> type[ViewPatchModel]:
         return ReviewsViewPatchModel
     elif view_type == "versions":
         return VersionsViewPatchModel
-    elif view_type == "reports":
-        return ReportsViewPatchModel
-    elif view_type == "scheduler":
-        return SchedulerViewPatchModel
-    elif view_type == "planner":
-        return PlannerViewPatchModel
-    raise ValueError("Invalid view type provided")
+    else:
+        return GenericViewPatchModel

--- a/api/views/views.py
+++ b/api/views/views.py
@@ -345,6 +345,13 @@ async def create_view(
         RETURNING id;
         """
 
+        if isinstance(payload.settings, OPModel):
+            settings_dict = payload.settings.dict()
+        elif isinstance(payload.settings, dict):
+            settings_dict = payload.settings
+        else:
+            settings_dict = {}
+
         await Postgres.execute(
             query,
             payload.id,
@@ -352,7 +359,7 @@ async def create_view(
             payload.label,
             current_user.name,
             payload.working,
-            payload.settings.dict(),
+            settings_dict,
         )
 
     return EntityIdResponse(id=payload.id)

--- a/ayon_server/views/models.py
+++ b/ayon_server/views/models.py
@@ -18,6 +18,8 @@ ViewType = Literal[
     "reviews",
     "versions",
     "reports",
+    "scheduler",
+    "planner",
 ]
 
 FViewScope = Annotated[
@@ -181,6 +183,41 @@ class ReportsSettings(OPModel):
     date_format: str | None = None
 
 
+class RangeModel(OPModel):
+    start: int
+    end: int
+
+
+class SchedulerSettings(OPModel):
+    show_hierarchy: bool = True
+    row_height: int | None = None
+    group_by: str | None = None
+    show_empty_groups: bool = False
+    sort_by: str | None = None
+    sort_desc: bool = False
+    filter: QueryFilter | None = None
+    columns: FColumnList
+    range: RangeModel | None = None
+    color_by: str | None = None
+    show_planner: bool = False
+    scenario: str | None = None
+    panel_width: int | None = None
+
+
+class PlannerSettings(OPModel):
+    filter: QueryFilter | None = None
+    range: RangeModel | None = None
+    group_by: str | None = None
+    group_by_desc: bool = False
+    sort_by: str | None = None
+    sort_by_desc: bool = False
+    sort_by_tracks: str | None = None
+    sort_by_tracks_desc: bool = False
+    color_by: str | None = None
+    scenario: str | None = None
+    panel_width: int | None = None
+
+
 ViewSettingsModel = (
     OverviewSettings
     | TaskProgressSettings
@@ -188,4 +225,6 @@ ViewSettingsModel = (
     | VersionsSettings
     | ReportsSettings
     | ReviewsSettings
+    | SchedulerSettings
+    | PlannerSettings
 )

--- a/ayon_server/views/models.py
+++ b/ayon_server/views/models.py
@@ -11,16 +11,7 @@ from ayon_server.utils import create_uuid
 #
 
 ViewScopes = Literal["project", "studio"]
-ViewType = Literal[
-    "overview",
-    "taskProgress",
-    "lists",
-    "reviews",
-    "versions",
-    "reports",
-    "scheduler",
-    "planner",
-]
+ViewType = Literal["overview", "taskProgress", "lists", "reviews" "versions"] | str
 
 FViewScope = Annotated[
     ViewScopes,
@@ -175,56 +166,11 @@ class VersionsSettings(OPModel):
     columns: FColumnList
 
 
-class ReportsSettings(OPModel):
-    widgets: Annotated[
-        list[dict[str, Any]],
-        Field(title="List of report widgets", default_factory=list),
-    ]
-    date_format: str | None = None
-
-
-class RangeModel(OPModel):
-    start: int
-    end: int
-
-
-class SchedulerSettings(OPModel):
-    show_hierarchy: bool = True
-    row_height: int | None = None
-    group_by: str | None = None
-    show_empty_groups: bool = False
-    sort_by: str | None = None
-    sort_desc: bool = False
-    filter: QueryFilter | None = None
-    columns: FColumnList
-    range: RangeModel | None = None
-    color_by: str | None = None
-    show_planner: bool = False
-    scenario: str | None = None
-    panel_width: int | None = None
-
-
-class PlannerSettings(OPModel):
-    filter: QueryFilter | None = None
-    range: RangeModel | None = None
-    group_by: str | None = None
-    group_by_desc: bool = False
-    sort_by: str | None = None
-    sort_by_desc: bool = False
-    sort_by_tracks: str | None = None
-    sort_by_tracks_desc: bool = False
-    color_by: str | None = None
-    scenario: str | None = None
-    panel_width: int | None = None
-
-
 ViewSettingsModel = (
     OverviewSettings
     | TaskProgressSettings
     | ListsSettings
     | VersionsSettings
-    | ReportsSettings
     | ReviewsSettings
-    | SchedulerSettings
-    | PlannerSettings
+    | dict[str, Any]
 )

--- a/ayon_server/views/models.py
+++ b/ayon_server/views/models.py
@@ -131,11 +131,13 @@ class OverviewSettings(OPModel):
     sort_by: str | None = None
     sort_desc: bool = False
     filter: QueryFilter | None = None
+    slice_type: str | None = None
     columns: FColumnList
 
 
 class TaskProgressSettings(OPModel):
     filter: QueryFilter | None = None
+    slice_type: str | None = None
     columns: FColumnList
 
 


### PR DESCRIPTION
This pull request refactors the handling of the "reports" view type in the view models, replacing the specialized `Reports*Model` classes with generic `Generic*Model` classes that accept arbitrary settings as a dictionary. This change makes the system more flexible and simplifies the addition of new view types in the future. The most important changes are grouped below.