### PR TITLE
Fix access to linked entities

### DIFF
--- a/ayon_server/access/utils.py
+++ b/ayon_server/access/utils.py
@@ -261,6 +261,9 @@ class TrieNode:
         self.children = {}
         self.is_end = False
 
+    def __repr__(self):
+        return f"TrieNode(end={self.is_end}, children={list(self.children.keys())})"
+
 
 class AccessChecker:
     """

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -70,13 +70,8 @@ class LinkEdge(BaseEdge):
         access_checker = info.context.get("access_checker")
         if access_checker:
             entity_folder_path = (entity_node._folder_path or "").strip("/")
-            if entity_folder_path not in access_checker.exact_paths:
-                # We don't handle partial errors in the frontend yet,
-                # but it would probably be a good idea to do so in the future.
-                #
-                # For now we just silently hide the linked entity if access is denied.
-                #
-                # raise ForbiddenException("Access to the linked entity denied")
+            if not access_checker[entity_folder_path]:
+                # No access to the folder containing the linked entity
                 return None
         return entity_node
 


### PR DESCRIPTION
This pull request introduces a minor improvement to the codebase by enhancing debugging and clarifying access checks. The changes include adding a `__repr__` method for the `TrieNode` class to improve its string representation and updating the access check logic in the GraphQL node resolver for clarity and correctness.