### PR TITLE
Collect project names with saturated metrics

### DIFF
--- a/ayon_server/metrics/projects.py
+++ b/ayon_server/metrics/projects.py
@@ -85,9 +85,8 @@ async def get_project_metrics(
     saturated: bool = False,
     system: bool = False,
 ) -> ProjectMetrics:
-    result: dict[str, Any] = {
-        "nickname": project.nickname,
-    }
+    nickname = project.name if saturated else project.nickname
+    result: dict[str, Any] = {"nickname": nickname}
 
     for entity_type in [
         "folder",


### PR DESCRIPTION
When `AYON_METRICS_SEND_SATURATED` environment variable is enabled (default is false), metrics now provides actual project names instead of nicknames. This is NOT used for any statistics, but enables YnputCloud users to see additional project related data in the Ynput cloud dashboard and to manage the cloud storage.