### PR TITLE
Folder type colors

### DIFF
--- a/ayon_server/entities/project_aux_tables.py
+++ b/ayon_server/entities/project_aux_tables.py
@@ -20,6 +20,7 @@ class BaseAuxTable(TypedDict):
 class FolderTypeDict(BaseAuxTable):
     shortName: NotRequired[str]
     icon: NotRequired[str]
+    color: NotRequired[str]
 
 
 class TaskTypeDict(BaseAuxTable):

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -73,6 +73,7 @@ class FolderType:
     name: str
     icon: str | None = None
     short_name: str | None = None
+    color: str | None = None
 
 
 @strawberry.type
@@ -270,6 +271,7 @@ class ProjectNode:
             FolderType(
                 name=row["name"],
                 short_name=row["data"].get("shortName"),
+                color=row["data"].get("color"),
                 icon=row["data"].get("icon"),
             )
             for row in res

--- a/ayon_server/settings/anatomy/folder_types.py
+++ b/ayon_server/settings/anatomy/folder_types.py
@@ -5,6 +5,7 @@ from .aux_model import BaseAuxModel
 
 class FolderType(BaseAuxModel):
     shortName: str = SettingsField("", title="Short name")
+    color: str = SettingsField("#cccccc", title="Color", widget="color")
     icon: str = SettingsField("folder", title="Icon", widget="icon")
 
 


### PR DESCRIPTION
This pull request adds support for a `color` attribute to folder types across the codebase. The changes ensure that folder types can now have an associated color, which is stored, exposed via the API, and configured in settings.