### PR TITLE
Prefer project scoped views when querying default views

### DIFF
--- a/api/views/views.py
+++ b/api/views/views.py
@@ -247,6 +247,7 @@ async def get_default_view(
             )
 
         if not row:
+            await Postgres.set_public_schema()
             row = await Postgres.fetchrow(
                 query,
                 view_id,
@@ -256,6 +257,7 @@ async def get_default_view(
             )
 
         if not row:
+            await Postgres.set_public_schema()
             row = await Postgres.fetchrow(
                 """
                 SELECT *, $2 AS scope FROM views

--- a/api/views/views.py
+++ b/api/views/views.py
@@ -236,15 +236,7 @@ async def get_default_view(
     """
 
     async with Postgres.transaction():
-        row = await Postgres.fetchrow(
-            query,
-            view_id,
-            view_type,
-            user.name,
-            "studio",
-        )
-
-        if not row and project_name:
+        if project_name:
             await Postgres.set_project_schema(project_name)
             row = await Postgres.fetchrow(
                 query,
@@ -252,6 +244,15 @@ async def get_default_view(
                 view_type,
                 user.name,
                 "project",
+            )
+
+        if not row:
+            row = await Postgres.fetchrow(
+                query,
+                view_id,
+                view_type,
+                user.name,
+                "studio",
             )
 
         if not row:

--- a/ayon_server/lib/postgres.py
+++ b/ayon_server/lib/postgres.py
@@ -247,6 +247,15 @@ class Postgres:
             await conn.execute(f"SET LOCAL search_path TO project_{project_name}")
 
     @classmethod
+    async def set_public_schema(cls) -> None:
+        """Set the search path to the public schema."""
+        async with cls.acquire() as conn:
+            assert (
+                conn.is_in_transaction()
+            ), "Cannot set public schema outside of a transaction"
+            await conn.execute("SET LOCAL search_path TO public")
+
+    @classmethod
     async def iterate(
         cls,
         query: str,


### PR DESCRIPTION
This pull request improves how database schemas are set and queried when retrieving default views, and adds a utility to explicitly switch to the public schema. The main changes focus on ensuring the correct schema is used for queries depending on whether a project is specified, and on providing a new method for setting the public schema within a transaction.