### PR TITLE
Table: Sorting of groups

### DIFF
--- a/ayon_server/views/models.py
+++ b/ayon_server/views/models.py
@@ -127,6 +127,7 @@ class OverviewSettings(OPModel):
     show_hierarchy: bool = True
     row_height: int | None = None
     group_by: str | None = None
+    group_sort_by_desc: bool = False
     show_empty_groups: bool = False
     sort_by: str | None = None
     sort_desc: bool = False
@@ -162,6 +163,7 @@ class VersionsSettings(OPModel):
     featured_version_order: list[str] | None = None
     slicer_type: str | None = None
     group_by: str | None = None
+    group_sort_by_desc: bool = False
     show_empty_groups: bool = False
     sort_by: str | None = None
     sort_desc: bool = False


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
 Add `group_sort_by_desc` option to `OverviewSettings` and `VersionsSettings` view models, allowing groups to be sorted in descending order.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

- Added `group_sort_by_desc: bool = False` to `OverviewSettings` and `VersionsSettings`
- Defaults to `False` (ascending), maintaining backward compatibility
- No migration needed as the field has a default value

### Additional context

<!-- Add any other context or screenshots here. -->

this issue is beckend support for frontend issue [#1706](https://github.com/ynput/ayon-frontend/issues/1706)
