### PR TITLE
Activities access control

### DIFF
--- a/api/activities/activity.py
+++ b/api/activities/activity.py
@@ -145,7 +145,7 @@ async def post_project_activity(
         body=activity.body,
         tags=activity.tags,
         files=activity.files,
-        user_name=user.name,
+        user=user,
         timestamp=activity.timestamp,
         sender=sender,
         sender_type=sender_type,

--- a/api/operations/activities_operations.py
+++ b/api/operations/activities_operations.py
@@ -177,7 +177,7 @@ async def process_activity_operation(
                 activity_type=activity.activity_type,
                 body=activity.body,
                 files=activity.files,
-                user_name=user.name,
+                user=user,
                 timestamp=activity.timestamp,
                 sender=sender,
                 sender_type=sender_type,

--- a/ayon_server/access/permissions.py
+++ b/ayon_server/access/permissions.py
@@ -36,6 +36,13 @@ def _top_level_fields_enum() -> list[dict[str, str]]:
     ]
 
 
+def _activities_permissions_enum() -> list[dict[str, str]]:
+    return [
+        {"value": "comment", "label": "Comment"},
+        {"value": "reviewable", "label": "Upload reviewables"},
+    ]
+
+
 @aiocache.cached(ttl=300)
 async def _attr_enum():
     return [
@@ -146,6 +153,15 @@ class ActionsAccessList(BasePermissionsModel):
     actions: list[str] = SettingsField(
         default_factory=list,
         enum_resolver=_actions_enum,
+    )
+
+
+class ActivitiesAccessList(BasePermissionsModel):
+    activities: list[str] = SettingsField(
+        title=" ",
+        default_factory=list,
+        enum_resolver=_activities_permissions_enum,
+        widget="switchbox",
     )
 
 
@@ -281,6 +297,12 @@ class Permissions(BaseSettingsModel):
         default_factory=AttributeWriteAccessList,
         title="Restrict attribute update",
         description="Whitelist attributes a user can write",
+    )
+
+    activities: ActivitiesAccessList = SettingsField(
+        default_factory=ActivitiesAccessList,
+        title="Restrict activities",
+        description="Whitelist activities a user can perform",
     )
 
     actions: ActionsAccessList = SettingsField(

--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -29,7 +29,11 @@ from ayon_server.entities import UserEntity
 from ayon_server.entities.core import ProjectLevelEntity
 from ayon_server.entities.project import ProjectEntity
 from ayon_server.events.eventstream import EventStream
-from ayon_server.exceptions import BadRequestException, NotFoundException
+from ayon_server.exceptions import (
+    BadRequestException,
+    ForbiddenException,
+    NotFoundException,
+)
 from ayon_server.helpers.hierarchy_cache import rebuild_hierarchy_cache
 from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import logger
@@ -44,7 +48,8 @@ async def create_activity(
     tags: list[str] | None = None,
     files: list[str] | None = None,
     activity_id: str | None = None,
-    user_name: str | None = None,
+    user: UserEntity | None = None,
+    user_name: str | None = None,  # deprecated, use user instead
     extra_references: list[ActivityReferenceModel] | None = None,
     data: dict[str, Any] | None = None,
     timestamp: datetime.datetime | None = None,
@@ -58,6 +63,30 @@ async def create_activity(
     They are autopopulated based on the activity body and the current
     user if not provided.
     """
+
+    if (
+        user is None
+        and user_name is not None
+        and activity_type in ["comment", "reviewable"]  # we need acl for these
+    ):
+        user = await UserEntity.load(user_name)
+
+    if user_name is None and user is not None:
+        user_name = user.name
+
+    if (
+        user is not None
+        and activity_type in ["comment", "reviewable"]
+        and not user.is_manager
+    ):
+        # Check if the user can create enity activities for the given entity
+
+        perms = user.permissions(project_name=entity.project_name)
+        if perms.activities.enabled:
+            if activity_type not in perms.activities.activities:
+                raise ForbiddenException(
+                    f"You don't have permission to create {activity_type}"
+                )
 
     if timestamp is None:
         timestamp = datetime.datetime.now(datetime.UTC)

--- a/ayon_server/activities/models.py
+++ b/ayon_server/activities/models.py
@@ -14,6 +14,7 @@ ActivityType = Literal[
     "version.publish",
 ]
 
+
 ActivityReferenceType = Literal[
     "origin",
     "mention",


### PR DESCRIPTION
This pull request introduces a permissions system for controlling which activity types users can perform, specifically focusing on "comment" and "reviewable" activities. It adds new permission fields, enforces access control checks, and updates function signatures to use user objects instead of usernames for better consistency and authorization.

<img width="1097" height="212" alt="image" src="https://github.com/user-attachments/assets/697c565c-15bb-46aa-a999-417907a967be" />


This only provides the backend support and permission checks. Additional frontend implementation should be done to hide the comment editor and upload widget based on the user permissions