### PR TITLE
Support for files in simpleform payloads

### DIFF
--- a/api/bundles/actions.py
+++ b/api/bundles/actions.py
@@ -13,9 +13,9 @@ async def promote_bundle(bundle: BundleModel, user: UserEntity):
     That includes copying staging settings to production.
     """
 
-    assert (
-        await Postgres.is_in_transaction()
-    ), "promote_bundle function must be called within a transaction"
+    assert await Postgres.is_in_transaction(), (
+        "promote_bundle function must be called within a transaction"
+    )
 
     if not user.is_admin:
         raise ForbiddenException("Only admins can promote bundles")

--- a/api/bundles/bundles.py
+++ b/api/bundles/bundles.py
@@ -103,9 +103,9 @@ async def _create_new_bundle(
     sender: str | None = None,
     sender_type: str | None = None,
 ):
-    assert (
-        await Postgres.is_in_transaction()
-    ), "_create_new_bundle must be called in a transaction"
+    assert await Postgres.is_in_transaction(), (
+        "_create_new_bundle must be called in a transaction"
+    )
 
     # Clear constrained values if they are being updated
     if bundle.is_production:

--- a/api/project_dashboard/dashboard.py
+++ b/api/project_dashboard/dashboard.py
@@ -200,7 +200,7 @@ async def get_project_activity(
     project_name: ProjectName,
     days: int = Query(50, description="Number of days to retrieve activity for"),
 ) -> ActivityResponseModel:
-    activity = {k: 0 for k in get_midnight_dates(days)}
+    activity = dict.fromkeys(get_midnight_dates(days), 0)
 
     query = """
         SELECT

--- a/api/resolve/templating.py
+++ b/api/resolve/templating.py
@@ -202,8 +202,7 @@ class TemplatePartResult:
 
         else:
             raise TypeError(
-                f'Cannot add data from "{type(other)}"'
-                f' to "{self.__class__.__name__}"'
+                f'Cannot add data from "{type(other)}" to "{self.__class__.__name__}"'
             )
 
     @property

