### PR TITLE
Improved folder filtering

### DIFF
--- a/api/folders/__init__.py
+++ b/api/folders/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ["router", "folders", "list_folders"]
+__all__ = ["router", "folders", "list_folders", "search"]
 
-from . import folders, list_folders
+from . import folders, list_folders, search
 from .router import router

--- a/api/folders/search.py
+++ b/api/folders/search.py
@@ -1,0 +1,215 @@
+from typing import Annotated
+
+from ayon_server.access.utils import folder_access_list
+from ayon_server.api.dependencies import CurrentUser, ProjectName
+from ayon_server.exceptions import BadRequestException
+from ayon_server.lib.postgres import Postgres
+from ayon_server.sqlfilter import QueryFilter, build_filter
+from ayon_server.types import Field, OPModel
+from ayon_server.utils import SQLTool, slugify
+
+from .router import router
+
+
+class FolderSearchRequest(OPModel):
+    task_filter: Annotated[
+        QueryFilter | None,
+        Field(title="Filter", description="Filter object used to resolve the tasks"),
+    ] = None
+
+    task_search: Annotated[
+        str | None,
+        Field(
+            title="Text search",
+            description="'fulltext' search used to resolve the tasks",
+        ),
+    ] = None
+
+    folder_filter: Annotated[
+        QueryFilter | None,
+        Field(
+            title="Folder Filter",
+            description="Filter object used to resolve the folders",
+        ),
+    ] = None
+
+    folder_search: Annotated[
+        str | None,
+        Field(
+            title="Folder Text search",
+            description="'fulltext' search used to resolve the folders",
+        ),
+    ] = None
+
+
+class FolderSearchResponse(OPModel):
+    folder_ids: Annotated[
+        list[str],
+        Field(
+            default_factory=list,
+            description="List of folder ids containing tasks matching the query",
+            example=[
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222",
+            ],
+        ),
+    ]
+
+
+TASK_ALLOWED_KEYS = [
+    "id",
+    "name",
+    "label",
+    "task_type",
+    "assignees",
+    "status",
+    "attrib",
+    "data",
+    "tags",
+    "active",
+    "created_at",
+    "updated_at",
+    "created_by",
+    "updated_by",
+]
+
+
+FOLDER_ALLOWED_FIELDS = [
+    "id",
+    "name",
+    "label",
+    "folder_type",
+    "parent_id",
+    "attrib",
+    "data",
+    "active",
+    "status",
+    "tags",
+    "created_at",
+    "updated_at",
+    "created_by",
+    "updated_by",
+]
+
+
+@router.post("/search")
+async def search_folders(
+    user: CurrentUser,
+    project_name: ProjectName,
+    payload: FolderSearchRequest,
+) -> FolderSearchResponse:
+    sql_cte = []
+    sql_joins = []
+    sql_conditions = []
+
+    #
+    # Filtering by tasks
+    #
+
+    if payload.task_filter or payload.task_search:
+        task_conditions = []
+
+        if payload.task_filter:
+            try:
+                filter = build_filter(
+                    payload.task_filter,
+                    table_prefix="tasks",
+                    column_whitelist=TASK_ALLOWED_KEYS,
+                    column_map={"attrib": "(ex.attrib || tasks.attrib)"},
+                )
+            except ValueError as e:
+                raise BadRequestException(str(e))
+
+            if filter is not None:
+                task_conditions.append(filter)
+            else:
+                raise BadRequestException(
+                    "Task filter provided but could not be parsed"
+                )
+
+        if payload.task_search:
+            terms = slugify(payload.task_search, make_set=True)
+            for term in terms:
+                cond = f"""(
+                tasks.name ILIKE '{term}%'
+                OR tasks.label ILIKE '{term}%'
+                OR tasks.task_type ILIKE '{term}%'
+                OR ex.path ILIKE '%{term}%'
+                )"""
+                task_conditions.append(cond)
+
+        sql_cte.append(
+            f"""
+            filtered_tasks AS (
+                SELECT DISTINCT tasks.folder_id
+                FROM project_{project_name}.tasks AS tasks
+                JOIN project_{project_name}.exported_attributes as ex
+                ON tasks.folder_id = ex.folder_id
+                {SQLTool.conditions(task_conditions)}
+            )
+            """
+        )
+
+        sql_joins.append(
+            """
+            JOIN filtered_tasks AS ft
+            ON ft.folder_id = folders.id
+            """
+        )
+
+    #
+    # Filtering by folders
+    #
+
+    if payload.folder_filter:
+        pass
+
+        if fcond := build_filter(
+            payload.folder_filter,
+            column_whitelist=FOLDER_ALLOWED_FIELDS,
+            table_prefix="folders",
+            column_map={
+                "attrib": "e.attrib",
+                "path": "e.path",
+            },
+        ):
+            sql_conditions.append(fcond)
+
+    if payload.folder_search:
+        terms = slugify(payload.folder_search, make_set=True)
+        for term in terms:
+            sql_conditions.append(
+                f"(folders.name ILIKE '%{term}%' OR "
+                f"folders.label ILIKE '%{term}%' OR "
+                f"e.path ILIKE '%{term}%')"
+            )
+
+    facl = await folder_access_list(user, project_name, "read")
+    if facl is not None:
+        cond = f"e.path like ANY ('{{ {','.join(facl)} }}')"
+        sql_conditions.append(cond)
+
+    #
+    # Query
+    #
+
+    if sql_cte:
+        cte = ", ".join(sql_cte)
+        cte = f"WITH {cte}"
+    else:
+        cte = ""
+
+    query = f"""
+        {cte}
+        SELECT folders.id AS folder_id
+        FROM project_{project_name}.folders AS folders
+        JOIN project_{project_name}.exported_attributes AS e
+        ON folders.id = e.folder_id
+        {" ".join(sql_joins)}
+        {SQLTool.conditions(sql_conditions)}
+    """
+    result = []
+    async for row in Postgres.iterate(query):
+        result.append(row["folder_id"])
+
+    return FolderSearchResponse(folder_ids=result)

--- a/api/tasks_folders/tasks_folders.py
+++ b/api/tasks_folders/tasks_folders.py
@@ -58,7 +58,7 @@ ALLOWED_KEYS = [
 ]
 
 
-@router.post("/projects/{project_name}/tasksFolders")
+@router.post("/projects/{project_name}/tasksFolders", deprecated=True)
 async def query_tasks_folders(
     user: CurrentUser,
     project_name: ProjectName,


### PR DESCRIPTION
This pull request adds support for filtering folders by associated tasks in the `get_folders` GraphQL resolver. The main change introduces a new `task_filter` argument, allowing clients to specify task-based criteria for folder retrieval. The implementation parses the filter, constructs a SQL Common Table Expression (CTE) to select relevant folders, and joins this with the folders query, ensuring only folders with matching tasks are returned.


<img width="1368" height="500" alt="image" src="https://github.com/user-attachments/assets/f770f316-c8a2-4c72-9a1b-d6671f8d55bc" />


## Folder search endpoint

Added new endpoint `[POST] /api/projects/{projectname}/folders/search` that enables searching for folder ids matching given criteria (taskFilter, folderFilter, taskSearch, folderSearch). mimicking graphql folder resolver. This endpoint deprecates taskFolders endpoint that does the same, but with limited functionality

<img width="1498" height="737" alt="image" src="https://github.com/user-attachments/assets/46385cc6-7ef7-4652-b39c-3674617099dc" />

