### PR TITLE
Add data and product base type to permission model

### DIFF
--- a/ayon_server/access/permissions.py
+++ b/ayon_server/access/permissions.py
@@ -30,7 +30,9 @@ def _top_level_fields_enum() -> list[dict[str, str]]:
         {"value": "folder_id", "label": "Move task"},
         {"value": "task_type", "label": "Change task type"},
         {"value": "assignees", "label": "Change task assignees"},
+        {"value": "product_base_type", "label": "Change product base type"},
         {"value": "product_type", "label": "Change product type"},
+        {"value": "data", "label": "Change additional data"},
     ]
 
 


### PR DESCRIPTION
This pull request makes a small update to the permissions system by adding new top-level fields that can be used for permission checks. These fields expand the granularity of permissions related to products and their associated data.

- Permissions:
  * Added `product_base_type` and `data` as new options in the `_top_level_fields_enum` function in `ayon_server/access/permissions.py`, allowing permissions to be set for changing a product's base type and additional data.

<img width="1051" height="265" alt="image" src="https://github.com/user-attachments/assets/749517f7-cf6d-473a-b4b8-6a8de7bda42f" />
