### PR TITLE
Use studio logo in emails

### DIFF
--- a/api/users/password_reset.py
+++ b/api/users/password_reset.py
@@ -63,7 +63,11 @@ async def password_reset_request(payload: PasswordResetRequestModel, request: Re
     }
 
     template = EmailTemplate()
-    body = await template.render_template("password_reset.jinja", tplvars)
+    body = await template.render_template(
+        "password_reset.jinja",
+        tplvars,
+        base_url=server_url,
+    )
     subject = "Ayon password reset request"
 
     await user.save()

--- a/ayon_server/auth/tokenauth.py
+++ b/ayon_server/auth/tokenauth.py
@@ -67,7 +67,7 @@ async def send_invite_email(
         ctx.update(context)
 
     template = EmailTemplate()
-    body = await template.render(body_template, ctx)
+    body = await template.render(body_template, base_url=base_url, context=ctx)
     subject = subject or "Invitation to Ayon instance"
 
     logger.debug(f"Sending guest invite to {email}: redirect to {redirect_url}")
@@ -100,7 +100,11 @@ async def send_extend_email(payload: TokenPayload, base_url: str) -> None:
     }
 
     template = EmailTemplate()
-    body = await template.render_template("token_renew.jinja", ctx)
+    body = await template.render_template(
+        "token_renew.jinja",
+        ctx,
+        base_url=base_url,
+    )
     subject = payload.subject or "Ayon access link renewal"
     logger.debug(
         f"Sending guest exted email to {payload.email}: "

--- a/ayon_server/helpers/email.py
+++ b/ayon_server/helpers/email.py
@@ -12,6 +12,7 @@ import jinja2
 from pydantic import BaseModel, Field
 
 from ayon_server.config import ayonconfig
+from ayon_server.config.serverconfig import get_server_config
 from ayon_server.exceptions import AyonException
 from ayon_server.helpers.cloud import CloudUtils
 from ayon_server.logging import log_traceback, logger
@@ -185,16 +186,53 @@ async def send_mail(
         await send_api_email(recipient_list, subject, text, html)
 
 
+async def get_studio_logo_url(base_url: str | None) -> str:
+    file_name = ""
+    if base_url:
+        config = await get_server_config()
+        customization = config.customization
+        file_name = customization.studio_logo
+    if not file_name:
+        return "https://static.ynput.team/AYON_whiteG_dot.png"
+    return f"{base_url}/static/customization/{file_name}"
+
+
 class EmailTemplate:
     def __init__(self) -> None:
         # TODO: async rendering
         self.env = jinja2.Environment(loader=jinja2.FileSystemLoader("static/email"))
 
-    async def render(self, template: str, context: dict[str, Any]) -> str:
+    async def render(
+        self,
+        template: str,
+        context: dict[str, Any] | None = None,
+        base_url: str | None = None,
+    ) -> str:
+        if context is None:
+            context = {}
         # Render the template string
         template_obj = self.env.from_string(template)
-        return template_obj.render(context)
 
-    async def render_template(self, template_name: str, context: dict[str, Any]) -> str:
+        full_context = {
+            "base_url": base_url,
+            "studio_logo_url": await get_studio_logo_url(base_url),
+            **context,
+        }
+
+        return template_obj.render(full_context)
+
+    async def render_template(
+        self,
+        template_name: str,
+        context: dict[str, Any] | None = None,
+        base_url: str | None = None,
+    ) -> str:
+        if context is None:
+            context = {}
         template = self.env.get_template(template_name)
-        return template.render(context)
+        full_context = {
+            "base_url": base_url,
+            "studio_logo_url": await get_studio_logo_url(base_url),
+            **context,
+        }
+        return template.render(full_context)

--- a/static/email/base.jinja
+++ b/static/email/base.jinja
@@ -29,8 +29,8 @@
                 style="background-color:#1C2026; height:104px; padding:17px 0;"
               >
                 <img
-                  src="https://static.ynput.team/AYON_whiteG_dot.png"
-                  alt="AYON Logo"
+                  src="{{ studio_logo_url }}"
+                  alt="Studio logo"
                   style="height:70px;"
                 />
               </td>


### PR DESCRIPTION
This pull request introduces improvements to email template rendering, allowing for dynamic customization of the studio logo and base URL in outgoing emails. The changes ensure that emails sent from the application can display a studio-specific logo if configured, otherwise falling back to a default image. Additionally, the email rendering functions are updated to consistently pass context variables, including the base URL and logo, to templates.
