### PR TITLE
Expose `data` for the LinkEdge GraphQL response

### DIFF
--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any, Optional
 
 import strawberry
+from strawberry.scalars import JSON
 
 from ayon_server.entities import UserEntity
 from ayon_server.exceptions import AyonException
@@ -36,6 +37,7 @@ class LinkEdge(BaseEdge):
     description: str = strawberry.field(default="")
     author: str | None = strawberry.field(default=None)
     cursor: str | None = strawberry.field(default=None)
+    data: JSON | None = strawberry.field(default=None)
 
     @strawberry.field(description="Linked node")
     async def node(self, info: Info) -> Optional["BaseNode"]:

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -37,7 +37,7 @@ class LinkEdge(BaseEdge):
     description: str = strawberry.field(default="")
     author: str | None = strawberry.field(default=None)
     cursor: str | None = strawberry.field(default=None)
-    data: JSON | None = strawberry.field(default=None)
+    data: JSON = strawberry.field(default_factory=dict)
 
     @strawberry.field(description="Linked node")
     async def node(self, info: Info) -> Optional["BaseNode"]:

--- a/ayon_server/graphql/resolvers/links.py
+++ b/ayon_server/graphql/resolvers/links.py
@@ -92,6 +92,7 @@ async def get_links(
                 cursor=link_id,
                 description=description,
                 author=row["author"],
+                data=row["data"] or None,
             )
         )
 

--- a/ayon_server/graphql/resolvers/links.py
+++ b/ayon_server/graphql/resolvers/links.py
@@ -92,7 +92,7 @@ async def get_links(
                 cursor=link_id,
                 description=description,
                 author=row["author"],
-                data=row["data"] or None,
+                data=row["data"],
             )
         )
 


### PR DESCRIPTION
## Description of changes

Expose the `data` field to GraphQL for LinkEdge.

So that e.g.

```graphql
query GetProjectLinksData {
  project(name: "projectname") {
    folders {
      edges {
        node {
          links {
            edges {
              data
              name
            }
          }
        }
      }
    }
  }
}
```

Also provides back the `data` that was stored with the links.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

### Additional context

<!-- Add any other context or screenshots here. -->
