### PR TITLE
Support for strawberry 0.306.0

### DIFF
--- a/ayon_server/entities/core/base.py
+++ b/ayon_server/entities/core/base.py
@@ -130,8 +130,8 @@ class BaseEntity:
 
     @classmethod
     def strawberry_attrib(cls):
-        fields = list(cls.model.attrib_model.__fields__.keys())
-        return pydantic_type(model=cls.model.attrib_model, fields=fields)
+        # fields = list(cls.model.attrib_model.__fields__.keys())
+        return pydantic_type(model=cls.model.attrib_model, all_fields=True)
 
     #
     # DB

--- a/ayon_server/graphql/edges.py
+++ b/ayon_server/graphql/edges.py
@@ -1,106 +1,91 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 import strawberry
-from strawberry import LazyType
 
 from ayon_server.graphql.types import BaseEdge
 
 if TYPE_CHECKING:
-    from ayon_server.graphql.nodes.activity import ActivityNode
-    from ayon_server.graphql.nodes.entity_list import EntityListNode
-    from ayon_server.graphql.nodes.event import EventNode
-    from ayon_server.graphql.nodes.folder import FolderNode
-    from ayon_server.graphql.nodes.kanban import KanbanNode
-    from ayon_server.graphql.nodes.product import ProductNode
-    from ayon_server.graphql.nodes.project import ProjectNode
-    from ayon_server.graphql.nodes.representation import RepresentationNode
-    from ayon_server.graphql.nodes.task import TaskNode
-    from ayon_server.graphql.nodes.user import UserNode
-    from ayon_server.graphql.nodes.version import VersionNode
-    from ayon_server.graphql.nodes.workfile import WorkfileNode
-else:
-    ActivityNode = LazyType["ActivityNode", ".nodes.activity"]
-    BaseNode = LazyType["BaseNode", ".nodes.common"]
-    EntityListNode = LazyType["EntityListNode", ".nodes.entity_list"]
-    EventNode = LazyType["EventNode", ".nodes.event"]
-    FolderNode = LazyType["FolderNode", ".nodes.folder"]
-    KanbanNode = LazyType["KanbanNode", ".nodes.kanban"]
-    ProductNode = LazyType["ProductNode", ".nodes.product"]
-    ProjectNode = LazyType["ProjectNode", ".nodes.project"]
-    RepresentationNode = LazyType["RepresentationNode", ".nodes.representation"]
-    TaskNode = LazyType["TaskNode", ".nodes.task"]
-    UserNode = LazyType["UserNode", ".nodes.user"]
-    VersionNode = LazyType["VersionNode", ".nodes.version"]
-    WorkfileNode = LazyType["WorkfileNode", ".nodes.workfile"]
+    from .nodes.activity import ActivityNode
+    from .nodes.entity_list import EntityListNode
+    from .nodes.event import EventNode
+    from .nodes.folder import FolderNode
+    from .nodes.kanban import KanbanNode
+    from .nodes.product import ProductNode
+    from .nodes.project import ProjectNode
+    from .nodes.representation import RepresentationNode
+    from .nodes.task import TaskNode
+    from .nodes.user import UserNode
+    from .nodes.version import VersionNode
+    from .nodes.workfile import WorkfileNode
 
 
 @strawberry.type
 class ProjectEdge(BaseEdge):
