### PR TITLE
Independent openapi schemas for addons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default:
 	uv run pre-commit install
 
 check:
-	sed -i "s/^version = \".*\"/version = \"$(VERSION)\"/" pyproject.toml
+	uv version $(VERSION)
 	uv run ruff check . --select=I --fix
 	uv run ruff format .
 	uv run ruff check . --fix

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -228,7 +228,7 @@ class BaseServerAddon:
             }
         )
 
-    def get_openapi(self) -> dict[str, Any] | None:
+    def get_openapi(self) -> dict[str, Any]:
 
         if ayonconfig.disable_rest_docs:
             raise ForbiddenException("OpenAPI documentation is disabled")
@@ -239,12 +239,12 @@ class BaseServerAddon:
 
             if user is None:
                 raise ForbiddenException(
-                    "You must be logged in to access API documentation"
+                    "You must be logged in to access addon OpenAPI schema"
                 )
 
             if not user.is_manager:
                 raise ForbiddenException(
-                    "You are not allowed to access API documentation"
+                    "You are not allowed to access addon OpenAPI schema"
                 )
 
         prefix = f"/api/addons/{self.name}/{self.version}"

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -11,6 +11,8 @@ except ModuleNotFoundError:
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
+from fastapi import FastAPI
+
 from ayon_server.actions.config import get_action_config, set_action_config
 from ayon_server.actions.context import ActionContext
 from ayon_server.actions.execute import ActionExecutor, ExecuteResponseModel
@@ -219,6 +221,37 @@ class BaseServerAddon:
                 "description": description or handler.__doc__ or "",
             }
         )
+
+    def get_openapi(self) -> dict[str, Any] | None:
+        prefix = f"/api/addons/{self.name}/{self.version}"
+        temp_app = FastAPI(
+            title=self.definition.friendly_name,
+            version=self.version,
+        )
+        for endpoint in self.endpoints:
+            path = endpoint["path"].lstrip("/")
+            path = f"{prefix}/{path}"
+            temp_app.add_api_route(
+                path,
+                endpoint["handler"],
+                methods=[endpoint["method"]],
+                name=endpoint["name"],
+                description=endpoint["description"],
+                operation_id=endpoint["name"],
+            )
+
+        def generate_unique_id(route):
+            return route.name
+
+        for router in self.routers:
+            temp_app.include_router(
+                router,
+                prefix=prefix,
+                generate_unique_id_function=generate_unique_id,
+            )
+
+        router_openapi = temp_app.openapi()
+        return router_openapi
 
     async def get_frontend_scopes(self) -> FrontendScopes:
         return self.frontend_scopes

--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -1,8 +1,6 @@
 import inspect
 import os
 
-from ayon_server.entities.user import UserEntity
-
 try:
     import toml
 except ModuleNotFoundError:
@@ -28,7 +26,15 @@ from ayon_server.addons.models import (
     SSOOption,
 )
 from ayon_server.addons.settings_caching import AddonSettingsCache
-from ayon_server.exceptions import AyonException, BadRequestException, NotFoundException
+from ayon_server.api.context import get_request_context
+from ayon_server.config import ayonconfig
+from ayon_server.entities.user import UserEntity
+from ayon_server.exceptions import (
+    AyonException,
+    BadRequestException,
+    ForbiddenException,
+    NotFoundException,
+)
 from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import log_traceback, logger
 from ayon_server.settings import BaseSettingsModel, apply_overrides
@@ -223,6 +229,24 @@ class BaseServerAddon:
         )
 
     def get_openapi(self) -> dict[str, Any] | None:
+
+        if ayonconfig.disable_rest_docs:
+            raise ForbiddenException("OpenAPI documentation is disabled")
+
+        if ayonconfig.openapi_require_authentication:
+            ctx = get_request_context()
+            user = ctx.user
+
+            if user is None:
+                raise ForbiddenException(
+                    "You must be logged in to access API documentation"
+                )
+
+            if not user.is_manager:
+                raise ForbiddenException(
+                    "You are not allowed to access API documentation"
+                )
+
         prefix = f"/api/addons/{self.name}/{self.version}"
         temp_app = FastAPI(
             title=self.definition.friendly_name,

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -83,6 +83,18 @@ def init_addon_endpoints(target_app: "FastAPI") -> None:
                     ),
                 )
 
+            if addon.endpoints or addon.routers:
+                target_app.add_api_route(
+                    f"/api/addons/{addon_name}/{version}/openapi.json",
+                    addon.get_openapi,
+                    include_in_schema=False,
+                    methods=["GET"],
+                    name=f"{addon_name}_{version}_openapi",
+                    operation_id=slugify(
+                        f"{addon_name}_{version}_openapi", separator="_"
+                    ),
+                )
+
 
 def init_addon_static(target_app: "FastAPI") -> None:
     """Serve static files for addon frontends."""

--- a/ayon_server/operations/project_level/__init__.py
+++ b/ayon_server/operations/project_level/__init__.py
@@ -321,7 +321,7 @@ class ProjectLevelOperations:
         as_user: str | UserEntity | None = None,
         operation_id: str | None = None,
         force: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         if isinstance(as_user, UserEntity):
             self.user_entities_map[as_user.name] = as_user
@@ -349,7 +349,7 @@ class ProjectLevelOperations:
         entity_id: str | None = None,
         *,
         as_user: str | UserEntity | None = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """Create a project level entity."""
         self.add(


### PR DESCRIPTION
This pull request introduces a mechanism to expose OpenAPI documentation for each addon in the system. The main changes involve dynamically generating and serving an OpenAPI schema for addon endpoints and routers, making it easier to discover and integrate with addon APIs.

**OpenAPI Documentation Exposure:**

* Added a `get_openapi` method to the `Addon` class in `addon.py`, which dynamically creates a temporary `FastAPI` app, registers all addon endpoints and routers, and generates an OpenAPI schema for them. 

**API Routing Enhancements:**

* Updated the `init_addon_endpoints` function in `lifespan.py` to add a new route for each addon exposing an api at, which serves the generated OpenAPI schema via the new `get_openapi` method.


<img width="562" height="716" alt="image" src="https://github.com/user-attachments/assets/4c06e524-3f7e-4d07-88ff-e41b7dd141ec" />
