### PR TITLE
Fixed fetching custom list item attributes

### DIFF
--- a/ayon_server/graphql/nodes/entity_list.py
+++ b/ayon_server/graphql/nodes/entity_list.py
@@ -45,7 +45,7 @@ class EntityListItemEdge(BaseEdge):
     _user: strawberry.Private[UserEntity]
 
     @strawberry.field()
-    def all_attrib(self) -> str:
+    def all_attrib(self, info: Info) -> str:
         """All attributes field is a JSON string."""
         if self._entity is None:
             return "{}"
@@ -72,13 +72,15 @@ class EntityListItemEdge(BaseEdge):
                 project_name=self.project_name,
                 inherited_attrib=inherited_attrib,
                 project_attrib=project_attrib,
+                list_attribute_config=info.context.get("list_attributes"),
             )
         )
 
     @strawberry.field()
-    def own_attrib(self) -> list[str]:
+    def own_attrib(self, info: Info) -> list[str]:
         """Own attributes field is a JSON string."""
-        return list(self._attrib.keys())
+        configured_keys = info.context.get("list_attributes") or {}
+        return [key for key in self._attrib.keys() if key in configured_keys]
 
     @strawberry.field()
     def data(self) -> str:

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -132,6 +132,13 @@ async def get_entity_list_items(
             )
     else:
         info.context["entity_type"] = entity_type
+
+    # Get attribute definition for the entity list
+    attrs = root._data.get("attributes") or []
+    info.context["list_attributes"] = {
+        attr["name"]: attr["data"].get("type", "string") for attr in attrs
+    }
+
     fields = FieldInfo(info, None)
 
     #

--- a/ayon_server/graphql/utils.py
+++ b/ayon_server/graphql/utils.py
@@ -20,6 +20,7 @@ def process_attrib_data(
     project_name: str | None = None,
     inherited_attrib: dict[str, Any] | None = None,
     project_attrib: dict[str, Any] | None = None,
+    list_attribute_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     attr_limit: list[str] | Literal["all"] = []
 
@@ -78,13 +79,17 @@ def process_attrib_data(
         if not (attr_limit == "all" or key in attr_limit):
             continue
 
-        try:
-            attr = attribute_library.by_name_scoped(entity_type, key)
-        except KeyError:
-            # Attribute not defined for this entity type
-            continue
+        if list_attribute_config and key in own_attrib and key in list_attribute_config:
+            attr_type = list_attribute_config[key]
+        else:
+            try:
+                attr = attribute_library.by_name_scoped(entity_type, key)
+            except KeyError:
+                # Attribute not defined for this entity type
+                continue
+            attr_type = attr["type"]
 
-        if attr["type"] == "datetime":
+        if attr_type == "datetime":
             if isinstance(value, str):
                 try:
                     value = datetime.fromisoformat(value)
@@ -93,6 +98,7 @@ def process_attrib_data(
                     continue
 
         result[key] = value
+
     return result
 
 


### PR DESCRIPTION
This pull request enhances the way entity attributes are handled and exposed in the GraphQL API, focusing on ensuring that only configured attributes are included in responses and that their types are correctly determined. The main changes involve passing attribute configuration through the GraphQL context, filtering attributes based on this configuration, and improving type resolution in attribute processing.

**GraphQL attribute configuration and filtering:**

* The `all_attrib` and `own_attrib` fields in `EntityListItemEdge` now receive the GraphQL `info` context and use it to filter and serialize attributes according to the configured list of attributes. Only attributes present in the configuration are included in the output.
* The resolver `get_entity_list_items` now extracts the attribute definitions from the root entity's data and stores them in the GraphQL context as `list_attributes`, mapping attribute names to their types.