-    node: ProjectNode = strawberry.field(description="The project node")
+    node: Annotated["ProjectNode", strawberry.lazy(".nodes.project")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class UserEdge(BaseEdge):
-    node: UserNode = strawberry.field(description="The user node")
+    node: Annotated["UserNode", strawberry.lazy(".nodes.user")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class FolderEdge(BaseEdge):
-    node: FolderNode = strawberry.field(description="The folder node")
+    node: Annotated["FolderNode", strawberry.lazy(".nodes.folder")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class TaskEdge(BaseEdge):
-    node: TaskNode = strawberry.field(description="The task node")
+    node: Annotated["TaskNode", strawberry.lazy(".nodes.task")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class ProductEdge(BaseEdge):
-    node: ProductNode = strawberry.field(description="Product node")
+    node: Annotated["ProductNode", strawberry.lazy(".nodes.product")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class VersionEdge(BaseEdge):
-    node: VersionNode = strawberry.field(description="Version node")
+    node: Annotated["VersionNode", strawberry.lazy(".nodes.version")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class RepresentationEdge(BaseEdge):
-    node: RepresentationNode = strawberry.field(description="Representation node")
+    node: Annotated["RepresentationNode", strawberry.lazy(".nodes.representation")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class WorkfileEdge(BaseEdge):
-    node: WorkfileNode = strawberry.field(description="Workfile node")
+    node: Annotated["WorkfileNode", strawberry.lazy(".nodes.workfile")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class EventEdge(BaseEdge):
-    node: EventNode = strawberry.field(description="Event node")
+    node: Annotated["EventNode", strawberry.lazy(".nodes.event")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class ActivityEdge(BaseEdge):
-    node: ActivityNode = strawberry.field(description="The activity node")
+    node: Annotated["ActivityNode", strawberry.lazy(".nodes.activity")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class KanbanEdge(BaseEdge):
-    node: KanbanNode = strawberry.field(description="The kanban node")
+    node: Annotated["KanbanNode", strawberry.lazy(".nodes.kanban")]
     cursor: str | None = strawberry.field(default=None)
 
 
 @strawberry.type
 class EntityListEdge(BaseEdge):
-    node: EntityListNode = strawberry.field(description="The entity list node")
+    node: Annotated["EntityListNode", strawberry.lazy(".nodes.entity_list")]
     cursor: str | None = strawberry.field(default=None)

--- a/ayon_server/graphql/nodes/activity.py
+++ b/ayon_server/graphql/nodes/activity.py
@@ -1,8 +1,7 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
-from strawberry import LazyType
 
 from ayon_server.activities.activity_categories import ActivityCategories
 from ayon_server.exceptions import ForbiddenException
@@ -13,8 +12,8 @@ if TYPE_CHECKING:
     from ayon_server.graphql.nodes.user import UserNode
     from ayon_server.graphql.nodes.version import VersionNode
 else:
-    UserNode = LazyType["UserNode", ".user"]
-    VersionNode = LazyType["VersionNode", ".version"]
+    UserNode = Annotated["UserNode", strawberry.lazy(".user")]
+    VersionNode = Annotated["VersionNode", strawberry.lazy(".version")]
 
 
 @strawberry.type
@@ -160,7 +159,7 @@ class ActivityNode:
         return None
 
     @strawberry.field
-    async def version(self, info: Info) -> Optional["VersionNode"]:
+    async def version(self, info: Info) -> VersionNode | None:
         if self.activity_type not in ["version.publish", "reviewable"]:
             return None
 

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
-from strawberry import LazyType
 
 from ayon_server.entities import FolderEntity
 from ayon_server.graphql.nodes.common import BaseNode, ThumbnailInfo
@@ -13,8 +12,10 @@ from ayon_server.utils import json_dumps
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import ProductsConnection, TasksConnection
 else:
-    ProductsConnection = LazyType["ProductsConnection", "..connections"]
-    TasksConnection = LazyType["TasksConnection", "..connections"]
+    ProductsConnection = Annotated[
+        "ProductsConnection", strawberry.lazy("..connections")
+    ]
+    TasksConnection = Annotated["TasksConnection", strawberry.lazy("..connections")]
 
 
 @FolderEntity.strawberry_attrib()
@@ -82,7 +83,7 @@ class FolderNode(BaseNode):
         return path.split("/")[:-1] if path else []
 
     @strawberry.field
-    async def parent(self, info: Info) -> Optional["FolderNode"]:
+    async def parent(self, info: Info) -> "FolderNode | None":
         if not self.parent_id:
             return None
         record = await info.context["folder_loader"].load(

--- a/ayon_server/graphql/nodes/product.py
+++ b/ayon_server/graphql/nodes/product.py
@@ -1,8 +1,7 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
-from strawberry import LazyType
 
 from ayon_server.entities import ProductEntity
 from ayon_server.graphql.nodes.common import BaseNode
@@ -15,9 +14,11 @@ if TYPE_CHECKING:
     from ayon_server.graphql.nodes.folder import FolderNode
     from ayon_server.graphql.nodes.version import VersionNode
 else:
-    FolderNode = LazyType["FolderNode", ".folder"]
-    VersionNode = LazyType["VersionNode", ".version"]
-    VersionsConnection = LazyType["VersionsConnection", "..connections"]
+    VersionsConnection = Annotated[
+        "VersionsConnection", strawberry.lazy("..connections")
+    ]
+    FolderNode = Annotated["FolderNode", strawberry.lazy(".folder")]
+    VersionNode = Annotated["VersionNode", strawberry.lazy(".version")]
 
 
 @strawberry.type

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -1,8 +1,7 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
-from strawberry import LazyType
 
 from ayon_server.entities import ProjectEntity
 from ayon_server.entities.user import UserEntity
@@ -29,7 +28,7 @@ from ayon_server.settings.anatomy.product_base_types import (
 from ayon_server.utils import json_dumps
 
 if TYPE_CHECKING:
-    from ayon_server.graphql.connections import (
+    from ..connections import (
         EntityListsConnection,
         FoldersConnection,
         ProductsConnection,
@@ -38,29 +37,42 @@ if TYPE_CHECKING:
         VersionsConnection,
         WorkfilesConnection,
     )
-    from ayon_server.graphql.nodes.entity_list import EntityListNode
-    from ayon_server.graphql.nodes.folder import FolderNode
-    from ayon_server.graphql.nodes.product import ProductNode
-    from ayon_server.graphql.nodes.representation import RepresentationNode
-    from ayon_server.graphql.nodes.task import TaskNode
-    from ayon_server.graphql.nodes.version import VersionNode
-    from ayon_server.graphql.nodes.workfile import WorkfileNode
-else:
-    EntityListConnection = LazyType["EntityListConnection", "..connections"]
-    FoldersConnection = LazyType["FoldersConnection", "..connections"]
-    RepresentationsConnection = LazyType["RepresentationsConnection", "..connections"]
-    ProductsConnection = LazyType["ProductsConnection", "..connections"]
-    TasksConnection = LazyType["TasksConnection", "..connections"]
-    VersionsConnection = LazyType["VersionsConnection", "..connections"]
-    WorkfilesConnection = LazyType["WorkfilesConnection", "..connections"]
+    from .entity_list import EntityListNode
+    from .folder import FolderNode
+    from .product import ProductNode
+    from .representation import RepresentationNode
+    from .task import TaskNode
+    from .version import VersionNode
+    from .workfile import WorkfileNode
 
-    EntityListNode = LazyType["EntityListNode", ".entity_list"]
-    FolderNode = LazyType["FolderNode", ".folder"]
-    RepresentationNode = LazyType["RepresentationNode", ".representation"]
-    ProductNode = LazyType["ProductNode", ".product"]
-    TaskNode = LazyType["TaskNode", ".task"]
-    VersionNode = LazyType["VersionNode", ".version"]
-    WorkfileNode = LazyType["WorkfileNode", ".workfile"]
+else:
+    EntityListNode = Annotated["EntityListNode", strawberry.lazy(".entity_list")]
+    FolderNode = Annotated["FolderNode", strawberry.lazy(".folder")]
+    RepresentationNode = Annotated[
+        "RepresentationNode", strawberry.lazy(".representation")
+    ]
+    ProductNode = Annotated["ProductNode", strawberry.lazy(".product")]
+    TaskNode = Annotated["TaskNode", strawberry.lazy(".task")]
+    VersionNode = Annotated["VersionNode", strawberry.lazy(".version")]
+    WorkfileNode = Annotated["WorkfileNode", strawberry.lazy(".workfile")]
+
+    EntityListConnection = Annotated[
+        "EntityListsConnection", strawberry.lazy("..connections")
+    ]
+    FoldersConnection = Annotated["FoldersConnection", strawberry.lazy("..connections")]
+    ProductsConnection = Annotated[
+        "ProductsConnection", strawberry.lazy("..connections")
+    ]
+    RepresentationsConnection = Annotated[
+        "RepresentationsConnection", strawberry.lazy("..connections")
+    ]
+    TasksConnection = Annotated["TasksConnection", strawberry.lazy("..connections")]
+    VersionsConnection = Annotated[
+        "VersionsConnection", strawberry.lazy("..connections")
+    ]
+    WorkfilesConnection = Annotated[
+        "WorkfilesConnection", strawberry.lazy("..connections")
+    ]
 
 
 @strawberry.type

--- a/ayon_server/graphql/nodes/representation.py
+++ b/ayon_server/graphql/nodes/representation.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
-from strawberry import LazyType
 
 from ayon_server.entities import RepresentationEntity
 from ayon_server.graphql.nodes.common import BaseNode
@@ -11,7 +10,7 @@ from ayon_server.utils import get_base_name, json_dumps
 if TYPE_CHECKING:
     from ayon_server.graphql.nodes.version import VersionNode
 else:
-    VersionNode = LazyType["VersionNode", ".version"]
+    VersionNode = Annotated["VersionNode", strawberry.lazy(".version")]
 
 
 @strawberry.type

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -1,8 +1,7 @@
 import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
-from strawberry import LazyType
 
 from ayon_server.entities import TaskEntity
 from ayon_server.graphql.nodes.common import BaseNode, ThumbnailInfo
@@ -13,12 +12,16 @@ from ayon_server.logging import logger
 from ayon_server.utils import json_dumps
 
 if TYPE_CHECKING:
-    from ayon_server.graphql.connections import VersionsConnection, WorkfilesConnection
-    from ayon_server.graphql.nodes.folder import FolderNode
+    from ..connections import VersionsConnection, WorkfilesConnection
+    from .folder import FolderNode
 else:
-    FolderNode = LazyType["FolderNode", ".folder"]
-    VersionsConnection = LazyType["VersionsConnection", "..connections"]
-    WorkfilesConnection = LazyType["WorkfilesConnection", "..connections"]
+    FolderNode = Annotated["FolderNode", strawberry.lazy(".folder")]
+    VersionsConnection = Annotated[
+        "VersionsConnection", strawberry.lazy("..connections")
+    ]
+    WorkfilesConnection = Annotated[
+        "WorkfilesConnection", strawberry.lazy("..connections")
+    ]
 
 
 @TaskEntity.strawberry_attrib()
@@ -66,12 +69,12 @@ class TaskNode(BaseNode):
 
     # GraphQL specifics
 
-    versions: "VersionsConnection" = strawberry.field(
+    versions: VersionsConnection = strawberry.field(
         resolver=get_versions,
         description=get_versions.__doc__,
     )
 
-    workfiles: "WorkfilesConnection" = strawberry.field(
+    workfiles: WorkfilesConnection = strawberry.field(
         resolver=get_workfiles,
         description=get_workfiles.__doc__,
     )

--- a/ayon_server/graphql/nodes/user.py
+++ b/ayon_server/graphql/nodes/user.py
@@ -1,8 +1,7 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
-from strawberry import LazyType
 
 from ayon_server.entities import UserEntity
 from ayon_server.graphql.resolvers.tasks import get_tasks
@@ -13,7 +12,7 @@ from ayon_server.utils import json_dumps
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import TasksConnection
 else:
-    TasksConnection = LazyType["TasksConnection", "..connections"]
+    TasksConnection = Annotated["TasksConnection", strawberry.lazy("..connections")]
 
 
 @UserEntity.strawberry_attrib()
@@ -70,7 +69,7 @@ class UserNode:
         )
 
     @strawberry.field
-    async def tasks(self, info: Info, project_name: str) -> "TasksConnection":
+    async def tasks(self, info: Info, project_name: str) -> TasksConnection:
         root = FakeRoot(project_name)
         return await get_tasks(root, info, assignees=[self.name])
 

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -1,8 +1,8 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
-from strawberry import LazyType
 
+# from strawberry import LazyType
 from ayon_server.entities import VersionEntity
 from ayon_server.graphql.nodes.common import BaseNode, ThumbnailInfo
 from ayon_server.graphql.resolvers.representations import get_representations
@@ -14,9 +14,12 @@ if TYPE_CHECKING:
     from ayon_server.graphql.nodes.product import ProductNode
     from ayon_server.graphql.nodes.task import TaskNode
 else:
-    RepresentationsConnection = LazyType["RepresentationsConnection", "..connections"]
-    ProductNode = LazyType["ProductNode", ".product"]
-    TaskNode = LazyType["TaskNode", ".task"]
+    RepresentationsConnection = Annotated[
+        "RepresentationsConnection",
+        strawberry.lazy("..connections"),
+    ]
+    ProductNode = Annotated["ProductNode", strawberry.lazy(".product")]
+    TaskNode = Annotated["TaskNode", strawberry.lazy(".task")]
 
 
 @VersionEntity.strawberry_attrib()
@@ -47,7 +50,7 @@ class VersionNode(BaseNode):
 
     # GraphQL specifics
 
-    representations: "RepresentationsConnection" = strawberry.field(
+    representations: RepresentationsConnection = strawberry.field(
         resolver=get_representations,
         description=get_representations.__doc__,
     )

--- a/ayon_server/graphql/nodes/workfile.py
+++ b/ayon_server/graphql/nodes/workfile.py
@@ -1,7 +1,6 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
-from strawberry import LazyType
 
 from ayon_server.entities import WorkfileEntity
 from ayon_server.graphql.nodes.common import BaseNode, ThumbnailInfo
@@ -11,7 +10,7 @@ from ayon_server.utils import json_dumps
 if TYPE_CHECKING:
     from ayon_server.graphql.nodes.task import TaskNode
 else:
-    TaskNode = LazyType["TaskNode", ".task"]
+    TaskNode = Annotated["TaskNode", strawberry.lazy(".task")]
 
 
 @WorkfileEntity.strawberry_attrib()


### PR DESCRIPTION
This pull request modernizes and simplifies the type hinting and lazy import patterns used throughout the GraphQL schema codebase. The main change is the replacement of the deprecated `LazyType` with Python's `Annotated` and `strawberry.lazy` for forward references and lazy loading of GraphQL types. Additionally, some minor improvements to type annotations and field declarations were made for clarity and consistency.
