### PR TITLE
Request context

### DIFF
--- a/api/activities/activity.py
+++ b/api/activities/activity.py
@@ -19,8 +19,6 @@ from ayon_server.api.dependencies import (
     PathEntityID,
     PathProjectLevelEntityType,
     ProjectName,
-    Sender,
-    SenderType,
 )
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.entities import ProjectEntity
@@ -71,8 +69,6 @@ async def post_project_activity(
     user: CurrentUser,
     activity: ProjectActivityPostModel,
     background_tasks: BackgroundTasks,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> CreateActivityResponseModel:
     """Create an activity.
 
@@ -147,8 +143,6 @@ async def post_project_activity(
         files=activity.files,
         user=user,
         timestamp=activity.timestamp,
-        sender=sender,
-        sender_type=sender_type,
         data=activity.data,
         bump_entity_updated_at=True,
     )
@@ -167,8 +161,6 @@ async def delete_project_activity(
     activity_id: ActivityID,
     user: CurrentUser,
     background_tasks: BackgroundTasks,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Delete an activity.
 
@@ -180,8 +172,6 @@ async def delete_project_activity(
         activity_id,
         user_name=user.name,
         is_admin=user.is_admin,
-        sender=sender,
-        sender_type=sender_type,
     )
 
     background_tasks.add_task(delete_unused_files, project_name)
@@ -220,8 +210,6 @@ async def patch_project_activity(
     user: CurrentUser,
     activity: ActivityPatchModel,
     background_tasks: BackgroundTasks,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Edit an activity.
 
@@ -243,8 +231,6 @@ async def patch_project_activity(
         append_files=activity.append_files,
         data=activity.data,
         user_name=user_name,
-        sender=sender,
-        sender_type=sender_type,
         is_admin=user.is_admin,
     )
 

--- a/api/activities/reactions.py
+++ b/api/activities/reactions.py
@@ -9,8 +9,6 @@ from ayon_server.api.dependencies import (
     AllowGuests,
     CurrentUser,
     ProjectName,
-    Sender,
-    SenderType,
 )
 from ayon_server.entities import UserEntity
 from ayon_server.events.eventstream import EventStream
@@ -27,9 +25,6 @@ async def modify_reactions(
     user: UserEntity,
     reaction: str,
     action: Literal["add", "remove"],
-    *,
-    sender: str | None = None,
-    sender_type: str | None = None,
 ):
     """
 
@@ -121,8 +116,6 @@ async def modify_reactions(
         summary=summary,
         store=False,
         user=user.name,
-        sender=sender,
-        sender_type=sender_type,
     )
 
 
@@ -145,8 +138,6 @@ async def create_reaction_to_activity(
     project_name: ProjectName,
     activity_id: ActivityID,
     request: CreateReactionModel,
-    sender: Sender,
-    sender_type: SenderType,
 ):
     if user.is_guest:
         await ensure_guest_can_react(user, project_name, activity_id)
@@ -157,8 +148,6 @@ async def create_reaction_to_activity(
         user,
         request.reaction,
         "add",
-        sender=sender,
-        sender_type=sender_type,
     )
 
 
@@ -171,8 +160,6 @@ async def delete_reaction_to_activity(
     user: CurrentUser,
     project_name: ProjectName,
     activity_id: ActivityID,
-    sender: Sender,
-    sender_type: SenderType,
     reaction: str = Path(
         ...,
         description="The reaction to be deleted",
@@ -186,6 +173,4 @@ async def delete_reaction_to_activity(
         user,
         reaction,
         "remove",
-        sender=sender,
-        sender_type=sender_type,
     )

--- a/api/activities/watchers.py
+++ b/api/activities/watchers.py
@@ -1,3 +1,5 @@
+from typing import Annotated
+
 from ayon_server.activities.watchers.set_watchers import set_watchers
 from ayon_server.activities.watchers.watcher_list import get_watcher_list
 from ayon_server.api.dependencies import (
@@ -6,8 +8,6 @@ from ayon_server.api.dependencies import (
     PathEntityID,
     PathProjectLevelEntityType,
     ProjectName,
-    Sender,
-    SenderType,
 )
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.exceptions import ForbiddenException
@@ -18,7 +18,7 @@ from .router import router
 
 
 class WatchersModel(OPModel):
-    watchers: list[str] = Field(..., example=["user1", "user2"])
+    watchers: Annotated[list[str], Field(example=["user1", "user2"])]
 
 
 @router.get("/{entity_type}/{entity_id}/watchers", dependencies=[AllowGuests])
@@ -53,8 +53,6 @@ async def set_entity_watchers(
     entity_id: PathEntityID,
     user: CurrentUser,
     watchers: WatchersModel,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     if user.is_guest:
         # Guests cannot modify watchers
@@ -64,12 +62,6 @@ async def set_entity_watchers(
     entity = await entity_class.load(project_name, entity_id)
     await entity.ensure_update_access(user)
 
-    await set_watchers(
-        entity,
-        watchers.watchers,
-        user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    await set_watchers(entity, watchers.watchers, user)
 
     return EmptyResponse()

--- a/api/bundles/bundles.py
+++ b/api/bundles/bundles.py
@@ -3,7 +3,7 @@ from typing import Any, Literal
 from fastapi import Query
 
 from ayon_server.addons import AddonLibrary
-from ayon_server.api.dependencies import AllowGuests, CurrentUser, Sender, SenderType
+from ayon_server.api.dependencies import AllowGuests, CurrentUser
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.entities import UserEntity
 from ayon_server.events import EventStream
@@ -100,8 +100,6 @@ async def _create_new_bundle(
     bundle: BundleModel,
     *,
     user: UserEntity | None = None,
-    sender: str | None = None,
-    sender_type: str | None = None,
 ):
     assert await Postgres.is_in_transaction(), (
         "_create_new_bundle must be called in a transaction"
@@ -161,8 +159,6 @@ async def _create_new_bundle(
 
     await EventStream.dispatch(
         "bundle.created",
-        sender=sender,
-        sender_type=sender_type,
         user=user.name if user else None,
         description=f"New{stat} bundle '{bundle.name}' created",
         summary={
@@ -187,8 +183,6 @@ async def check_bundle_compatibility(
 async def create_new_bundle(
     bundle: BundleModel,
     user: CurrentUser,
-    sender: Sender,
-    sender_type: SenderType,
     force: bool = Query(False, description="Force creation of bundle"),
 ) -> EmptyResponse:
     if not user.is_admin:
@@ -225,12 +219,7 @@ async def create_new_bundle(
                 bundle.addons.pop(addon_name)
 
     async with Postgres.transaction():
-        await _create_new_bundle(
-            bundle,
-            user=user,
-            sender=sender,
-            sender_type=sender_type,
-        )
+        await _create_new_bundle(bundle, user=user)
     if bundle.is_production or bundle.is_staging:
         await AddonLibrary.clear_addon_list_cache()
 
@@ -247,8 +236,6 @@ async def update_bundle(
     bundle_name: str,
     patch: BundlePatchModel,
     user: CurrentUser,
-    sender: Sender,
-    sender_type: SenderType,
     build: list[Platform] | None = Query(
         None,
         title="Request build",
@@ -434,9 +421,6 @@ async def update_bundle(
 
     await EventStream.dispatch(
         "bundle.updated",
-        sender=sender,
-        sender_type=sender_type,
-        user=user.name,
         description=patch.get_changes_description(bundle_name),
         summary={
             "name": bundle_name,

--- a/api/entity_lists/entity_list_folders.py
+++ b/api/entity_lists/entity_list_folders.py
@@ -4,8 +4,6 @@ from ayon_server.api.dependencies import (
     CurrentUser,
     FolderID,
     ProjectName,
-    Sender,
-    SenderType,
 )
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
 from ayon_server.exceptions import (
@@ -99,8 +97,6 @@ async def get_entity_list_folders(
 async def create_entity_list_folder(
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
     payload: EntityListFolderPostModel,
 ) -> EntityIdResponse:
     if payload.id is None:
@@ -132,8 +128,6 @@ async def update_entity_list_folder(
     user: CurrentUser,
     project_name: ProjectName,
     folder_id: FolderID,
-    sender: Sender,
-    sender_type: SenderType,
     payload: EntityListFolderPatchModel,
 ) -> EmptyResponse:
     async with Postgres.transaction():
@@ -182,8 +176,6 @@ async def delete_entity_list_folder(
     user: CurrentUser,
     project_name: ProjectName,
     folder_id: FolderID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     async with Postgres.transaction():
         await Postgres.set_project_schema(project_name)
@@ -219,8 +211,6 @@ class EntityListFolderOrderModel(OPModel):
 async def set_entity_list_folders_order(
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
     payload: EntityListFolderOrderModel,
 ) -> EmptyResponse:
     async with Postgres.transaction():

--- a/api/entity_lists/entity_list_items.py
+++ b/api/entity_lists/entity_list_items.py
@@ -24,8 +24,6 @@ async def create_entity_list_item(
     user: CurrentUser,
     project_name: ProjectName,
     entity_list_id: EntityListID,
-    sender: Sender,
-    sender_type: SenderType,
     payload: EntityListItemPostModel,
 ) -> None:
     async with Postgres.transaction():
@@ -41,7 +39,7 @@ async def create_entity_list_item(
             data=payload.data,
             tags=payload.tags,
         )
-        await entity_list.save(sender=sender, sender_type=sender_type)
+        await entity_list.save()
 
 
 @router.patch("/lists/{entity_list_id}/items/{entity_list_item_id}")

--- a/api/entity_lists/entity_lists.py
+++ b/api/entity_lists/entity_lists.py
@@ -7,8 +7,6 @@ from ayon_server.api.dependencies import (
     CurrentUser,
     EntityListID,
     ProjectName,
-    Sender,
-    SenderType,
 )
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.entity_lists.entity_list import EntityList
@@ -30,8 +28,6 @@ async def create_entity_list(
     user: CurrentUser,
     project_name: ProjectName,
     payload: EntityListPostModel,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EntityListSummary:
     """Create a new entity list.
 
@@ -76,7 +72,7 @@ async def create_entity_list(
                 tags=item.tags,
             )
 
-        return await entity_list.save(sender=sender, sender_type=sender_type)
+        return await entity_list.save()
 
 
 @router.patch("/lists/{entity_list_id}")
@@ -85,8 +81,6 @@ async def update_entity_list(
     project_name: ProjectName,
     entity_list_id: EntityListID,
     payload: EntityListPatchModel,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Update entity list metadata"""
 
@@ -105,7 +99,7 @@ async def update_entity_list(
             else:
                 setattr(entity_list.payload, key, value)
 
-        await entity_list.save(sender=sender, sender_type=sender_type)
+        await entity_list.save()
 
     return EmptyResponse()
 
@@ -170,15 +164,13 @@ async def delete_entity_list(
     user: CurrentUser,
     project_name: ProjectName,
     entity_list_id: EntityListID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Delete entity list from the database"""
 
     async with Postgres.transaction():
         entity_list = await EntityList.load(project_name, entity_list_id, user=user)
         await entity_list.ensure_can_admin()
-        await entity_list.delete(sender=sender, sender_type=sender_type)
+        await entity_list.delete()
 
     return EmptyResponse()
 
@@ -188,8 +180,6 @@ async def materialize_entity_list(
     user: CurrentUser,
     project_name: ProjectName,
     entity_list_id: EntityListID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EntityListSummary:
     """Materialize an entity list."""
 
@@ -197,4 +187,4 @@ async def materialize_entity_list(
         entity_list = await EntityList.load(project_name, entity_list_id, user=user)
         await entity_list.ensure_can_admin()
         await entity_list.materialize()
-        return await entity_list.save(sender=sender, sender_type=sender_type)
+        return await entity_list.save()

--- a/api/files/files.py
+++ b/api/files/files.py
@@ -202,7 +202,7 @@ async def get_project_file(
     return RedirectResponse(url=url, status_code=302)
 
 
-@router.get("/{file_id}/info", response_model=FileInfo, dependencies=[AllowGuests])
+@router.get("/{file_id}/info", dependencies=[AllowGuests])
 async def get_project_file_info(
     project_name: ProjectName,
     file_id: FileID,

--- a/api/folders/folders.py
+++ b/api/folders/folders.py
@@ -1,12 +1,6 @@
 from fastapi import BackgroundTasks, Query
 
-from ayon_server.api.dependencies import (
-    CurrentUser,
-    FolderID,
-    ProjectName,
-    Sender,
-    SenderType,
-)
+from ayon_server.api.dependencies import CurrentUser, FolderID, ProjectName
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
 from ayon_server.entities import FolderEntity
 from ayon_server.operations.project_level import ProjectLevelOperations
@@ -42,17 +36,10 @@ async def create_folder(
     background_tasks: BackgroundTasks,
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EntityIdResponse:
     """Create a new folder."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
 
     ops.create("folder", **post_data.dict(exclude_unset=True))
     res = await ops.process(can_fail=False, raise_on_error=True)
@@ -73,8 +60,6 @@ async def update_folder(
     user: CurrentUser,
     project_name: ProjectName,
     folder_id: FolderID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Patch (partially update) a folder.
 
@@ -82,12 +67,7 @@ async def update_folder(
     cannot be changed.
     """
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.update("folder", folder_id, **post_data.dict(exclude_unset=True))
     await ops.process(can_fail=False, raise_on_error=True)
     return EmptyResponse()
@@ -103,8 +83,6 @@ async def delete_folder(
     user: CurrentUser,
     project_name: ProjectName,
     folder_id: FolderID,
-    sender: Sender,
-    sender_type: SenderType,
     force: bool = Query(False, description="Allow recursive deletion"),
 ) -> EmptyResponse:
     """Delete a folder.
@@ -113,12 +91,7 @@ async def delete_folder(
     its subfolders. Otherwise, deletes the folder and all its subfolders.
     """
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
 
     ops.delete("folder", folder_id, force=force)
     await ops.process(can_fail=False, raise_on_error=True)

--- a/api/links/links.py
+++ b/api/links/links.py
@@ -7,8 +7,6 @@ from ayon_server.api.dependencies import (
     LinkID,
     LinkType,
     ProjectName,
-    Sender,
-    SenderType,
 )
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
 from ayon_server.entities.models.submodels import LinkTypeModel
@@ -209,8 +207,6 @@ async def create_entity_link(
     user: CurrentUser,
     project_name: ProjectName,
     post_data: CreateLinkRequestModel,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EntityIdResponse:
     """Create a new entity link."""
 
@@ -297,8 +293,6 @@ async def create_entity_link(
             description=event_description,
             project=project_name,
             user=user.name,
-            sender=sender,
-            sender_type=sender_type,
         )
 
     logger.debug(
@@ -320,8 +314,6 @@ async def delete_entity_link(
     user: CurrentUser,
     project_name: ProjectName,
     link_id: LinkID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Delete a link.
 
@@ -362,8 +354,6 @@ async def delete_entity_link(
             ),
             project=project_name,
             user=user.name,
-            sender=sender,
-            sender_type=sender_type,
         )
 
     return EmptyResponse()

--- a/api/operations/activities_operations.py
+++ b/api/operations/activities_operations.py
@@ -7,7 +7,7 @@ from ayon_server.activities import (
     delete_activity,
     update_activity,
 )
-from ayon_server.api.dependencies import CurrentUser, ProjectName, Sender, SenderType
+from ayon_server.api.dependencies import CurrentUser, ProjectName
 from ayon_server.entities import UserEntity
 from ayon_server.exceptions import (
     AyonException,
@@ -146,8 +146,6 @@ async def process_activity_operation(
     project_name: str,
     operation: ActivityOperationModel,
     user: UserEntity,
-    sender: str | None = None,
-    sender_type: str | None = None,
 ) -> ActivityOperationResponseModel:
     if operation.type == "create":
         if not operation.data:
@@ -179,8 +177,6 @@ async def process_activity_operation(
                 files=activity.files,
                 user=user,
                 timestamp=activity.timestamp,
-                sender=sender,
-                sender_type=sender_type,
                 data=activity.data,
             )
         except Exception as e:
@@ -213,8 +209,6 @@ async def process_activity_operation(
                 append_files=patch.append_files,
                 user_name=user.name,
                 is_admin=user.is_admin,
-                sender=sender,
-                sender_type=sender_type,
                 data=patch.data,
             )
         except Exception as e:
@@ -236,8 +230,6 @@ async def process_activity_operation(
                 operation.activity_id,
                 user_name=user.name,
                 is_admin=user.is_admin,
-                sender=sender,
-                sender_type=sender_type,
             )
         except Exception as e:
             raise AyonException(str(e))
@@ -257,8 +249,6 @@ async def activities_operations(
     user: CurrentUser,
     project_name: ProjectName,
     payload: ActivityOperationsRequestModel,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> ActivityOperationsResponseModel:
     """
     Perform multiple operations on activities.
@@ -279,8 +269,6 @@ async def activities_operations(
                 project_name,
                 operation,
                 user,
-                sender,
-                sender_type,
             )
         except AyonException as e:
             response = ActivityOperationResponseModel(

--- a/api/operations/operations.py
+++ b/api/operations/operations.py
@@ -2,7 +2,7 @@ from typing import Literal
 
 from fastapi import BackgroundTasks
 
-from ayon_server.api.dependencies import CurrentUser, ProjectName, Sender, SenderType
+from ayon_server.api.dependencies import CurrentUser, ProjectName
 from ayon_server.exceptions import ForbiddenException, NotFoundException
 from ayon_server.lib.redis import Redis
 from ayon_server.operations.project_level import (
@@ -25,17 +25,12 @@ class OperationsRequestModel(OPModel):
     raise_on_error: bool = False
 
 
-@router.post(
-    "/projects/{project_name}/operations",
-    response_model=OperationsResponseModel,
-)
+@router.post("/projects/{project_name}/operations")
 async def operations(
     payload: OperationsRequestModel,
     project_name: ProjectName,
     user: CurrentUser,
-    sender: Sender,
-    sender_type: SenderType,
-):
+) -> OperationsResponseModel:
     """
     Process multiple operations (create / update / delete) in a single request.
 
@@ -54,12 +49,7 @@ async def operations(
     Always check the `success` field of the response.
     """
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
 
     for operation in payload.operations:
         if operation.as_user:
@@ -129,8 +119,6 @@ async def background_operations(
     payload: OperationsRequestModel,
     project_name: ProjectName,
     user: CurrentUser,
-    sender: Sender,
-    sender_type: SenderType,
     background_tasks: BackgroundTasks,
 ) -> BackgroundOperationsResponseModel:
     """
@@ -139,12 +127,7 @@ async def background_operations(
     query the status of the task.
     """
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
 
     for operation in payload.operations:
         if operation.as_user:

--- a/api/products/products.py
+++ b/api/products/products.py
@@ -1,12 +1,6 @@
 from fastapi import APIRouter
 
-from ayon_server.api.dependencies import (
-    CurrentUser,
-    ProductID,
-    ProjectName,
-    Sender,
-    SenderType,
-)
+from ayon_server.api.dependencies import CurrentUser, ProductID, ProjectName
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
 from ayon_server.entities import ProductEntity
 from ayon_server.operations.project_level import ProjectLevelOperations
@@ -43,20 +37,14 @@ async def create_product(
     post_data: ProductEntity.model.post_model,  # type: ignore
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EntityIdResponse:
     """Create a new product."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.create("product", **post_data.dict())
     res = await ops.process(can_fail=False, raise_on_error=True)
     entity_id = res.operations[0].entity_id
+    assert entity_id
     return EntityIdResponse(id=entity_id)
 
 
@@ -71,16 +59,12 @@ async def update_product(
     user: CurrentUser,
     project_name: ProjectName,
     product_id: ProductID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Patch (partially update) a product."""
 
     ops = ProjectLevelOperations(
         project_name,
         user=user,
-        sender=sender,
-        sender_type=sender_type,
     )
     ops.update("product", product_id, **post_data.dict(exclude_unset=True))
     await ops.process(can_fail=False, raise_on_error=True)
@@ -97,20 +81,13 @@ async def delete_product(
     user: CurrentUser,
     project_name: ProjectName,
     product_id: ProductID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Delete a product.
 
     This will also delete all the product's versions and representations.
     """
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.delete("product", product_id)
     await ops.process(can_fail=False, raise_on_error=True)
     return EmptyResponse(status_code=204)

--- a/api/projects/anatomy.py
+++ b/api/projects/anatomy.py
@@ -1,4 +1,4 @@
-from ayon_server.api.dependencies import CurrentUser, ProjectName, Sender, SenderType
+from ayon_server.api.dependencies import CurrentUser, ProjectName
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.entities import ProjectEntity
 from ayon_server.events import EventStream
@@ -24,8 +24,6 @@ async def set_project_anatomy(
     payload: Anatomy,
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Set a project anatomy."""
 
@@ -40,11 +38,6 @@ async def set_project_anatomy(
     await project.save()
 
     for event in events:
-        await EventStream.dispatch(
-            **event,
-            sender=sender,
-            sender_type=sender_type,
-            user=user.name,
-        )
+        await EventStream.dispatch(**event)
 
     return EmptyResponse()

--- a/api/projects/bundle.py
+++ b/api/projects/bundle.py
@@ -5,7 +5,7 @@ from fastapi import Query
 from pydantic import Field
 
 from ayon_server.addons.library import AddonLibrary
-from ayon_server.api.dependencies import CurrentUser, ProjectName, Sender, SenderType
+from ayon_server.api.dependencies import CurrentUser, ProjectName
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.bundles.project_bundles import (
     freeze_project_bundle,
@@ -35,14 +35,11 @@ async def set_project_bundles(
     user: CurrentUser,
     project_name: ProjectName,
     payload: ProjectBundleModel,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Set project bundle
 
     Deprecated: Use the freeze_project_bundle function instead.
     """
-    _ = sender, sender_type
 
     if not user.is_manager:
         raise ForbiddenException("Only managers can set project bundle")
@@ -129,16 +126,12 @@ class ProjectBundle(OPModel):
 async def set_project_bundle(
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
     payload: ProjectBundle,
     variant: BundleVariant = "production",
 ) -> None:
     """Set project bundle"""
     if not user.is_manager:
         raise ForbiddenException("Only managers can set project bundle")
-
-    _ = sender, sender_type
 
     for addon_name, addon_version in payload.addons.items():
         if addon_version == "__disable__":
@@ -157,15 +150,11 @@ async def set_project_bundle(
 async def unset_project_bundle(
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
     variant: BundleVariant = "production",
 ) -> None:
     """Unset project bundle"""
     if not user.is_manager:
         raise ForbiddenException("Only managers can unset project bundle")
-
-    _ = sender, sender_type
 
     return await unfreeze_project_bundle(
         project_name,

--- a/api/projects/projects.py
+++ b/api/projects/projects.py
@@ -5,8 +5,6 @@ from ayon_server.api.dependencies import (
     CurrentUser,
     NewProjectName,
     ProjectName,
-    Sender,
-    SenderType,
 )
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.entities import ProjectEntity
@@ -130,8 +128,6 @@ async def create_project(
     put_data: ProjectPostModel,
     user: CurrentUser,
     project_name: NewProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Create a new project.
 
@@ -162,10 +158,7 @@ async def create_project(
 
     await EventStream.dispatch(
         "entity.project.created",
-        sender=sender,
-        sender_type=sender_type,
         project=project.name,
-        user=user.name,
         description=f"Created project {project.name}",
     )
 
@@ -182,8 +175,6 @@ async def update_project(
     patch_data: ProjectPatchModel,
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ):
     """Patch a project.
 
@@ -206,12 +197,7 @@ async def update_project(
     await project.save()
 
     for edata in events:
-        await EventStream.dispatch(
-            **edata,
-            sender=sender,
-            sender_type=sender_type,
-            user=user.name,
-        )
+        await EventStream.dispatch(**edata)
     return EmptyResponse()
 
 
@@ -248,8 +234,6 @@ async def unassign_users_from_deleted_projects() -> None:
 async def delete_project(
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Delete a given project including all its entities."""
 
@@ -268,10 +252,7 @@ async def delete_project(
 
     await EventStream.dispatch(
         "entity.project.deleted",
-        sender=sender,
-        sender_type=sender_type,
         project=project.name,
-        user=user.name,
         description=f"Deleted project {project.name}",
     )
 

--- a/api/representations/representations.py
+++ b/api/representations/representations.py
@@ -1,11 +1,7 @@
-from fastapi import BackgroundTasks
-
 from ayon_server.api.dependencies import (
     CurrentUser,
     ProjectName,
     RepresentationID,
-    Sender,
-    SenderType,
 )
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
 from ayon_server.entities import RepresentationEntity
@@ -39,26 +35,15 @@ async def get_representation(
 #
 
 
-@router.post(
-    "/projects/{project_name}/representations",
-    status_code=201,
-    response_model=EntityIdResponse,
-)
+@router.post("/projects/{project_name}/representations", status_code=201)
 async def create_representation(
     post_data: RepresentationEntity.model.post_model,  # type: ignore
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EntityIdResponse:
     """Create a new representation."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.create("representation", **post_data.dict(exclude_unset=True))
     res = await ops.process(can_fail=False, raise_on_error=True)
     entity_id = res.operations[0].entity_id
@@ -75,21 +60,13 @@ async def create_representation(
 )
 async def update_representation(
     post_data: RepresentationEntity.model.patch_model,  # type: ignore
-    background_tasks: BackgroundTasks,
     user: CurrentUser,
     project_name: ProjectName,
     representation_id: RepresentationID,
-    sender: Sender,
-    sender_type: SenderType,
 ):
     """Patch (partially update) a representation."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.update(
         "representation",
         representation_id,
@@ -108,21 +85,13 @@ async def update_representation(
     "/projects/{project_name}/representations/{representation_id}", status_code=204
 )
 async def delete_representation(
-    background_tasks: BackgroundTasks,
     user: CurrentUser,
     project_name: ProjectName,
     representation_id: RepresentationID,
-    sender: Sender,
-    sender_type: SenderType,
 ):
     """Delete a representation."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.delete("representation", representation_id)
     await ops.process(can_fail=False, raise_on_error=True)
     return EmptyResponse()

--- a/api/review/upload.py
+++ b/api/review/upload.py
@@ -3,8 +3,6 @@ from fastapi import Query, Request
 from ayon_server.api.dependencies import (
     CurrentUser,
     ProjectName,
-    Sender,
-    SenderType,
     VersionID,
     XContentType,
     XFileName,
@@ -27,8 +25,6 @@ async def upload_reviewable(
     user: CurrentUser,
     project_name: ProjectName,
     version_id: VersionID,
-    sender: Sender,
-    sender_type: SenderType,
     x_file_name: XFileName,
     content_type: XContentType,
     label: str | None = Query(None, description="Label", alias="label"),
@@ -60,6 +56,4 @@ async def upload_reviewable(
         activity_id=None,
         content_type=content_type,
         user_name=user.name,
-        sender=sender,
-        sender_type=sender_type,
     )

--- a/api/services/hosts.py
+++ b/api/services/hosts.py
@@ -51,8 +51,8 @@ class HeartbeatResponseModel(OPModel):
     )
 
 
-@router.get("/hosts", response_model=HostListResponseModel)
-async def list_hosts(user: CurrentUser):
+@router.get("/hosts")
+async def list_hosts(user: CurrentUser) -> HostListResponseModel:
     """Return a list of all hosts.
 
     A host is an instance of Ayon Service Host (ASH) that is capable of
@@ -66,12 +66,11 @@ async def list_hosts(user: CurrentUser):
     )
 
 
-@router.post(
-    "/hosts/heartbeat",
-    response_model=HeartbeatResponseModel,
-    dependencies=[NoTraces],
-)
-async def host_heartbeat(payload: HeartbeatRequestModel, user: CurrentUser):
+@router.post("/hosts/heartbeat", dependencies=[NoTraces])
+async def host_heartbeat(
+    user: CurrentUser,
+    payload: HeartbeatRequestModel,
+) -> HeartbeatResponseModel:
     """Send a heartbeat from a host.
 
     This endpoint is called by ASH to send a heartbeat to the API. The

--- a/api/tasks/tasks.py
+++ b/api/tasks/tasks.py
@@ -3,8 +3,6 @@ from typing import Any, Literal
 from ayon_server.api.dependencies import (
     CurrentUser,
     ProjectName,
-    Sender,
-    SenderType,
     TaskID,
 )
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
@@ -43,29 +41,18 @@ async def get_task(
 #
 
 
-@router.post(
-    "/projects/{project_name}/tasks",
-    status_code=201,
-    response_model=EntityIdResponse,
-)
+@router.post("/projects/{project_name}/tasks", status_code=201)
 async def create_task(
     post_data: TaskEntity.model.post_model,  # type: ignore
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EntityIdResponse:
     """Create a new task.
 
     Use a POST request to create a new task (with a new id).
     """
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.create("task", **post_data.dict(exclude_unset=True))
     res = await ops.process(can_fail=False, raise_on_error=True)
     entity_id = res.operations[0].entity_id
@@ -83,17 +70,10 @@ async def update_task(
     user: CurrentUser,
     project_name: ProjectName,
     task_id: TaskID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Patch (partially update) a task."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.update("task", task_id, **post_data.dict(exclude_unset=True))
     await ops.process(can_fail=False, raise_on_error=True)
     return EmptyResponse()
@@ -109,17 +89,10 @@ async def delete_task(
     user: CurrentUser,
     project_name: ProjectName,
     task_id: TaskID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Delete a task."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.delete("task", task_id)
     await ops.process(can_fail=False, raise_on_error=True)
     return EmptyResponse()

--- a/api/users/users.py
+++ b/api/users/users.py
@@ -4,11 +4,8 @@ from fastapi import Path
 
 from ayon_server.api.clientinfo import ClientInfo
 from ayon_server.api.dependencies import (
-    AccessToken,
     AllowGuests,
     CurrentUser,
-    Sender,
-    SenderType,
     UserName,
 )
 from ayon_server.api.responses import EmptyResponse
@@ -122,8 +119,6 @@ async def create_user(
     put_data: NewUserModel,
     user: CurrentUser,
     user_name: UserName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Create a new user."""
 
@@ -160,12 +155,7 @@ async def create_user(
     }
 
     await nuser.save()
-    await EventStream.dispatch(
-        sender=sender,
-        sender_type=sender_type,
-        user=user.name,
-        **event,
-    )
+    await EventStream.dispatch(**event)
     return EmptyResponse()
 
 
@@ -173,8 +163,6 @@ async def create_user(
 async def delete_user(
     user: CurrentUser,
     user_name: UserName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     if not user.is_manager:
         raise ForbiddenException
@@ -191,13 +179,7 @@ async def delete_user(
         }
 
     await target_user.delete()
-    await EventStream.dispatch(
-        "entity.user.deleted",
-        sender=sender,
-        sender_type=sender_type,
-        user=user.name,
-        **event,
-    )
+    await EventStream.dispatch("entity.user.deleted", **event)
     return EmptyResponse()
 
 
@@ -206,7 +188,6 @@ async def patch_user(
     payload: UserEntity.model.patch_model,  # type: ignore
     user: CurrentUser,
     user_name: UserName,
-    access_token: AccessToken,
 ) -> EmptyResponse:
     payload.data["updatedBy"] = user.name
     target_user = await UserEntity.load(user_name)
@@ -356,8 +337,6 @@ async def change_user_name(
     patch_data: ChangeUserNameRequestModel,
     user: CurrentUser,
     user_name: UserName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Changes the user name of a user.
 
@@ -372,8 +351,6 @@ async def change_user_name(
         user_name,
         patch_data.new_name,
         invoking_user_name=user.name,
-        sender=sender,
-        sender_type=sender_type,
     )
     return EmptyResponse()
 

--- a/api/versions/versions.py
+++ b/api/versions/versions.py
@@ -3,8 +3,6 @@ from fastapi import APIRouter
 from ayon_server.api.dependencies import (
     CurrentUser,
     ProjectName,
-    Sender,
-    SenderType,
     VersionID,
 )
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
@@ -43,8 +41,6 @@ async def create_version(
     post_data: VersionEntity.model.post_model,  # type: ignore
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EntityIdResponse:
     """Create a new version.
 
@@ -52,12 +48,7 @@ async def create_version(
     """
 
     payload = post_data.dict(exclude_unset=True)
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
 
     ops.create("version", **payload)
     res = await ops.process(can_fail=False, raise_on_error=True)
@@ -76,17 +67,10 @@ async def update_version(
     user: CurrentUser,
     project_name: ProjectName,
     version_id: VersionID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Patch (partially update) a version."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
 
     ops.update("version", version_id, **post_data.dict(exclude_unset=True))
     await ops.process(can_fail=False, raise_on_error=True)
@@ -103,20 +87,13 @@ async def delete_version(
     user: CurrentUser,
     project_name: ProjectName,
     version_id: VersionID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Delete a version.
 
     This will also delete all representations of the version.
     """
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.delete("version", version_id)
     await ops.process(can_fail=False, raise_on_error=True)
     return EmptyResponse()

--- a/api/workfiles/workfiles.py
+++ b/api/workfiles/workfiles.py
@@ -1,12 +1,6 @@
 from fastapi import APIRouter
 
-from ayon_server.api.dependencies import (
-    CurrentUser,
-    ProjectName,
-    Sender,
-    SenderType,
-    WorkfileID,
-)
+from ayon_server.api.dependencies import CurrentUser, ProjectName, WorkfileID
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
 from ayon_server.entities import WorkfileEntity
 from ayon_server.operations.project_level import ProjectLevelOperations
@@ -44,8 +38,6 @@ async def create_workfile(
     post_data: WorkfileEntity.model.post_model,  # type: ignore
     user: CurrentUser,
     project_name: ProjectName,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EntityIdResponse:
     """Create a new workfile.
 
@@ -57,12 +49,7 @@ async def create_workfile(
     if not post_data.updated_by:
         post_data.updated_by = post_data.created_by
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
 
     ops.create("workfile", **post_data.dict(exclude_unset=True))
     res = await ops.process(can_fail=False, raise_on_error=True)
@@ -81,17 +68,10 @@ async def update_workfile(
     user: CurrentUser,
     project_name: ProjectName,
     workfile_id: WorkfileID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Patch (partially update) a workfile."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
 
     ops.update("workfile", workfile_id, **post_data.dict(exclude_unset=True))
     await ops.process(can_fail=False, raise_on_error=True)
@@ -108,17 +88,10 @@ async def delete_workfile(
     user: CurrentUser,
     project_name: ProjectName,
     workfile_id: WorkfileID,
-    sender: Sender,
-    sender_type: SenderType,
 ) -> EmptyResponse:
     """Delete a workfile."""
 
-    ops = ProjectLevelOperations(
-        project_name,
-        user=user,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    ops = ProjectLevelOperations(project_name, user=user)
     ops.delete("workfile", workfile_id)
     await ops.process(can_fail=False, raise_on_error=True)
     return EmptyResponse()

--- a/ayon_server/api/context.py
+++ b/ayon_server/api/context.py
@@ -1,0 +1,72 @@
+import contextlib
+from collections.abc import AsyncIterator
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from ayon_server.entities.user import UserEntity
+
+
+@dataclass
+class RequestContext:
+    """
+    Context of the request, which can be used to store additional information
+    about the request, such as the user making the request, the project, etc.
+    """
+
+    user: UserEntity | None = None
+    sender: str | None = None
+    sender_type: str | None = None
+
+
+request_context: ContextVar[RequestContext | None] = ContextVar(
+    "request_context", default=None
+)
+
+
+def get_request_context() -> RequestContext:
+    """
+    Get the request context for the current request.
+
+    Returns:
+        RequestContext: The request context for the current request.
+    """
+    return request_context.get() or RequestContext()
+
+
+@contextlib.asynccontextmanager
+async def request_context_manager(context: RequestContext) -> AsyncIterator[None]:
+    """
+    Context manager for setting the request context for the current request.
+
+    Args:
+        context (RequestContext): The request context to set for the current request.
+    """
+    token = request_context.set(context)
+    try:
+        yield
+    finally:
+        request_context.reset(token)
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware for setting the request context for each request.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        try:
+            user = request.state.user
+        except AttributeError:
+            user = None
+
+        context = RequestContext(
+            user=user,
+            sender=request.headers.get("X-Sender"),
+            sender_type=request.headers.get("X-Sender-Type"),
+        )
+        async with request_context_manager(context):
+            response = await call_next(request)
+        return response

--- a/ayon_server/api/context.py
+++ b/ayon_server/api/context.py
@@ -1,4 +1,5 @@
 import contextlib
+import re
 from collections.abc import AsyncIterator
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -7,6 +8,9 @@ from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from ayon_server.entities.user import UserEntity
+from ayon_server.types import NAME_REGEX
+
+_NAME_PATTERN = re.compile(NAME_REGEX)
 
 
 @dataclass
@@ -64,9 +68,20 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
 
         context = RequestContext(
             user=user,
-            sender=request.headers.get("X-Sender"),
-            sender_type=request.headers.get("X-Sender-Type"),
+            sender=self._validated_header(request.headers.get("X-Sender")),
+            sender_type=self._validated_header(
+                request.headers.get("X-Sender-Type"), default="api"
+            ),
         )
         async with request_context_manager(context):
             response = await call_next(request)
         return response
+
+    @staticmethod
+    def _validated_header(value: str | None, default: str | None = None) -> str | None:
+        """Return value if it matches NAME_REGEX, else return default."""
+        if value is None:
+            return default
+        if _NAME_PATTERN.match(value):
+            return value
+        return default

--- a/ayon_server/api/server.py
+++ b/ayon_server/api/server.py
@@ -15,6 +15,7 @@ from fastapi.websockets import WebSocket, WebSocketDisconnect
 
 # okay. now the rest
 from ayon_server.api.auth import AuthMiddleware
+from ayon_server.api.context import RequestContextMiddleware
 from ayon_server.api.dependencies import CurrentUser, CurrentUserOptional
 from ayon_server.api.lifespan import lifespan
 from ayon_server.api.logging import LoggingMiddleware
@@ -45,6 +46,7 @@ app = FastAPI(
     **app_meta,
 )
 
+app.add_middleware(RequestContextMiddleware)
 app.add_middleware(LoggingMiddleware)
 app.add_middleware(AuthMiddleware)
 

--- a/ayon_server/events/eventstream.py
+++ b/ayon_server/events/eventstream.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from typing import Any
 
+from ayon_server.api.context import get_request_context
 from ayon_server.exceptions import ConstraintViolationException, NotFoundException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
@@ -38,8 +39,6 @@ class EventStream:
         cls,
         topic: str,
         *,
-        sender: str | None = None,
-        sender_type: str | None = None,
         hash: str | None = None,
         project: str | None = None,
         user: str | None = None,
@@ -51,6 +50,8 @@ class EventStream:
         store: bool = True,
         reuse: bool = False,
         recipients: list[str] | None = None,
+        sender: str | None = None,
+        sender_type: str | None = None,
     ) -> str:
         """
 
@@ -66,6 +67,7 @@ class EventStream:
         recipients:
             list of user names to notify via websocket (None for all users)
         """
+
         if summary is None:
             summary = {}
         if payload is None:
@@ -80,11 +82,16 @@ class EventStream:
         status: str = "finished" if finished else "pending"
         progress: float = 100 if finished else 0.0
 
+        request_context = get_request_context()
+
+        if user is None and request_context.user:
+            user = request_context.user.name
+
         event = EventModel(
             id=event_id,
             hash=hash,
-            sender=sender,
-            sender_type=sender_type,
+            sender=request_context.sender,
+            sender_type=request_context.sender_type,
             topic=topic,
             project=project,
             user=user,
@@ -225,8 +232,6 @@ class EventStream:
         cls,
         event_id: str,
         *,
-        sender: str | None = None,
-        sender_type: str | None = None,
         project: str | None = None,
         user: str | None = None,
         status: EventStatus | None = None,
@@ -237,13 +242,28 @@ class EventStream:
         store: bool = True,
         retries: int | None = None,
         recipients: list[str] | None = None,
+        sender: str | None = None,
+        sender_type: str | None = None,
     ) -> bool:
         new_data: dict[str, Any] = {"updated_at": datetime.now()}
 
+        request_context = get_request_context()
+
         if sender is not None:
             new_data["sender"] = sender
+        elif request_context.sender is not None:
+            new_data["sender"] = request_context.sender
+
         if sender_type is not None:
             new_data["sender_type"] = sender_type
+        elif request_context is not None:
+            new_data["sender_type"] = request_context.sender_type
+
+        if user is not None:
+            new_data["user_name"] = user
+        elif request_context.user is not None:
+            new_data["user_name"] = request_context.user.name
+
         if project is not None:
             new_data["project_name"] = project
         if status is not None:
@@ -256,8 +276,6 @@ class EventStream:
             new_data["payload"] = payload
         if retries is not None:
             new_data["retries"] = retries
-        if user is not None:
-            new_data["user_name"] = user
 
         if store:
             query = SQLTool.update(

--- a/ayon_server/events/eventstream.py
+++ b/ayon_server/events/eventstream.py
@@ -256,7 +256,7 @@ class EventStream:
 
         if sender_type is not None:
             new_data["sender_type"] = sender_type
-        elif request_context is not None:
+        elif request_context.sender_type is not None:
             new_data["sender_type"] = request_context.sender_type
 
         if user is not None:

--- a/ayon_server/events/eventstream.py
+++ b/ayon_server/events/eventstream.py
@@ -90,8 +90,8 @@ class EventStream:
         event = EventModel(
             id=event_id,
             hash=hash,
-            sender=request_context.sender,
-            sender_type=request_context.sender_type,
+            sender=sender or request_context.sender,
+            sender_type=sender_type or request_context.sender_type,
             topic=topic,
             project=project,
             user=user,
@@ -187,8 +187,8 @@ class EventStream:
                     "summary": event.summary,
                     "status": event.status,
                     "progress": progress,
-                    "sender": sender,
-                    "senderType": sender_type,
+                    "sender": event.sender,
+                    "senderType": event.sender_type,
                     "store": store,  # useful to allow querying details
                     "recipients": recipients,
                     "createdAt": event.created_at,


### PR DESCRIPTION
This endpoint introduces new api middleware "Request context", that collects shared request info and provides it in a context variable. That makes certain variables - namely sender, sender type and current user available everywhere without explicitly passing it down. 

As a P.O.C. this PR removes Sender and SenderType dependencies from most of the endpoints - where it was used only to be passed down to EventStream.dispatch, and reducing codebase. EventStream.dispatch and EventStream.update was modified to read sender, sender_type and the current user name from the contextvar, but it is still possible to explicitly provide them as an override.

<img width="928" height="280" alt="image" src="https://github.com/user-attachments/assets/93dac692-5b93-458c-af95-a863425b6ab1" />
