### PR TITLE
Comments: Allow Admins and Managers to delete other users comments

### DIFF
--- a/api/activities/activity.py
+++ b/api/activities/activity.py
@@ -178,8 +178,7 @@ async def delete_project_activity(
     await delete_activity(
         project_name,
         activity_id,
-        user_name=user.name,
-        is_manager=user.is_manager,
+        user=user,
         sender=sender,
         sender_type=sender_type,
     )

--- a/api/operations/activities_operations.py
+++ b/api/operations/activities_operations.py
@@ -234,8 +234,7 @@ async def process_activity_operation(
             await delete_activity(
                 project_name,
                 operation.activity_id,
-                user_name=user.name,
-                is_manager=user.is_manager,
+                user=user,
                 sender=sender,
                 sender_type=sender_type,
             )


### PR DESCRIPTION

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Allow admins and managers to delete comments (activities) created by other users. Previously, only admins and the comment author could delete a comment. Now managers have the same privilege.
### Technical details

<!-- Please state any technical details such as limitations -->

 - Added `is_manager` parameter to `delete_activity()` in `ayon_server/activities/delete_activity.py`
  - Updated the authorization check from `if user_name and not is_admin` to `if user_name and not is_admin and not is_manager`, so managers bypass the author ownership check
  - Passed `user.is_manager` from the API endpoint in `api/activities/activity.py` to the `delete_activity` call
  - Updated the endpoint docstring to reflect the new behavior

<!-- reasons for additional dependencies, benchmarks etc. here. -->

### Additional context

<!-- Add any other context or screenshots here. -->
Resolves [#1822](https://github.com/ynput/ayon-frontend/issues/1822)
Frontend PR: [#1833](https://github.com/ynput/ayon-frontend/pull/1833)