### PR TITLE
Better addon imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__
+ayon_server.egg-info/
 
 .pytest_cache
 .mypy_cache

--- a/ayon_server/helpers/modules.py
+++ b/ayon_server/helpers/modules.py
@@ -39,7 +39,14 @@ def import_module(name: str, path: str) -> ModuleType:
     try:
         spec = importlib.util.spec_from_file_location(name, path)
         if spec is None or spec.loader is None:
-            raise ImportError(f"Could not load spec for {name}")
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            # Remove partially initialized module to avoid leaving a broken
+            # module object in sys.modules if exec_module fails.
+            if sys.modules.get(name) is module:
+                del sys.modules[name]
+            raise
 
         module = importlib.util.module_from_spec(spec)
 

--- a/ayon_server/helpers/modules.py
+++ b/ayon_server/helpers/modules.py
@@ -11,42 +11,24 @@ T = TypeVar("T", bound=type)
 def import_module(name: str, path: str) -> ModuleType:
     """
     Imports a plugin module into a unique namespace to prevent collisions.
-
-    The ``name`` argument is an arbitrary unique identifier used as the
-    module's namespace (i.e. the key in ``sys.modules``). It does not have
-    to be a valid dotted Python package path and may contain characters
-    like ``-`` or ``/``.
-
-    Examples:
-        - ``f"{vname}-package"`` (e.g. ``"my-addon-package"``)
-        - ``"ayon_server/enum/resolvers"``
+    Example: 'my_plugin.v1_0_0.server'
     """
 
-    server_dir = os.path.dirname(os.path.abspath(path))  # Directory containing the module
-    # Determine which directory should be added to sys.path:
-    # - If the module is inside a 'server' package, add its parent (the 'version' folder)
-    #   so that 'server' is importable as a top-level package.
-    # - Otherwise, add the module's own directory to avoid inserting overly broad paths.
+    server_dir = os.path.dirname(os.path.abspath(path))
     if os.path.basename(server_dir) == "server":
         base_dir = os.path.dirname(server_dir)
     else:
         base_dir = server_dir
 
-    # Add the dir containing the module (or its parent, for 'server' packages) to sys.path temporarily.
+    # Add the dir containing the module (or its parent, for 'server' packages)
+    # to sys.path temporarily.
     # This allows: 'from server.subfolder import module' in addons when appropriate.
     sys.path.insert(0, base_dir)
 
     try:
         spec = importlib.util.spec_from_file_location(name, path)
         if spec is None or spec.loader is None:
-        try:
-            spec.loader.exec_module(module)
-        except Exception:
-            # Remove partially initialized module to avoid leaving a broken
-            # module object in sys.modules if exec_module fails.
-            if sys.modules.get(name) is module:
-                del sys.modules[name]
-            raise
+            raise ImportError(f"Could not load spec for {name}")
 
         module = importlib.util.module_from_spec(spec)
 

--- a/ayon_server/helpers/modules.py
+++ b/ayon_server/helpers/modules.py
@@ -14,11 +14,18 @@ def import_module(name: str, path: str) -> ModuleType:
     Example: 'my_plugin.v1_0_0.server'
     """
 
-    server_dir = os.path.dirname(os.path.abspath(path))  # The 'server' folder
-    base_dir = os.path.dirname(server_dir)  # The 'version' folder
+    server_dir = os.path.dirname(os.path.abspath(path))  # Directory containing the module
+    # Determine which directory should be added to sys.path:
+    # - If the module is inside a 'server' package, add its parent (the 'version' folder)
+    #   so that 'server' is importable as a top-level package.
+    # - Otherwise, add the module's own directory to avoid inserting overly broad paths.
+    if os.path.basename(server_dir) == "server":
+        base_dir = os.path.dirname(server_dir)
+    else:
+        base_dir = server_dir
 
-    # Add the dir containing the module to sys.path temporarily.
-    # This allows: 'from server.subfolder import module' in addons
+    # Add the dir containing the module (or its parent, for 'server' packages) to sys.path temporarily.
+    # This allows: 'from server.subfolder import module' in addons when appropriate.
     sys.path.insert(0, base_dir)
 
     try:

--- a/ayon_server/helpers/modules.py
+++ b/ayon_server/helpers/modules.py
@@ -8,18 +8,6 @@ from typing import TypeVar
 T = TypeVar("T", bound=type)
 
 
-# def import_module(name: str, path: str) -> ModuleType:
-#     if (spec := importlib.util.spec_from_file_location(name, path)) is None:
-#         raise ModuleNotFoundError(f"Module {name} not found")
-#     if (module := importlib.util.module_from_spec(spec)) is None:
-#         raise ImportError(f"Module {name} cannot be imported")
-#     if spec.loader is None:
-#         raise ImportError(f"Module {name} cannot be imported. No loader found.")
-#     sys.modules[spec.name] = module
-#     spec.loader.exec_module(module)
-#     return module
-
-
 def import_module(name: str, path: str) -> ModuleType:
     """
     Imports a plugin module into a unique namespace to prevent collisions.

