### PR TITLE
Strict validation of entity list ids

### DIFF
--- a/api/entity_lists/entity_list_attributes.py
+++ b/api/entity_lists/entity_list_attributes.py
@@ -12,16 +12,16 @@ class EntityListAttributeDefinition(AttributeNameModel):
     data: AttributeData
 
 
-@router.get("/lists/{list_id}/attributes", response_model_exclude_unset=True)
+@router.get("/lists/{entity_list_id}/attributes", response_model_exclude_unset=True)
 async def get_entity_list_attributes_definition(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
+    entity_list_id: str,
 ) -> list[EntityListAttributeDefinition]:
     """Return a list of custom attributes for the entity list."""
 
     query = f"SELECT data FROM project_{project_name}.entity_lists WHERE id = $1"
-    res = await Postgres.fetchrow(query, list_id)
+    res = await Postgres.fetchrow(query, entity_list_id)
     if not res:
         raise NotFoundException("Entity list not found")
     adata = res["data"].get("attributes", [])
@@ -35,18 +35,20 @@ async def get_entity_list_attributes_definition(
         try:
             attr_definition = EntityListAttributeDefinition(**attr_definition)
         except Exception:
-            logger.warning(f"Invalid attribute definition for entity list {list_id}")
+            logger.warning(
+                f"Invalid attribute definition for entity list {entity_list_id}"
+            )
             continue
         result.append(attr_definition)
 
     return result
 
 
-@router.put("/lists/{list_id}/attributes")
+@router.put("/lists/{entity_list_id}/attributes")
 async def set_entity_list_attributes_definition(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
+    entity_list_id: str,
     payload: list[EntityListAttributeDefinition],
 ) -> None:
     """Set the custom attributes for the entity list."""
@@ -65,11 +67,11 @@ async def set_entity_list_attributes_definition(
         validate_attribute_data(attr_definition.name, attr_definition.data)
         payload_list.append(attr_definition.dict(exclude_unset=True, exclude_none=True))
 
-    logger.debug(f"Setting attributes for entity list {list_id}: {payload_list}")
+    logger.debug(f"Setting attributes for entity list {entity_list_id}: {payload_list}")
 
     query = f"""
         UPDATE project_{project_name}.entity_lists
         SET data = jsonb_set(data, '{{attributes}}', $1)
         WHERE id = $2
     """
-    await Postgres.execute(query, payload_list, list_id)
+    await Postgres.execute(query, payload_list, entity_list_id)

--- a/api/entity_lists/entity_list_entities.py
+++ b/api/entity_lists/entity_list_entities.py
@@ -13,11 +13,11 @@ class EntityListEnities(OPModel):
     entity_ids: Annotated[list[str], Field(title="Entity IDs")]
 
 
-@router.get("/lists/{list_id}/entities")
+@router.get("/lists/{entity_list_id}/entities")
 async def get_list_entities(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
+    entity_list_id: str,
 ) -> EntityListEnities:
     """Get the entities of a list."""
 
@@ -35,13 +35,13 @@ async def get_list_entities(
     entity_type: ProjectLevelEntityType | None = None
     entity_ids: set[str] = set()
 
-    async for row in Postgres.iterate(query, list_id):
+    async for row in Postgres.iterate(query, entity_list_id):
         entity_type = row["entity_type"]
         entity_ids.add(row["entity_id"])
 
     if entity_type is None:
         raise NotFoundException(
-            f"Entity list ID '{list_id}' not found",
+            f"Entity list ID '{entity_list_id}' not found",
         )
 
     return EntityListEnities(

--- a/api/entity_lists/entity_list_items.py
+++ b/api/entity_lists/entity_list_items.py
@@ -1,5 +1,7 @@
 from ayon_server.api.dependencies import (
     CurrentUser,
+    EntityListID,
+    EntityListItemID,
     ProjectName,
     Sender,
     SenderType,
@@ -17,17 +19,17 @@ from ayon_server.lib.postgres import Postgres
 from .router import router
 
 
-@router.post("/lists/{list_id}/items", status_code=201)
+@router.post("/lists/{entity_list_id}/items", status_code=201)
 async def create_entity_list_item(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
+    entity_list_id: EntityListID,
     sender: Sender,
     sender_type: SenderType,
     payload: EntityListItemPostModel,
 ) -> None:
     async with Postgres.transaction():
-        entity_list = await EntityList.load(project_name, list_id, user=user)
+        entity_list = await EntityList.load(project_name, entity_list_id, user=user)
         await entity_list.ensure_can_update()
 
         await entity_list.add(
@@ -42,20 +44,20 @@ async def create_entity_list_item(
         await entity_list.save(sender=sender, sender_type=sender_type)
 
 
-@router.patch("/lists/{list_id}/items/{list_item_id}")
+@router.patch("/lists/{entity_list_id}/items/{entity_list_item_id}")
 async def update_entity_list_item(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
-    list_item_id: str,
+    entity_list_id: EntityListID,
+    entity_list_item_id: EntityListItemID,
     sender: Sender,
     sender_type: SenderType,
     payload: EntityListItemPatchModel,
 ) -> None:
     async with Postgres.transaction():
-        entity_list = await EntityList.load(project_name, list_id, user=user)
+        entity_list = await EntityList.load(project_name, entity_list_id, user=user)
         await entity_list.ensure_can_update()
-        item = entity_list.item_by_id(list_item_id)
+        item = entity_list.item_by_id(entity_list_item_id)
 
         payload_dict = payload.dict(exclude_unset=True)
         await entity_list.update(
@@ -66,19 +68,19 @@ async def update_entity_list_item(
         await entity_list.save(sender=sender, sender_type=sender_type)
 
 
-@router.delete("/lists/{list_id}/items/{list_item_id}")
+@router.delete("/lists/{entity_list_id}/items/{entity_list_item_id}")
 async def delete_entity_list_item(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
-    list_item_id: str,
+    entity_list_id: EntityListID,
+    entity_list_item_id: EntityListItemID,
     sender: Sender,
     sender_type: SenderType,
 ) -> None:
     async with Postgres.transaction():
-        entity_list = await EntityList.load(project_name, list_id, user=user)
+        entity_list = await EntityList.load(project_name, entity_list_id, user=user)
         await entity_list.ensure_can_update()
-        await entity_list.remove(list_item_id)
+        await entity_list.remove(entity_list_item_id)
         await entity_list.save(sender=sender, sender_type=sender_type)
 
 

--- a/api/entity_lists/entity_lists.py
+++ b/api/entity_lists/entity_lists.py
@@ -5,6 +5,7 @@ from fastapi import Query
 from ayon_server.api.dependencies import (
     AllowGuests,
     CurrentUser,
+    EntityListID,
     ProjectName,
     Sender,
     SenderType,
@@ -78,11 +79,11 @@ async def create_entity_list(
         return await entity_list.save(sender=sender, sender_type=sender_type)
 
 
-@router.patch("/lists/{list_id}")
+@router.patch("/lists/{entity_list_id}")
 async def update_entity_list(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
+    entity_list_id: EntityListID,
     payload: EntityListPatchModel,
     sender: Sender,
     sender_type: SenderType,
@@ -90,7 +91,7 @@ async def update_entity_list(
     """Update entity list metadata"""
 
     async with Postgres.transaction():
-        entity_list = await EntityList.load(project_name, list_id, user=user)
+        entity_list = await EntityList.load(project_name, entity_list_id, user=user)
         await entity_list.ensure_can_admin()
 
         payload_dict = payload.dict(exclude_unset=True)
@@ -113,11 +114,11 @@ def dict_keep_keys(d: dict[str, Any], *keys: str) -> dict[str, Any]:
     return {k: v for k, v in d.items() if k in keys}
 
 
-@router.get("/lists/{list_id}", dependencies=[AllowGuests])
+@router.get("/lists/{entity_list_id}", dependencies=[AllowGuests])
 async def get_entity_list(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
+    entity_list_id: EntityListID,
     metadata_only: bool = Query(False, description="When true, only return metadata"),
 ) -> EntityListModel:
     """Get entity list
@@ -134,7 +135,7 @@ async def get_entity_list(
 
     entity_list = await EntityList.load(
         project_name,
-        list_id,
+        entity_list_id,
         user=user,
         with_items=not metadata_only,
     )
@@ -164,36 +165,36 @@ async def get_entity_list(
     return payload
 
 
-@router.delete("/lists/{list_id}")
+@router.delete("/lists/{entity_list_id}")
 async def delete_entity_list(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
+    entity_list_id: EntityListID,
     sender: Sender,
     sender_type: SenderType,
 ) -> EmptyResponse:
     """Delete entity list from the database"""
 
     async with Postgres.transaction():
-        entity_list = await EntityList.load(project_name, list_id, user=user)
+        entity_list = await EntityList.load(project_name, entity_list_id, user=user)
         await entity_list.ensure_can_admin()
         await entity_list.delete(sender=sender, sender_type=sender_type)
 
     return EmptyResponse()
 
 
-@router.post("/lists/{list_id}/materialize")
+@router.post("/lists/{entity_list_id}/materialize")
 async def materialize_entity_list(
     user: CurrentUser,
     project_name: ProjectName,
-    list_id: str,
+    entity_list_id: EntityListID,
     sender: Sender,
     sender_type: SenderType,
 ) -> EntityListSummary:
     """Materialize an entity list."""
 
     async with Postgres.transaction():
-        entity_list = await EntityList.load(project_name, list_id, user=user)
+        entity_list = await EntityList.load(project_name, entity_list_id, user=user)
         await entity_list.ensure_can_admin()
         await entity_list.materialize()
         return await entity_list.save(sender=sender, sender_type=sender_type)

--- a/ayon_server/api/dependencies.py
+++ b/ayon_server/api/dependencies.py
@@ -432,6 +432,26 @@ async def dep_activity_id(
 ActivityID = Annotated[str, Depends(dep_activity_id)]
 
 
+async def dep_entity_list_id(
+    entity_list_id: str = Path(..., title="Entity list ID", **EntityID.META),
+) -> str:
+    """Validate and return an entity list id specified in an endpoint path."""
+    return entity_list_id
+
+
+EntityListID = Annotated[str, Depends(dep_entity_list_id)]
+
+
+async def dep_entity_list_item_id(
+    entity_list_item_id: str = Path(..., title="Entity list item ID", **EntityID.META),
+) -> str:
+    """Validate and return an entity list item id specified in an endpoint path."""
+    return entity_list_item_id
+
+
+EntityListItemID = Annotated[str, Depends(dep_entity_list_item_id)]
+
+
 async def dep_file_id(
     file_id: str = Path(..., title="File ID", **EntityID.META),
 ) -> str:


### PR DESCRIPTION
This pull request refactors the API endpoints for entity lists to use more descriptive and validated path parameter names, replacing `list_id` and `list_item_id` with `entity_list_id` and `entity_list_item_id`. It also introduces new dependency classes for these IDs to ensure proper validation and typing throughout the codebase. The changes enhance clarity, consistency, and maintainability of the API.