### PR TITLE
Fixed event update permission check for non-manager users

### DIFF
--- a/api/events/events.py
+++ b/api/events/events.py
@@ -166,7 +166,7 @@ async def update_existing_event(
                 raise ForbiddenException("Not allowed to update status of this event")
 
     if not user.is_manager:
-        if event_user == user.name:
+        if event_user != user.name:
             raise ForbiddenException("Not allowed to update this event")
         if payload.user and payload.user != user.name:
             raise ForbiddenException("Not allowed to change user of this event")


### PR DESCRIPTION
## PR Checklist
- [x] This comment contains a description of changes
- [x] Referenced issue is linked

## Description of changes
Fixes wrong permission check in `PATCH /events/{event_id}` for non-manager users.
Changed condition so users can update their own event, while still preventing updates to others' events.

Fixes #774

### Technical details
In `api/events/events.py`, changed:
`if event_user == user.name: raise ForbiddenException(...)`
to:
`if event_user != user.name: raise ForbiddenException(...)`

### Additional context
This matches the behavior described in issue #774.
