### PR TITLE
Chore: Fix missing space in version not a valid semantic version log message

### DIFF
--- a/api/bundles/models.py
+++ b/api/bundles/models.py
@@ -74,7 +74,7 @@ class BundleModel(BaseBundleModel):
             if not re.match(SEMVER_REGEX, version):
                 logger.warning(
                     f"Version '{version}' for addon '{addon_name}'"
-                    f"is not a valid semantic version."
+                    " is not a valid semantic version."
                 )
         return value
 
@@ -121,7 +121,7 @@ class BundlePatchModel(BaseBundleModel):
             if not re.match(SEMVER_REGEX, version):
                 raise ValueError(
                     f"Version '{version}' for addon '{addon_name}'"
-                    f"is not a valid semantic version."
+                    " is not a valid semantic version."
                 )
         return value
 


### PR DESCRIPTION
## Description of changes

Fix missing space in log message

### Technical details

Fixes:
- `Version 'ayon_2603171458_windows.zip' for addon 'windows'is not a valid semantic version.`
- `Version 'ayon_2603171458_windows.zip' for addon 'windows' is not a valid semantic version.`

### Additional context

