### PR TITLE
Expose productBaseTypes in graphql project config

### DIFF
--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -23,6 +23,9 @@ from ayon_server.graphql.resolvers.workfiles import get_workfile, get_workfiles
 from ayon_server.graphql.utils import parse_attrib_data, process_attrib_data
 from ayon_server.helpers.tags import get_used_project_tags
 from ayon_server.lib.postgres import Postgres
+from ayon_server.settings.anatomy.product_base_types import (
+    enrich_project_config_with_product_base_types,
+)
 from ayon_server.utils import json_dumps
 
 if TYPE_CHECKING:
@@ -407,7 +410,9 @@ async def project_from_record(
         user.check_project_access(record["name"])
 
         data = record.get("data", {})
-        config = record.get("config", None)
+        config = record.get("config", {})
+        enrich_project_config_with_product_base_types(config)
+
         bundle_data = data.get("bundle", {})
         if bundle_data:
             bundle = ProjectBundleType(

--- a/ayon_server/settings/anatomy/product_base_types.py
+++ b/ayon_server/settings/anatomy/product_base_types.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Any
 
 from ayon_server.settings.common import BaseSettingsModel
 from ayon_server.settings.settings_field import SettingsField
@@ -73,3 +73,25 @@ class ProductBaseTypes(BaseSettingsModel):
             default_factory=lambda: default_product_type_definitions,
         ),
     ]
+
+
+def enrich_project_config_with_product_base_types(config: dict[str, Any]) -> None:
+    """Enrich project config with product base types settings."""
+
+    product_base_types_config = config.get("productBaseTypes", {})
+    default_pt_definitions = [p.dict() for p in default_product_type_definitions]
+
+    product_base_types_config["default"] = DefaultProductBaseType(
+        **product_base_types_config.get("default", {})
+    ).dict()
+
+    if "definitions" not in product_base_types_config:
+        product_base_types_config["definitions"] = default_pt_definitions
+    else:
+        product_base_types_config["definitions"] = [
+            ProductBaseType(**pt).dict()
+            for pt in product_base_types_config["definitions"]
+        ]
+
+    config["productBaseTypes"] = product_base_types_config
+    config.pop("productTypes", None)  # legacy


### PR DESCRIPTION
This pull request refactors how project configuration is enriched with product base types by moving the enrichment logic into a reusable function, and updates all relevant code paths to use this new function. This change improves maintainability and consistency across both the REST API and GraphQL endpoints.