### PR TITLE
Track original bundle state in bundle.updated event

### DIFF
--- a/api/bundles/bundles.py
+++ b/api/bundles/bundles.py
@@ -288,6 +288,10 @@ async def update_bundle(
             is_archived=row["is_archived"],
         )
 
+        was_production = bundle.is_production
+        was_staging = bundle.is_staging
+        was_archived = bundle.is_archived
+
         if patch.is_archived and (bundle.is_production or bundle.is_staging):
             raise BadRequestException(
                 "Cannot archive bundle that is production or staging"
@@ -432,21 +436,26 @@ async def update_bundle(
     if patch.is_production is not None or patch.is_staging is not None or patch.addons:
         await AddonLibrary.clear_addon_list_cache()
 
+    summary = {
+        "name": bundle_name,
+        "changedFields": patch.get_changed_fields(),
+        "isProduction": bundle.is_production,
+        "isStaging": bundle.is_staging,
+        "isArchived": bundle.is_archived,
+        "isDev": bundle.is_dev,
+        "isProject": bundle.is_project,
+        "wasProduction": was_production,
+        "wasStaging": was_staging,
+        "wasArchived": was_archived,
+    }
+
     await EventStream.dispatch(
         "bundle.updated",
         sender=sender,
         sender_type=sender_type,
         user=user.name,
         description=patch.get_changes_description(bundle_name),
-        summary={
-            "name": bundle_name,
-            "changedFields": patch.get_changed_fields(),
-            "isProduction": bundle.is_production,
-            "isStaging": bundle.is_staging,
-            "isArchived": bundle.is_archived,
-            "isDev": bundle.is_dev,
-            "isProject": bundle.is_project,
-        },
+        summary=summary,
         payload=data,
     )
 


### PR DESCRIPTION
This pull request refactors the event dispatch logic in the `update_bundle` function to provide more detailed information about bundle state changes. It introduces tracking of previous bundle states and ensures that these are included in the event summary, improving traceability for updates.

Enhancements to event dispatch and bundle state tracking:

* Added previous state of the bundle (`wasProduction`, `wasStaging`, `wasArchived`) to the event summary

<img width="648" height="539" alt="image" src="https://github.com/user-attachments/assets/4f721515-4fcb-4731-b6ff-6d9857bc63c1" />
