### PR TITLE
Add isEmpty flag to project folders

### DIFF
--- a/api/project_folders/project_folders.py
+++ b/api/project_folders/project_folders.py
@@ -60,6 +60,12 @@ class ProjectFolderModel(OPModel):
     label: Annotated[str, FFolderLabel]
     parent_id: Annotated[str | None, FFolderParentID] = None
     position: Annotated[int, Field(title="Folder position", ge=0)] = 0
+    is_empty: Annotated[
+        bool,
+        Field(
+            title="Whether the folder (or any of its subfolders) contains any projects",
+        ),
+    ] = False
     data: Annotated[ProjectFolderData, FFolderData]
 
 
@@ -76,10 +82,49 @@ class ProjectFoldersResponseModel(OPModel):
 async def get_project_folders(user: CurrentUser) -> ProjectFoldersResponseModel:
     result = []
     async with Postgres.transaction():
+        query = """
+            SELECT distinct(data->>'projectFolder')
+            FROM projects WHERE data ? 'projectFolder'
+        """
+        stmt = await Postgres.prepare(query)
+        project_folder_ids = set()
+        async for row in stmt.cursor():
+            if row[0] is not None:
+                project_folder_ids.add(row[0])
+
         query = "SELECT * FROM project_folders ORDER BY parent_id, position, label"
         stmt = await Postgres.prepare(query)
         async for row in stmt.cursor():
             result.append(ProjectFolderModel(**row))
+
+        # Mark folders that contain projects
+        # This is done in Python instead of SQL for simplicity,
+        # as the number of folders is expected to be small
+        #
+        # A folder is considered empty if it doesn't contain any projects directly
+        # or in any of its subfolders.
+        # Folder that contains subfolders is considered empty only if
+        # all of its subfolders are also empty.
+
+        folder_with_projects = set()
+
+        def crawl_folder(parent_id: str | None) -> bool:
+            res = False
+            for folder in result:
+                if folder.parent_id != parent_id:
+                    continue
+                if folder.id in project_folder_ids:
+                    folder_with_projects.add(folder.id)
+                    res = True
+                if crawl_folder(folder.id):
+                    folder_with_projects.add(folder.id)
+                    res = True
+            return res
+
+        crawl_folder(None)
+
+        for folder in result:
+            folder.is_empty = folder.id not in folder_with_projects
 
     return ProjectFoldersResponseModel(folders=result)
 


### PR DESCRIPTION
This pull request introduces an enhancement to the project folders API by adding the ability to determine whether a folder (or any of its subfolders) contains projects. The main change is the addition of an `is_empty` field to the `ProjectFolderModel`, along with logic to compute this value for each folder.

Enhancement to project folder metadata:

* Added an `is_empty` boolean field to the `ProjectFolderModel` to indicate whether the folder (or any of its subfolders) contains any projects.

Logic for computing folder emptiness:

* Implemented a Python-based recursive crawl in `get_project_folders` to mark folders as empty if they and all their subfolders contain no projects, using a set of folder IDs derived from the projects table.