### PR TITLE
Fixed versions sorting by path

### DIFF
--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -40,7 +40,7 @@ SORT_OPTIONS = {
     "createdBy": "versions.created_by",
     "updatedBy": "versions.updated_by",
     "tags": "array_to_string(versions.tags, '')",
-    "path": "hierarchy.path || '/' || products.name || '/' || versions.version::text",
+    "path": "hierarchy.path || '/' || products.name || '/' || LPAD(versions.version::text, 5, '0')",  # noqa 501
     "productType": "products.product_type",
     "productName": "products.name",
     "folderName": "folders.name",


### PR DESCRIPTION
This pull request makes a small change to the way the `path` field is constructed in the `versions.py` GraphQL resolver. The version number in the path is now zero-padded to a width of 5 digits for consistency and sorting purposes.

* Updated the `path` construction in the `versions.py` resolver to use `LPAD` for zero-padding the version number to 5 digits.