### PR TITLE
GraphQL: Task folder filter

### DIFF
--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -162,7 +162,9 @@ async def get_tasks(
     ] = False,
     search: Annotated[str | None, argdesc("Fuzzy text search filter")] = None,
     filter: Annotated[str | None, argdesc("Filter tasks using QueryFilter")] = None,
-    folder_filter: Annotated[str | None, argdesc("Filter tasks by queryfilter on folders")] = None,
+    folder_filter: Annotated[
+        str | None, argdesc("Filter tasks by queryfilter on folders")
+    ] = None,
     sort_by: Annotated[str | None, sortdesc(SORT_OPTIONS)] = None,
 ) -> TasksConnection:
     """Return a list of tasks."""
@@ -398,7 +400,6 @@ async def get_tasks(
         ):
             sql_conditions.append(fcond)
 
-
     if folder_filter:
         column_whitelist = [
             "id",
@@ -416,13 +417,13 @@ async def get_tasks(
             "created_by",
             "updated_by",
         ]
-        fdata = json.loads(filter)
+        fdata = json.loads(folder_filter)
         fq = QueryFilter(**fdata)
         if fcond := build_filter(
-                fq,
-                column_whitelist=column_whitelist,
-                table_prefix="folders",
-                column_map={ "attrib": "f_ex.attrib" },
+            fq,
+            column_whitelist=column_whitelist,
+            table_prefix="folders",
+            column_map={"attrib": "f_ex.attrib"},
         ):
             sql_conditions.append(fcond)
             use_folder_query = True


### PR DESCRIPTION
This pull request enhances the task querying capabilities in the GraphQL resolver by adding support for filtering tasks based on folder properties. The main changes introduce a new `folderFilter` argument, which allows clients to filter tasks using conditions on their parent folders, and updates the SQL query construction to support this feature.

<img width="1176" height="666" alt="image" src="https://github.com/user-attachments/assets/e152d349-e768-4778-bbeb-0fcbc5abf072" />
