### PR TITLE
Validate addon versions in bundles requests

### DIFF
--- a/api/bundles/models.py
+++ b/api/bundles/models.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from pydantic import validator
 
+from ayon_server.logging import logger
 from ayon_server.types import NAME_REGEX, SEMVER_REGEX, Field, OPModel, Platform
 from ayon_server.utils import camelize
 
@@ -66,12 +67,16 @@ class BundleModel(BaseBundleModel):
             if version is None:
                 continue
             if version.lower() == "none":
+                value[addon_name] = None
+                continue
+            if version in ["__inherit__", "__disable__"]:
                 continue
             if not re.match(SEMVER_REGEX, version):
-                raise ValueError(
+                logger.warning(
                     f"Version '{version}' for addon '{addon_name}'"
                     f"is not a valid semantic version."
                 )
+        return value
 
     installer_version: str | None = Field(None, example="1.2.3")
     dependency_packages: dict[Platform, str | None] = Field(
@@ -109,12 +114,16 @@ class BundlePatchModel(BaseBundleModel):
             if version is None:
                 continue
             if version.lower() == "none":
+                value[addon_name] = None
+                continue
+            if version in ["__inherit__", "__disable__"]:
                 continue
             if not re.match(SEMVER_REGEX, version):
                 raise ValueError(
                     f"Version '{version}' for addon '{addon_name}'"
                     f"is not a valid semantic version."
                 )
+        return value
 
     installer_version: str | None = Field(None, example="1.2.3")
     dependency_packages: dict[Platform, str | None] | None = Field(

--- a/api/bundles/models.py
+++ b/api/bundles/models.py
@@ -1,7 +1,10 @@
+import re
 from datetime import datetime
 from typing import Any
 
-from ayon_server.types import NAME_REGEX, Field, OPModel, Platform
+from pydantic import validator
+
+from ayon_server.types import NAME_REGEX, SEMVER_REGEX, Field, OPModel, Platform
 from ayon_server.utils import camelize
 
 dependency_packages_meta: dict[str, Any] = {
@@ -54,6 +57,22 @@ class BundleModel(BaseBundleModel):
         title="Addons",
         example={"ftrack": "1.2.3"},
     )
+
+    @validator("addons")
+    def validate_addons(
+        cls, value: dict[str, str | None]
+    ) -> dict[str, str | None] | None:
+        for addon_name, version in value.items():
+            if version is None:
+                continue
+            if version.lower() == "none":
+                continue
+            if not re.match(SEMVER_REGEX, version):
+                raise ValueError(
+                    f"Version '{version}' for addon '{addon_name}'"
+                    f"is not a valid semantic version."
+                )
+
     installer_version: str | None = Field(None, example="1.2.3")
     dependency_packages: dict[Platform, str | None] = Field(
         default_factory=dict,
@@ -79,6 +98,24 @@ class BundlePatchModel(BaseBundleModel):
         title="Addons",
         example={"ftrack": None, "kitsu": "1.2.3"},
     )
+
+    @validator("addons")
+    def validate_addons(
+        cls, value: dict[str, str | None] | None
+    ) -> dict[str, str | None] | None:
+        if value is None:
+            return value
+        for addon_name, version in value.items():
+            if version is None:
+                continue
+            if version.lower() == "none":
+                continue
+            if not re.match(SEMVER_REGEX, version):
+                raise ValueError(
+                    f"Version '{version}' for addon '{addon_name}'"
+                    f"is not a valid semantic version."
+                )
+
     installer_version: str | None = Field(None, example="1.2.3")
     dependency_packages: dict[Platform, str | None] | None = Field(
         None,

--- a/ayon_server/bundles/project_bundles.py
+++ b/ayon_server/bundles/project_bundles.py
@@ -300,7 +300,7 @@ async def unfreeze_project_bundle(
             if not addon_version:
                 continue
 
-            if addon_version in ("__inherit__", "__disabled__"):
+            if addon_version in ("__inherit__", "__disable__"):
                 continue
 
             try:


### PR DESCRIPTION
This pull request adds validation logic to ensure that addon versions specified in the `BundleModel` and `BundlePatchModel` classes conform to semantic versioning. It introduces new validators that check each addon's version string and raise an error if it does not match the expected format.

As a temporary fix for the issue in the frontend, validator also handles '"none"' string value as actual 'null'