### PR TITLE
Explicit product base types

### DIFF
--- a/ayon_server/entities/core/projectlevel.py
+++ b/ayon_server/entities/core/projectlevel.py
@@ -234,6 +234,7 @@ class ProjectLevelEntity(BaseEntity):
                         attrib[key] = value
 
             if self.exists:
+                await self.pre_save(False)
                 # Update existing entity
                 fields = dict_exclude(
                     self.dict(),
@@ -243,7 +244,6 @@ class ProjectLevelEntity(BaseEntity):
                 fields["updated_at"] = datetime.now()
                 fields["updated_by"] = kwargs.get("user_name", None)
 
-                await self.pre_save(False)
                 await Postgres.execute(
                     *SQLTool.update(
                         f"project_{self.project_name}.{self.entity_type}s",
@@ -253,6 +253,7 @@ class ProjectLevelEntity(BaseEntity):
                 )
 
             else:
+                await self.pre_save(True)
                 # Create a new entity
                 fields = dict_exclude(
                     self.dict(exclude_none=True),
@@ -262,7 +263,6 @@ class ProjectLevelEntity(BaseEntity):
                 fields["created_by"] = kwargs.get("user_name", None)
                 fields["updated_by"] = kwargs.get("user_name", None)
 
-                await self.pre_save(True)
                 await Postgres.execute(
                     *SQLTool.insert(
                         f"project_{self.project_name}.{self.entity_type}s",

--- a/ayon_server/entities/product.py
+++ b/ayon_server/entities/product.py
@@ -35,6 +35,10 @@ class ProductEntity(ProjectLevelEntity):
 
     async def pre_save(self, insert: bool) -> None:
         """Hook called before saving the entity to the database."""
+
+        if self.product_base_type is None:
+            self.product_base_type = self.product_type
+
         await Postgres.execute(
             """
             INSERT INTO public.product_types (name)

--- a/schemas/migrations/00000011.sql
+++ b/schemas/migrations/00000011.sql
@@ -1,0 +1,33 @@
+-----------------
+-- Ayon 1.14.0 --
+-----------------
+
+-- 
+-- 1. Ensure index exists on products(product_base_type)
+-- 2. Copy product_type value to product_base_type if product_base_type is null
+--
+
+
+DO $$
+DECLARE rec RECORD;
+BEGIN
+    FOR rec IN select distinct nspname from pg_namespace where nspname like 'project_%'
+    LOOP
+
+      BEGIN -- split into multiple transactions to avoid one failure blocking all schemas
+
+        EXECUTE 'SET LOCAL search_path TO ' || quote_ident(rec.nspname);
+
+        CREATE INDEX IF NOT EXISTS product_base_type_idx ON products(product_base_type);
+
+        UPDATE products SET product_base_type = product_type
+          WHERE product_base_type IS NULL;
+
+      EXCEPTION
+        WHEN OTHERS THEN 
+           RAISE WARNING 'Skipping product base types validation in % due to error: %', rec.nspname, SQLERRM;
+      END;
+
+    END LOOP;
+    RETURN;
+END $$;

--- a/schemas/migrations/00000011.sql
+++ b/schemas/migrations/00000011.sql
@@ -23,6 +23,14 @@ BEGIN
         UPDATE products SET product_base_type = product_type
           WHERE product_base_type IS NULL;
 
+
+        -- TODO. In 1.15.0, we will enable this constraint after ensuring all existing rows are populated.
+        -- We leave it commented out for now, to allow server downgrades from 1.14.x to 1.13.x without issues.
+
+        -- ALTER TABLE products
+        --   ALTER COLUMN product_base_type SET NOT NULL;
+
+
       EXCEPTION
         WHEN OTHERS THEN 
            RAISE WARNING 'Skipping product base types validation in % due to error: %', rec.nspname, SQLERRM;


### PR DESCRIPTION
This pull request introduces a database migration and a related code update to ensure that the `product_base_type` field in the `products` table is properly populated and indexed. The changes help maintain data consistency and prepare for future constraints.

**Database migration and data consistency:**

* Adds a migration (`00000011.sql`) that creates an index on the `product_base_type` column in the `products` table for each project schema, and copies the value from `product_type` to `product_base_type` where it is currently null. This ensures existing data is consistent and improves query performance.
* In the `pre_save` method of the `Product` entity, sets `product_base_type` to `product_type` if it is not already set, ensuring new records are consistent with the migration.

**Preparation for future constraints:**

* The migration includes a commented-out step to enforce `product_base_type` as NOT NULL in a future release, signaling an upcoming stricter data integrity requirement.