--- a/api/settings/settings_addons_list.py
+++ b/api/settings/settings_addons_list.py
@@ -102,9 +102,9 @@ async def get_addon_list_for_settings(
             addons[addon_name] = addon_version
             inherited_addons.remove(addon_name)
 
-    assert (
-        bundle_name is not None
-    ), "Bundle name is None"  # won't happen, keep pyright happy
+    assert bundle_name is not None, (
+        "Bundle name is None"
+    )  # won't happen, keep pyright happy
 
     return AddonListForSettings(
         addons=addons,

--- a/api/users/users.py
+++ b/api/users/users.py
@@ -91,9 +91,9 @@ class NewUserModel(UserEntity.model.post_model):  # type: ignore
 def validate_user_data(data: dict[str, Any]) -> None:
     try:
         if default_access_groups := data.get("defaultAccessGroups"):
-            assert isinstance(
-                default_access_groups, list
-            ), "defaultAccessGroups must be a list"
+            assert isinstance(default_access_groups, list), (
+                "defaultAccessGroups must be a list"
+            )
             assert all(
                 isinstance(access_group, str) for access_group in default_access_groups
             ), "defaultAccessGroups must be a list of str"
@@ -104,9 +104,9 @@ def validate_user_data(data: dict[str, Any]) -> None:
             for project, ag_list in access_groups.items():
                 assert isinstance(project, str), "project name must be a string"
                 assert isinstance(ag_list, list), "access group list must be a list"
-                assert all(
-                    isinstance(ag, str) for ag in ag_list
-                ), "acces group list must be a list of str"
+                assert all(isinstance(ag, str) for ag in ag_list), (
+                    "acces group list must be a list of str"
+                )
                 if not ag_list:
                     ag_to_remove.append(project)
             for project in ag_to_remove:

--- a/ayon_server/access/utils.py
+++ b/ayon_server/access/utils.py
@@ -31,7 +31,7 @@ def path_to_paths(
     result = [f'"{path}/%"']
     if include_parents:
         for i in range(len(pelms)):
-            result.append(f"\"{'/'.join(pelms[0:i+1])}\"")
+            result.append(f'"{"/".join(pelms[0 : i + 1])}"')
     if include_self:
         slf = "/".join(pelms)
         result.append(f'"{slf}"')

--- a/ayon_server/actions/context.py
+++ b/ayon_server/actions/context.py
@@ -1,5 +1,4 @@
 import base64
-import functools
 from typing import Annotated, Any, Literal
 
 from pydantic import validator
@@ -22,6 +21,66 @@ ActionEntityType = Literal[
     "representation",
     "workfile",
 ]
+
+
+class FormFile:
+    payload: str
+    filename: str
+    cache_key: str | None
+
+    def __init__(
+        self,
+        payload: str,
+        filename: str,
+        cache_key: str | None = None,
+    ) -> None:
+        self.filename = filename
+        self.payload = payload
+        self.cache_key = cache_key
+
+    def get_bytes(self) -> bytes:
+        return base64.b64decode(self.payload)
+
+    def dump(self) -> dict[str, Any]:
+        return {
+            "filename": self.filename,
+            "payload": self.payload,
+        }
+
+    async def save_to_cache(self) -> str:
+        if not self.cache_key:
+            self.cache_key = create_uuid()
+        await Redis.set_json(
+            "action-file",
+            self.cache_key,
+            self.dump(),
+            ttl=3600,
+        )
+        return self.cache_key
+
+    @classmethod
+    async def from_cache(cls, cache_key: str) -> "FormFile":
+        data = await Redis.get_json("action-file", cache_key)
+        if not data:
+            raise ValueError(f"No cached file found for cache key '{cache_key}'")
+        return cls(
+            payload=data["payload"],
+            filename=data["filename"],
+            cache_key=cache_key,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "FormFile":
+        payload = data.get("payload")
+        filename = data.get("filename")
+        if not (payload and filename):
+            raise ValueError("Invalid file data")
+
+        return cls(
+            payload=payload,
+            filename=filename,
+            cache_key=None,
+        )
 
 
 class ActionContext(OPModel):
@@ -85,43 +144,30 @@ class ActionContext(OPModel):
         ),
     ] = None
 
-    @functools.cache
-    def _get_file_bytes(self, key: str) -> bytes | None:
-        """Get file bytes from form data."""
+    async def get_form_file(self, key: str, *, cache: bool = False) -> FormFile:
+        """Get file bytes from form data.
+
+        If a form contains a file input, this function can be used to
+        retrieve the file bytes and additional metadata.
+
+        Optionally, the file can be cached in Redis for later retrieval
+        using a cache key (which will be included in FormFile object returned).
+        """
         if not self.form_data:
-            return None
+            raise ValueError("No form data provided")
 
-        file_encoded = self.form_data.get(key)
-        if not file_encoded:
-            return None
+        file_data = self.form_data.get(key)
+        if not file_data:
+            raise ValueError(f"No file found in form data for key '{key}'")
 
-        message_bytes = base64.b64decode(file_encoded)
-        return message_bytes
+        result = FormFile.from_dict(file_data)
+        if cache:
+            await result.save_to_cache()
+        return result
 
-    def get_file_bytes(self, key: str) -> bytes | None:
-        """Get file bytes from form data."""
-        return self._get_file_bytes(key)
-
-    async def cache_file_bytes(self, key: str) -> str:
-        """
-        Store file bytes from form data in Redis and return the key.
-        so it can be used later by actions.
-        """
-
-        cache_key = create_uuid()
-        payload = self.get_file_bytes(key)
-        await Redis.set(
-            "action-file-bytes",
-            cache_key,
-            payload or b"",
-            ttl=3600,
-        )
-        return cache_key
-
-    async def get_cached_file_bytes(self, cache_key: str) -> bytes | None:
+    async def get_cached_file(self, cache_key: str) -> FormFile:
         """Retrieve cached file bytes from Redis using the cache key."""
-        payload = await Redis.get("action-file-bytes", cache_key)
-        return payload
+        return await FormFile.from_cache(cache_key)
 
     #
     # Sanity checks

--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -93,7 +93,7 @@ async def create_activity(
         data["parents"] = await get_parents_from_entity(entity)
     except Postgres.UndefinedTableError as e:
         raise NotFoundException(
-            "Unable to get references. " f"Project {project_name} no longer exists"
+            f"Unable to get references. Project {project_name} no longer exists"
         ) from e
 
     if activity_type == "comment" and is_body_with_checklist(body):
@@ -152,7 +152,7 @@ async def create_activity(
             references.update(await get_references_from_entity(entity))
         except Postgres.UndefinedTableError as e:
             raise NotFoundException(
-                "Unable to get references. " f"Project {project_name} no longer exists"
+                f"Unable to get references. Project {project_name} no longer exists"
             ) from e
 
     #
@@ -190,7 +190,7 @@ async def create_activity(
             )
         except Postgres.UndefinedTableError as e:
             raise NotFoundException(
-                "Unable to create activity. " f"Project {project_name} no longer exists"
+                f"Unable to create activity. Project {project_name} no longer exists"
             ) from e
 
         if files is not None:
@@ -208,8 +208,7 @@ async def create_activity(
                 )
             except Postgres.UndefinedTableError as e:
                 raise NotFoundException(
-                    "Unable to update files. "
-                    f"Project {project_name} no longer exists"
+                    f"Unable to update files. Project {project_name} no longer exists"
                 ) from e
 
         st_ref = await Postgres.prepare(
@@ -239,8 +238,7 @@ async def create_activity(
             )
         except Postgres.UndefinedTableError as e:
             raise NotFoundException(
-                "Unable to create references. "
-                f"Project {project_name} no longer exists"
+                f"Unable to create references. Project {project_name} no longer exists"
             ) from e
 
         # bump entity updated_at timestamp

--- a/ayon_server/activities/watchers/watcher_list.py
+++ b/ayon_server/activities/watchers/watcher_list.py
@@ -30,7 +30,7 @@ async def build_watcher_list(entity: ProjectLevelEntity) -> list[str]:
         res = await Postgres.fetch(query, entity.entity_type, entity.id)
     except Postgres.UndefinedTableError:
         logger.debug(
-            "Unable to get watchers. " f"Project {entity.project_name} no longer exists"
+            f"Unable to get watchers. Project {entity.project_name} no longer exists"
         )
         return []
 

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -106,9 +106,9 @@ class BaseServerAddon:
                 setattr(self, key, kwargs[key])
 
         # ensure name and version are set
-        assert (
-            self.name and self.version
-        ), f"Addon {addon_dir} is missing name or version"
+        assert self.name and self.version, (
+            f"Addon {addon_dir} is missing name or version"
+        )
 
         self.definition = definition
         self.addon_dir = addon_dir

--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -156,7 +156,7 @@ async def handle_request_validation_error(
         traceback_msg += f"{loc}: {error['msg']}\n"
 
     detail = (
-        f"Request validation error in " f"[{request.method.upper()}] {request.url.path}"
+        f"Request validation error in [{request.method.upper()}] {request.url.path}"
     )
 
     extras["traceback"] = traceback_msg.strip()

--- a/ayon_server/entities/core/attrib.py
+++ b/ayon_server/entities/core/attrib.py
@@ -41,8 +41,7 @@ class AttributeLibrary:
         if Postgres.pool is not None:
             with logger.contextualize(nodb=True):
                 logger.error(
-                    "Postgres pool exist during attribute load. "
-                    "This should not happen."
+                    "Postgres pool exist during attribute load. This should not happen."
                 )
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)

--- a/ayon_server/entities/core/projectlevel.py
+++ b/ayon_server/entities/core/projectlevel.py
@@ -192,7 +192,7 @@ class ProjectLevelEntity(BaseEntity):
 
         query += f"""
             WHERE entity.id=$1
-            {'FOR UPDATE OF entity NOWAIT' if for_update else ''}
+            {"FOR UPDATE OF entity NOWAIT" if for_update else ""}
         """
 
         record = await query_entity_data(query, entity_id)

--- a/ayon_server/entities/project.py
+++ b/ayon_server/entities/project.py
@@ -62,7 +62,7 @@ class ProjectEntity(TopLevelEntity):
                 SELECT  *
                 FROM public.projects
                 WHERE name ILIKE $1
-                {'FOR UPDATE NOWAIT' if for_update else ''}
+                {"FOR UPDATE NOWAIT" if for_update else ""}
                 """,
                 name,
             )
@@ -77,7 +77,7 @@ class ProjectEntity(TopLevelEntity):
                 SELECT name, data
                 FROM project_{project_name}.folder_types
                 ORDER BY position
-                {'FOR UPDATE' if for_update else ''}
+                {"FOR UPDATE" if for_update else ""}
                 """
             ):
                 folder_types.append({"name": name, **data})
@@ -89,7 +89,7 @@ class ProjectEntity(TopLevelEntity):
                 SELECT name, data
                 FROM project_{project_name}.task_types
                 ORDER BY position
-                {'FOR UPDATE' if for_update else ''}
+                {"FOR UPDATE" if for_update else ""}
                 """
             ):
                 task_types.append({"name": name, **data})
@@ -100,7 +100,7 @@ class ProjectEntity(TopLevelEntity):
                 f"""
                 SELECT name, link_type, input_type, output_type, data
                 FROM project_{project_name}.link_types
-                {'FOR UPDATE' if for_update else ''}
+                {"FOR UPDATE" if for_update else ""}
                 """
             ):
                 link_types.append(dict(row))
@@ -112,7 +112,7 @@ class ProjectEntity(TopLevelEntity):
                 SELECT name, data
                 FROM project_{project_name}.statuses
                 ORDER BY position
-                {'FOR UPDATE' if for_update else ''}
+                {"FOR UPDATE" if for_update else ""}
                 """
             ):
                 statuses.append({"name": name, **data})
@@ -124,7 +124,7 @@ class ProjectEntity(TopLevelEntity):
                 SELECT name, data
                 FROM project_{project_name}.tags
                 ORDER BY position
-                {'FOR UPDATE' if for_update else ''}
+                {"FOR UPDATE" if for_update else ""}
                 """
             ):
                 tags.append({"name": name, **data})

--- a/ayon_server/entities/user.py
+++ b/ayon_server/entities/user.py
@@ -89,7 +89,7 @@ class UserEntity(TopLevelEntity):
 
         query = f"""
             SELECT * FROM public.users WHERE name = $1
-            {'FOR UPDATE' if for_update else ''}
+            {"FOR UPDATE" if for_update else ""}
             """
 
         try:

--- a/ayon_server/entity_lists/entity_folder_path.py
+++ b/ayon_server/entity_lists/entity_folder_path.py
@@ -59,7 +59,7 @@ async def get_entity_folder_path(
         query = f"""
         SELECT folders.path as path
         FROM hierarchy as folders
-        {' '.join(joins)}
+        {" ".join(joins)}
         WHERE {entity_type}s.id = $1
         """
         res = await Postgres.fetchrow(query, entity_id)

--- a/ayon_server/forms/simple_form.py
+++ b/ayon_server/forms/simple_form.py
@@ -11,6 +11,7 @@ SimpleFormFieldType = Literal[
     "integer",
     "float",
     "label",
+    "file",
 ]
 
 SimpleFormHighlightType = Literal[

--- a/ayon_server/forms/simple_form.py
+++ b/ayon_server/forms/simple_form.py
@@ -33,6 +33,7 @@ class FormSelectOption(TypedDict):
 class FormFileData(TypedDict):
     filename: str
     payload: str  # base64 encoded
+    download: NotRequired[bool]
 
 
 ValueType = (
@@ -60,6 +61,7 @@ class SimpleFormField(TypedDict):
     highlight: NotRequired[SimpleFormHighlightType]
     min: NotRequired[int | float]
     max: NotRequired[int | float]
+    valid_extensions: NotRequired[list[str]]
 
 
 def normalize_options(
@@ -248,20 +250,38 @@ class SimpleForm(list[SimpleFormField]):
         label: str | None = None,
         value: bytes | None = None,
         filename: str | None = None,
+        valid_extensions: list[str] | None = None,
     ) -> "SimpleForm":
+        """Add file input / file download field to the form.
+
+        When `value` is provided, the field will be used to
+        download a file with the given filename.
+
+        When `value` is not provided, the field will be used to
+        upload a file. In this case, `valid_extensions` can be provided
+        to restrict the allowed file types.
+        """
+
         field: SimpleFormField = {
             "type": "file",
             "name": name,
         }
         if label is not None:
             field["label"] = label
+
         if value is not None:
             if not filename:
                 raise ValueError("Filename must be provided when value is set.")
             field["value"] = {
                 "payload": b64encode(value).decode("utf-8"),
                 "filename": filename,
+                "download": True,
             }
+
+        elif valid_extensions is not None:
+            # for file uploads, we can specify valid extensions
+            field["valid_extensions"] = valid_extensions
+
         self.append(field)
         return self
 

--- a/ayon_server/graphql/nodes/activity.py
+++ b/ayon_server/graphql/nodes/activity.py
@@ -204,9 +204,7 @@ def replace_reference_body(node: ActivityNode) -> ActivityNode:
         return node  # should not happen
 
     if node.reference_type == "mention":
-        node.body = (
-            f"mentioned in a {node.activity_type} " f"on {node.origin.markdownlink}"
-        )
+        node.body = f"mentioned in a {node.activity_type} on {node.origin.markdownlink}"
         return node
 
     if node.reference_type == "relation":

--- a/ayon_server/graphql/resolvers/activities.py
+++ b/ayon_server/graphql/resolvers/activities.py
@@ -157,8 +157,8 @@ async def get_activities(
             AND (
                 activity_data->>'category' IS NULL
                 OR activity_data->>'category' = ANY({
-                    SQLTool.array(accessible_categories, curly=True)
-                })
+                SQLTool.array(accessible_categories, curly=True)
+            })
             )
             """
         )
@@ -174,8 +174,8 @@ async def get_activities(
                 (
                     activity_data->>'category' IS NULL
                     OR activity_data->>'category' = ANY({
-                        SQLTool.array(accessible_categories, curly=True)
-                    })
+                    SQLTool.array(accessible_categories, curly=True)
+                })
                 )
                 """
             )

--- a/ayon_server/graphql/resolvers/events.py
+++ b/ayon_server/graphql/resolvers/events.py
@@ -109,7 +109,7 @@ async def get_events(
                 continue
 
             lconds.append(
-                f"""({' OR '.join([f"{col} LIKE '%{elm}%'" for col in search_cols])})"""
+                f"""({" OR ".join([f"{col} LIKE '%{elm}%'" for col in search_cols])})"""
             )
 
         if lconds:

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -273,7 +273,7 @@ async def get_folders(
             lconds.append(f"folders.parent_id IN {SQLTool.id_array(list(pids_set))}")
 
         if lconds:
-            sql_conditions.append(f"({ ' OR '.join(lconds) })")
+            sql_conditions.append(f"({' OR '.join(lconds)})")
 
     if folder_types is not None:
         if not folder_types:

--- a/ayon_server/graphql/resolvers/projects.py
+++ b/ayon_server/graphql/resolvers/projects.py
@@ -83,7 +83,7 @@ async def get_projects(
     #
 
     query = f"""
-        SELECT {', '.join(cols)}
+        SELECT {", ".join(cols)}
         FROM public.projects
         {SQLTool.conditions(sql_conditions)}
         {ordering}

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -206,9 +206,9 @@ async def get_representations(
     #
 
     query = f"""
-        SELECT {cursor}, {', '.join(sql_columns)}
+        SELECT {cursor}, {", ".join(sql_columns)}
         FROM project_{project_name}.representations
-        {' '.join(sql_joins)}
+        {" ".join(sql_joins)}
         {SQLTool.conditions(sql_conditions)}
         {ordering}
     """

--- a/ayon_server/graphql/resolvers/sorting.py
+++ b/ayon_server/graphql/resolvers/sorting.py
@@ -15,7 +15,7 @@ def get_task_types_sort_case(project: ProjectEntity) -> str:
     case = "CASE"
     for i, task_type_name in enumerate(task_type_names):
         case += f" WHEN tasks.task_type = '{task_type_name}' THEN {i}"
-    case += f" ELSE {i+1}"
+    case += f" ELSE {i + 1}"
     case += " END"
     return case
 
@@ -32,7 +32,7 @@ def get_folder_types_sort_case(project: ProjectEntity) -> str:
     case = "CASE"
     for i, folder_type_name in enumerate(folder_type_names):
         case += f" WHEN folders.folder_type = '{folder_type_name}' THEN {i}"
-    case += f" ELSE {i+1}"
+    case += f" ELSE {i + 1}"
     case += " END"
     return case
 
@@ -49,7 +49,7 @@ def get_status_sort_case(project: ProjectEntity, exp: str) -> str:
     case = "CASE"
     for i, status_name in enumerate(status_names):
         case += f" WHEN {exp} = '{status_name}' THEN {i}"
-    case += f" ELSE {i+1}"
+    case += f" ELSE {i + 1}"
     case += " END"
     return case
 
@@ -69,6 +69,6 @@ async def get_attrib_sort_case(attr: str, exp: str) -> str:
     for i, eval in enumerate(enum):
         e = eval["value"]
         case += f" WHEN {exp}->>'{attr}' = '{e}' THEN {i}"
-    case += f" ELSE {i+1}"
+    case += f" ELSE {i + 1}"
     case += " END"
     return case

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -423,7 +423,7 @@ async def get_versions(
                 ON ldv.id = versions.id
                 LEFT JOIN hero_versions AS hv
                 ON hv.id = versions.id
-                WHERE {' OR '.join(where_clauses)}
+                WHERE {" OR ".join(where_clauses)}
                 ORDER BY versions.product_id, {order_clause}
             )
             """

--- a/ayon_server/helpers/entity_links.py
+++ b/ayon_server/helpers/entity_links.py
@@ -50,7 +50,7 @@ async def remove_dead_links(project_name: str) -> None:
                 WHERE link_type = $1
                 AND NOT EXISTS (
                     SELECT 1
-                    FROM project_{project_name}.{link_type['input_type']}s t
+                    FROM project_{project_name}.{link_type["input_type"]}s t
                     WHERE t.id = links.input_id
                 )
                 RETURNING *
@@ -68,7 +68,7 @@ async def remove_dead_links(project_name: str) -> None:
                 WHERE link_type = $1
                 AND NOT EXISTS (
                     SELECT 1
-                    FROM project_{project_name}.{link_type['output_type']}s t
+                    FROM project_{project_name}.{link_type["output_type"]}s t
                     WHERE t.id = links.output_id
                 )
                 RETURNING *

--- a/ayon_server/helpers/preview.py
+++ b/ayon_server/helpers/preview.py
@@ -58,7 +58,7 @@ async def create_video_thumbnail(
                 cmd.extend(
                     [
                         "-filter:v",
-                        f"scale={size[0] or -1 }:{size[1] or -1}",
+                        f"scale={size[0] or -1}:{size[1] or -1}",
                     ]
                 )
 

--- a/ayon_server/lib/postgres.py
+++ b/ayon_server/lib/postgres.py
@@ -40,9 +40,9 @@ def get_pg_connection_info() -> DBConnectionInfo:
     host = result.hostname
     port = result.port or 5432
     database = result.path[1:]  # Remove the leading '/'
-    assert (
-        user and password and host and database and port
-    ), "Postgres connection string is not valid"
+    assert user and password and host and database and port, (
+        "Postgres connection string is not valid"
+    )
 
     return DBConnectionInfo(
         user=user,
@@ -232,27 +232,27 @@ class Postgres:
     ) -> "PreparedStatement":  # type: ignore[type-arg]
         """Prepare a statement"""
         async with cls.acquire() as connection:
-            assert (
-                connection.is_in_transaction()
-            ), "Cannot prepare statement outside of a transaction"
+            assert connection.is_in_transaction(), (
+                "Cannot prepare statement outside of a transaction"
+            )
             return await connection.prepare(query, *args, timeout=timeout)
 
     @classmethod
     async def set_project_schema(cls, project_name: str) -> None:
         """Set the search path to the project schema."""
         async with cls.acquire() as conn:
-            assert (
-                conn.is_in_transaction()
-            ), "Cannot set project schema outside of a transaction"
+            assert conn.is_in_transaction(), (
+                "Cannot set project schema outside of a transaction"
+            )
             await conn.execute(f"SET LOCAL search_path TO project_{project_name}")
 
     @classmethod
     async def set_public_schema(cls) -> None:
         """Set the search path to the public schema."""
         async with cls.acquire() as conn:
-            assert (
-                conn.is_in_transaction()
-            ), "Cannot set public schema outside of a transaction"
+            assert conn.is_in_transaction(), (
+                "Cannot set public schema outside of a transaction"
+            )
             await conn.execute("SET LOCAL search_path TO public")
 
     @classmethod

--- a/ayon_server/utils/sqltool.py
+++ b/ayon_server/utils/sqltool.py
@@ -94,9 +94,9 @@ class SQLTool:
         keys = list(kwargs.keys())
         command = f"""
             INSERT INTO {table}
-            ({', '.join(keys)})
+            ({", ".join(keys)})
             VALUES
-            ({ ', '.join([f'${i+1}' for i, _ in enumerate(keys)]) })
+            ({", ".join([f"${i + 1}" for i, _ in enumerate(keys)])})
             """
         result: list[Any] = [command]
         for key in keys:
@@ -124,7 +124,7 @@ class SQLTool:
         keys = list(kwargs.keys())
         command = f"""
             UPDATE {table}
-            SET {', '.join([f'{key} = ${i+1}' for i, key in enumerate(keys)])}
+            SET {", ".join([f"{key} = ${i + 1}" for i, key in enumerate(keys)])}
             {conditions}
             """
 

--- a/ayon_server/views/models.py
+++ b/ayon_server/views/models.py
@@ -11,7 +11,7 @@ from ayon_server.utils import create_uuid
 #
 
 ViewScopes = Literal["project", "studio"]
-ViewType = Literal["overview", "taskProgress", "lists", "reviews" "versions"] | str
+ViewType = Literal["overview", "taskProgress", "lists", "reviewsversions"] | str
 
 FViewScope = Annotated[
     ViewScopes,

--- a/cli/optimize_thumbnails/optimize_thumbnails.py
+++ b/cli/optimize_thumbnails/optimize_thumbnails.py
@@ -132,9 +132,7 @@ async def optimize_thumbnails(
     logger.info(f"Took {elapsed_time:.2f} seconds to optimize thumbnails")
 
     if vacuum:
-        logger.info(
-            "Vacuuming the database to reclaim space..." " This may take a while."
-        )
+        logger.info("Vacuuming the database to reclaim space... This may take a while.")
 
         start_time = time.monotonic()
         await Postgres.execute("VACUUM FULL")

--- a/demogen/__main__.py
+++ b/demogen/__main__.py
@@ -18,7 +18,7 @@ def create_color() -> str:
     color = [random.randint(0, 255) for _ in range(3)]
     if sum(color) < 400:
         color = [255 - x for x in color]
-    return f'#{"".join([f"{x:02x}" for x in color])}'
+    return f"#{''.join([f'{x:02x}' for x in color])}"
 
 
 def generate_tags() -> list[Tag]:

--- a/linker/query.py
+++ b/linker/query.py
@@ -96,7 +96,7 @@ async def query_entities(
             project_{project_name}.version_list l
             ON s.id = l.product_id
         {SQLTool.conditions(conditions)}
-        {'ORDER BY RANDOM()' if limit is not None else ''}
+        {"ORDER BY RANDOM()" if limit is not None else ""}
     """
 
     used: list[str] = []  # faster that trying to find out, how to distinct

--- a/maintenance/tasks/remove_old_action_configs.py
+++ b/maintenance/tasks/remove_old_action_configs.py
@@ -27,7 +27,7 @@ async def clear_action_configs_by_projects() -> None:
         AND last_used < EXTRACT(EPOCH FROM NOW()) - 60 * 60 * 24 * 30
     """
 
-    msg = f"Removing old action configs for projects: " f"{','.join(project_names)}"
+    msg = f"Removing old action configs for projects: {','.join(project_names)}"
 
     logger.info(msg)
     await Postgres.execute(query, list(project_names))
@@ -58,7 +58,7 @@ async def clear_action_configs_by_users() -> None:
         AND last_used < EXTRACT(EPOCH FROM NOW()) - 60 * 60 * 24 * 30
     """
 
-    msg = f"Removing old action configs for users: " f"{','.join(user_names)}"
+    msg = f"Removing old action configs for users: {','.join(user_names)}"
     logger.info(msg)
 
     await Postgres.execute(query, list(user_names))

--- a/maintenance/tasks/remove_unused_activities.py
+++ b/maintenance/tasks/remove_unused_activities.py
@@ -75,8 +75,7 @@ async def clear_activities(project_name: str) -> None:
 
         if count:
             logger.debug(
-                f"Deleted {count} orphaned "
-                f"{entity_type} activities from {project_name}"
+                f"Deleted {count} orphaned {entity_type} activities from {project_name}"
             )
 
 

--- a/setup/initial_bundle.py
+++ b/setup/initial_bundle.py
@@ -56,7 +56,7 @@ async def create_initial_bundle(bundle_data: dict[str, Any]):
         if addon_name and addon_version:
             log_name = f"{addon_name} {addon_version}"
         else:  # If name and version is not provided, use the index
-            log_name = f"{i+1} of {len(addons)}"
+            log_name = f"{i + 1} of {len(addons)}"
 
         if addon_url := addon.get("url"):
             # Do not use helpers.download_addon here, as we need


### PR DESCRIPTION
This pull request introduces a new `FormFile` class for handling file uploads in action contexts, including support for caching files in Redis. 

* Added the `FormFile` class in `ayon_server/actions/context.py` to encapsulate file upload data, provide methods for base64 encoding/decoding, and support caching files in Redis for later retrieval. This includes new methods in `ActionContext` for accessing and retrieving cached files. 

**Form system enhancements:**

* Added `"file"` as a supported field type in `ayon_server/forms/simple_form.py`, and imported `b64encode` to support file handling. 


## Example usage

See https://github.com/ynput/ayon-example-addon/blob/develop/server/actions/file_action.py example

## Requires

frontend pr https://github.com/ynput/ayon-frontend/pull/1758