--- a/ayon_server/helpers/modules.py
+++ b/ayon_server/helpers/modules.py
@@ -1,5 +1,6 @@
 import importlib.util
 import inspect
+import os
 import sys
 from types import ModuleType
 from typing import TypeVar
@@ -7,16 +8,50 @@ from typing import TypeVar
 T = TypeVar("T", bound=type)
 
 
+# def import_module(name: str, path: str) -> ModuleType:
+#     if (spec := importlib.util.spec_from_file_location(name, path)) is None:
+#         raise ModuleNotFoundError(f"Module {name} not found")
+#     if (module := importlib.util.module_from_spec(spec)) is None:
+#         raise ImportError(f"Module {name} cannot be imported")
+#     if spec.loader is None:
+#         raise ImportError(f"Module {name} cannot be imported. No loader found.")
+#     sys.modules[spec.name] = module
+#     spec.loader.exec_module(module)
+#     return module
+
+
 def import_module(name: str, path: str) -> ModuleType:
-    if (spec := importlib.util.spec_from_file_location(name, path)) is None:
-        raise ModuleNotFoundError(f"Module {name} not found")
-    if (module := importlib.util.module_from_spec(spec)) is None:
-        raise ImportError(f"Module {name} cannot be imported")
-    if spec.loader is None:
-        raise ImportError(f"Module {name} cannot be imported. No loader found.")
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+    """
+    Imports a plugin module into a unique namespace to prevent collisions.
+    Example: 'my_plugin.v1_0_0.server'
+    """
+
+    server_dir = os.path.dirname(os.path.abspath(path))  # The 'server' folder
+    base_dir = os.path.dirname(server_dir)  # The 'version' folder
+
+    # Add the dir containing the module to sys.path temporarily.
+    # This allows: 'from server.subfolder import module' in addons
+    sys.path.insert(0, base_dir)
+
+    try:
+        spec = importlib.util.spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not load spec for {name}")
+
+        module = importlib.util.module_from_spec(spec)
+
+        # tell the module it belongs to our unique namespace
+        # Even if the file is physically in 'server/main.py'
+        sys.modules[name] = module
+
+        spec.loader.exec_module(module)
+        return module
+
+    finally:
+        # Clean up sys.path immediately so the next addon doesn't
+        # accidentally see this plugin's 'server' folder.
+        if base_dir in sys.path:
+            sys.path.remove(base_dir)
 
 
 def classes_from_module(superclass: T, module: ModuleType) -> list[T]:

--- a/ayon_server/helpers/modules.py
+++ b/ayon_server/helpers/modules.py
@@ -11,7 +11,15 @@ T = TypeVar("T", bound=type)
 def import_module(name: str, path: str) -> ModuleType:
     """
     Imports a plugin module into a unique namespace to prevent collisions.
-    Example: 'my_plugin.v1_0_0.server'
+
+    The ``name`` argument is an arbitrary unique identifier used as the
+    module's namespace (i.e. the key in ``sys.modules``). It does not have
+    to be a valid dotted Python package path and may contain characters
+    like ``-`` or ``/``.
+
+    Examples:
+        - ``f"{vname}-package"`` (e.g. ``"my-addon-package"``)
+        - ``"ayon_server/enum/resolvers"``
     """
 
     server_dir = os.path.dirname(os.path.abspath(path))  # Directory containing the module


### PR DESCRIPTION
This pull request refactors the `import_module` function in `ayon_server/helpers/modules.py` to improve how addon modules are imported and isolated, preventing namespace collisions and ensuring safer dynamic imports. The function now temporarily modifies `sys.path` to support relative imports within plugins, assigns modules to a unique namespace, and ensures cleanup after import.