### PR TITLE
Implemented adding new enum items

### DIFF
--- a/ayon_server/enum/base_resolver.py
+++ b/ayon_server/enum/base_resolver.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Any
 
 from ayon_server.forms import SimpleForm
-from ayon_server.types import SimpleValue
 
 from .enum_item import EnumItem
 
@@ -36,7 +35,7 @@ class BaseEnumResolver:
         item: EnumItem,
         project_name: str | None = None,
         **kwargs,
-    ) -> SimpleValue:
+    ) -> None:
         _ = (
             item,
             project_name,

--- a/ayon_server/enum/base_resolver.py
+++ b/ayon_server/enum/base_resolver.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from ayon_server.forms import SimpleForm
 
@@ -29,3 +29,11 @@ class BaseEnumResolver:
     async def resolve(self, context: dict[str, Any]) -> list[EnumItem]:
         """Resolve enum options based on the provided context."""
         return []
+
+    async def create_item(
+        self, item: EnumItem, project_name: Optional[str] = None, **kwargs
+    ) -> str:
+        """Resolve enum options based on the provided context."""
+        raise NotImplementedError(
+            "This enum resolver does not support item creation"
+        )

--- a/ayon_server/enum/base_resolver.py
+++ b/ayon_server/enum/base_resolver.py
@@ -1,6 +1,7 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from ayon_server.forms import SimpleForm
+from ayon_server.types import SimpleValue
 
 from .enum_item import EnumItem
 
@@ -31,9 +32,15 @@ class BaseEnumResolver:
         return []
 
     async def create_item(
-        self, item: EnumItem, project_name: Optional[str] = None, **kwargs
-    ) -> str:
+        self,
+        item: EnumItem,
+        project_name: str | None = None,
+        **kwargs,
+    ) -> SimpleValue:
+        _ = (
+            item,
+            project_name,
+            kwargs,
+        )  # Unused for now, but allows for future extensibility
         """Resolve enum options based on the provided context."""
-        raise NotImplementedError(
-            "This enum resolver does not support item creation"
-        )
+        raise NotImplementedError("This enum resolver does not support item creation")

--- a/ayon_server/enum/enum_registry.py
+++ b/ayon_server/enum/enum_registry.py
@@ -78,3 +78,33 @@ class EnumRegistry:
 
         enum = await resolver.resolve(context)
         return enum
+
+    @classmethod
+    async def create_item(
+        cls,
+        enum_name: str,
+        item: EnumItem,
+        project_name: str | None = None,
+        **kwargs
+    ) -> str:
+        """Create a new enum item using the appropriate resolver.
+
+        Args:
+            enum_name: The name of the enum (e.g., "statuses", "folderTypes")
+            item: The EnumItem to create
+            project_name: Optional project name for project-specific enums
+
+        Returns:
+            The value of the created item
+
+        Raises:
+            BadRequestException: If the resolver is not found
+            NotImplementedError: If the resolver doesn't support item creation
+        """
+        key = enum_name.split(".")[0]
+        try:
+            resolver = cls.resolvers[key]
+        except KeyError:
+            raise BadRequestException(f"Unknown enum resolver '{key}'")
+
+        return await resolver.create_item(item, project_name, **kwargs)

--- a/ayon_server/enum/enum_registry.py
+++ b/ayon_server/enum/enum_registry.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any
 from ayon_server.exceptions import BadRequestException
 from ayon_server.helpers.modules import classes_from_module, import_module
 from ayon_server.logging import logger
+from ayon_server.types import SimpleValue
 
 from .base_resolver import BaseEnumResolver
 from .enum_item import EnumItem
@@ -59,7 +60,6 @@ class EnumRegistry:
         user: "UserEntity | None" = None,
         **context: Any,
     ) -> list[EnumItem]:
-
         if "." in enum_name:
             key, name = enum_name.split(".", 1)
         else:
@@ -85,8 +85,8 @@ class EnumRegistry:
         enum_name: str,
         item: EnumItem,
         project_name: str | None = None,
-        **kwargs
-    ) -> str:
+        **kwargs,
+    ) -> SimpleValue:
         """Create a new enum item using the appropriate resolver.
 
         Args:

--- a/ayon_server/enum/resolvers/enum_anatomy.py
+++ b/ayon_server/enum/resolvers/enum_anatomy.py
@@ -6,7 +6,6 @@ from ayon_server.helpers.project_list import normalize_project_name
 from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.settings.enum import get_primary_anatomy_preset
-from ayon_server.types import SimpleValue
 
 
 class FolderTypesEnumResolver(BaseEnumResolver):
@@ -52,7 +51,7 @@ class FolderTypesEnumResolver(BaseEnumResolver):
         item: EnumItem,
         project_name: str | None = None,
         **kwargs,
-    ) -> SimpleValue:
+    ) -> None:
         _ = kwargs  # Unused for now, but allows for future extensibility
 
         if not project_name:
@@ -77,7 +76,6 @@ class FolderTypesEnumResolver(BaseEnumResolver):
                 },
             )
         await Redis.delete("project-anatomy", project_name)
-        return item.value
 
 
 class TaskTypesEnumResolver(BaseEnumResolver):
@@ -123,7 +121,7 @@ class TaskTypesEnumResolver(BaseEnumResolver):
         item: EnumItem,
         project_name: str | None = None,
         **kwargs,
-    ) -> SimpleValue:
+    ) -> None:
         if not project_name:
             raise ValueError("Missing project name in item data")
 
@@ -143,7 +141,6 @@ class TaskTypesEnumResolver(BaseEnumResolver):
                 },
             )
         await Redis.delete("project-anatomy", project_name)
-        return item.value
 
 
 class StatusesEnumResolver(BaseEnumResolver):
@@ -189,7 +186,7 @@ class StatusesEnumResolver(BaseEnumResolver):
         item: EnumItem,
         project_name: str | None = None,
         **kwargs,
-    ) -> SimpleValue:
+    ) -> None:
         if not project_name:
             raise ValueError("Missing project name in item data")
 
@@ -209,7 +206,6 @@ class StatusesEnumResolver(BaseEnumResolver):
                 },
             )
         await Redis.delete("project-anatomy", project_name)
-        return item.value
 
 
 class TagsEnumResolver(BaseEnumResolver):
@@ -253,7 +249,7 @@ class TagsEnumResolver(BaseEnumResolver):
         item: EnumItem,
         project_name: str | None = None,
         **kwargs,
-    ) -> SimpleValue:
+    ) -> None:
         if not project_name:
             raise ValueError("Missing project name in item data")
 
@@ -269,4 +265,3 @@ class TagsEnumResolver(BaseEnumResolver):
                 {"color": item.color or "#808080", "name": item.value},
             )
         await Redis.delete("project-anatomy", project_name)
-        return item.value

--- a/ayon_server/enum/resolvers/enum_anatomy.py
+++ b/ayon_server/enum/resolvers/enum_anatomy.py
@@ -6,6 +6,7 @@ from ayon_server.helpers.project_list import normalize_project_name
 from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.settings.enum import get_primary_anatomy_preset
+from ayon_server.types import SimpleValue
 
 
 class FolderTypesEnumResolver(BaseEnumResolver):
@@ -47,8 +48,13 @@ class FolderTypesEnumResolver(BaseEnumResolver):
         return result
 
     async def create_item(
-        self, item: EnumItem, project_name: str = None,**kwargs
-    ) -> str:
+        self,
+        item: EnumItem,
+        project_name: str | None = None,
+        **kwargs,
+    ) -> SimpleValue:
+        _ = kwargs  # Unused for now, but allows for future extensibility
+
         if not project_name:
             raise ValueError("Missing project name in item data")
 
@@ -58,13 +64,16 @@ class FolderTypesEnumResolver(BaseEnumResolver):
             await Postgres.execute(
                 """
                 INSERT INTO folder_types (name, data, position)
-                VALUES ($1, $2, (SELECT COALESCE(MAX(position), 0) + 1 FROM folder_types))
+                VALUES (
+                    $1,
+                    $2,
+                    (SELECT COALESCE(MAX(position), 0) + 1 FROM folder_types))
                 """,
                 item.value,
                 {
                     "icon": item.icon or "folder",
                     "color": item.color or "#808080",
-                    "name": item.value
+                    "name": item.value,
                 },
             )
         await Redis.delete("project-anatomy", project_name)
@@ -110,8 +119,11 @@ class TaskTypesEnumResolver(BaseEnumResolver):
         return result
 
     async def create_item(
-        self, item: EnumItem, project_name: str = None, **kwargs
-    ) -> str:
+        self,
+        item: EnumItem,
+        project_name: str | None = None,
+        **kwargs,
+    ) -> SimpleValue:
         if not project_name:
             raise ValueError("Missing project name in item data")
 
@@ -127,7 +139,7 @@ class TaskTypesEnumResolver(BaseEnumResolver):
                 {
                     "icon": item.icon or "task",
                     "color": item.color or "#808080",
-                    "name": item.value
+                    "name": item.value,
                 },
             )
         await Redis.delete("project-anatomy", project_name)
@@ -173,8 +185,11 @@ class StatusesEnumResolver(BaseEnumResolver):
         return result
 
     async def create_item(
-        self, item: EnumItem, project_name: str = None,  **kwargs
-    ) -> str:
+        self,
+        item: EnumItem,
+        project_name: str | None = None,
+        **kwargs,
+    ) -> SimpleValue:
         if not project_name:
             raise ValueError("Missing project name in item data")
 
@@ -190,7 +205,7 @@ class StatusesEnumResolver(BaseEnumResolver):
                 {
                     "icon": item.icon or "check_circle",
                     "color": item.color or "#808080",
-                    "name": item.value
+                    "name": item.value,
                 },
             )
         await Redis.delete("project-anatomy", project_name)
@@ -234,8 +249,11 @@ class TagsEnumResolver(BaseEnumResolver):
         return result
 
     async def create_item(
-        self, item: EnumItem, project_name: str = None, **kwargs
-    ) -> str:
+        self,
+        item: EnumItem,
+        project_name: str | None = None,
+        **kwargs,
+    ) -> SimpleValue:
         if not project_name:
             raise ValueError("Missing project name in item data")
 
@@ -248,10 +266,7 @@ class TagsEnumResolver(BaseEnumResolver):
                 VALUES ($1, $2, (SELECT COALESCE(MAX(position), 0) + 1 FROM tags))
                 """,
                 item.value,
-                {
-                    "color": item.color or "#808080",
-                    "name": item.value
-                },
+                {"color": item.color or "#808080", "name": item.value},
             )
         await Redis.delete("project-anatomy", project_name)
         return item.value

--- a/ayon_server/enum/resolvers/enum_anatomy.py
+++ b/ayon_server/enum/resolvers/enum_anatomy.py
@@ -45,6 +45,29 @@ class FolderTypesEnumResolver(BaseEnumResolver):
                 )
         return result
 
+    async def create_item(
+        self, item: EnumItem, project_name: str = None,**kwargs
+    ) -> str:
+        if not project_name:
+            raise ValueError("Missing project name in item data")
+
+        project_name = await normalize_project_name(project_name)
+        async with Postgres.transaction():
+            await Postgres.set_project_schema(project_name)
+            await Postgres.execute(
+                """
+                INSERT INTO folder_types (name, data, position)
+                VALUES ($1, $2, (SELECT COALESCE(MAX(position), 0) + 1 FROM folder_types))
+                """,
+                item.value,
+                {
+                    "icon": item.icon or "folder",
+                    "color": item.color or "#808080",
+                    "name": item.value
+                },
+            )
+        return item.value
+
 
 class TaskTypesEnumResolver(BaseEnumResolver):
     name = "taskTypes"
@@ -84,6 +107,29 @@ class TaskTypesEnumResolver(BaseEnumResolver):
                 )
         return result
 
+    async def create_item(
+        self, item: EnumItem, project_name: str = None, **kwargs
+    ) -> str:
+        if not project_name:
+            raise ValueError("Missing project name in item data")
+
+        project_name = await normalize_project_name(project_name)
+        async with Postgres.transaction():
+            await Postgres.set_project_schema(project_name)
+            await Postgres.execute(
+                """
+                INSERT INTO task_types (name, data, position)
+                VALUES ($1, $2, (SELECT COALESCE(MAX(position), 0) + 1 FROM task_types))
+                """,
+                item.value,
+                {
+                    "icon": item.icon or "task",
+                    "color": item.color or "#808080",
+                    "name": item.value
+                },
+            )
+        return item.value
+
 
 class StatusesEnumResolver(BaseEnumResolver):
     name = "statuses"
@@ -122,3 +168,85 @@ class StatusesEnumResolver(BaseEnumResolver):
                     )
                 )
         return result
+
+    async def create_item(
+        self, item: EnumItem, project_name: str = None,  **kwargs
+    ) -> str:
+        if not project_name:
+            raise ValueError("Missing project name in item data")
+
+        project_name = await normalize_project_name(project_name)
+        async with Postgres.transaction():
+            await Postgres.set_project_schema(project_name)
+            await Postgres.execute(
+                """
+                INSERT INTO statuses (name, data, position)
+                VALUES ($1, $2, (SELECT COALESCE(MAX(position), 0) + 1 FROM statuses))
+                """,
+                item.value,
+                {
+                    "icon": item.icon or "check_circle",
+                    "color": item.color or "#808080",
+                    "name": item.value
+                },
+            )
+        return item.value
+
+
+class TagsEnumResolver(BaseEnumResolver):
+    name = "tags"
+
+    async def get_accepted_params(self) -> dict[str, type]:
+        return {"project_name": str}
+
+    async def resolve(self, context: dict[str, Any]) -> list[EnumItem]:
+        project_name = context.get("project_name")
+        if not project_name:
+            anatomy = await get_primary_anatomy_preset()
+            return [
+                EnumItem(
+                    value=tag.name,
+                    label=tag.name,
+                    color=tag.color,
+                )
+                for tag in anatomy.tags
+            ]
+
+        project_name = await normalize_project_name(project_name)
+        result: list[EnumItem] = []
+        async with Postgres.transaction():
+            await Postgres.set_project_schema(project_name)
+            stmt = await Postgres.prepare(
+                "SELECT name, data FROM tags ORDER BY position"
+            )
+            async for row in stmt.cursor():
+                result.append(
+                    EnumItem(
+                        value=row["name"],
+                        label=row["name"],
+                        color=row["data"].get("color"),
+                    )
+                )
+        return result
+
+    async def create_item(
+        self, item: EnumItem, project_name: str = None, **kwargs
+    ) -> str:
+        if not project_name:
+            raise ValueError("Missing project name in item data")
+
+        project_name = await normalize_project_name(project_name)
+        async with Postgres.transaction():
+            await Postgres.set_project_schema(project_name)
+            await Postgres.execute(
+                """
+                INSERT INTO tags (name, data, position)
+                VALUES ($1, $2, (SELECT COALESCE(MAX(position), 0) + 1 FROM tags))
+                """,
+                item.value,
+                {
+                    "color": item.color or "#808080",
+                    "name": item.value
+                },
+            )
+        return item.value

--- a/ayon_server/enum/resolvers/enum_anatomy.py
+++ b/ayon_server/enum/resolvers/enum_anatomy.py
@@ -4,6 +4,7 @@ from ayon_server.enum.base_resolver import BaseEnumResolver
 from ayon_server.enum.enum_item import EnumItem
 from ayon_server.helpers.project_list import normalize_project_name
 from ayon_server.lib.postgres import Postgres
+from ayon_server.lib.redis import Redis
 from ayon_server.settings.enum import get_primary_anatomy_preset
 
 
@@ -66,6 +67,7 @@ class FolderTypesEnumResolver(BaseEnumResolver):
                     "name": item.value
                 },
             )
+        await Redis.delete("project-anatomy", project_name)
         return item.value
 
 
@@ -128,6 +130,7 @@ class TaskTypesEnumResolver(BaseEnumResolver):
                     "name": item.value
                 },
             )
+        await Redis.delete("project-anatomy", project_name)
         return item.value
 
 
@@ -190,6 +193,7 @@ class StatusesEnumResolver(BaseEnumResolver):
                     "name": item.value
                 },
             )
+        await Redis.delete("project-anatomy", project_name)
         return item.value
 
 
@@ -249,4 +253,5 @@ class TagsEnumResolver(BaseEnumResolver):
                     "name": item.value
                 },
             )
+        await Redis.delete("project-anatomy", project_name)
         return item.value

--- a/ayon_server/enum/resolvers/enum_link_types.py
+++ b/ayon_server/enum/resolvers/enum_link_types.py
@@ -8,7 +8,6 @@ from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.settings.anatomy import Anatomy
 from ayon_server.settings.anatomy.link_types import LinkType
-from ayon_server.types import SimpleValue
 
 
 def link_type_to_enum_item(link_type: LinkType) -> EnumItem:
@@ -59,7 +58,7 @@ class LinkTypesEnumResolver(BaseEnumResolver):
         item: EnumItem,
         project_name: str | None = None,
         **kwargs,
-    ) -> SimpleValue:
+    ) -> None:
         if not project_name or project_name == "_":
             raise ValueError("Link types require a project name")
 
@@ -88,4 +87,3 @@ class LinkTypesEnumResolver(BaseEnumResolver):
                 {"color": item.color or "#808080", "style": style},
             )
         await Redis.delete("project-anatomy", project_name)
-        return item.value

--- a/ayon_server/enum/resolvers/enum_link_types.py
+++ b/ayon_server/enum/resolvers/enum_link_types.py
@@ -1,5 +1,4 @@
 from typing import Any
-import json
 
 from ayon_server.enum.base_resolver import BaseEnumResolver
 from ayon_server.enum.enum_item import EnumItem

--- a/ayon_server/enum/resolvers/enum_link_types.py
+++ b/ayon_server/enum/resolvers/enum_link_types.py
@@ -4,6 +4,7 @@ import json
 from ayon_server.enum.base_resolver import BaseEnumResolver
 from ayon_server.enum.enum_item import EnumItem
 from ayon_server.helpers.anatomy import get_project_anatomy
+from ayon_server.helpers.project_list import normalize_project_name
 from ayon_server.lib.postgres import Postgres
 from ayon_server.settings.anatomy import Anatomy
 from ayon_server.settings.anatomy.link_types import LinkType
@@ -61,39 +62,31 @@ class LinkTypesEnumResolver(BaseEnumResolver):
         if not project_name or project_name == "_":
             raise ValueError("Link types require a project name")
 
-        from ayon_server.settings.anatomy import Anatomy
-
-        # Get current anatomy
-        anatomy = await get_project_anatomy(project_name)
-
-        # Check if item with same name already exists
-        for lt in anatomy.link_types:
-            if lt.name == item.value:
-                return item.value
-
-        # Create new link type
-        new_link_type = {
-            "name": item.value,
-            "link_type": item.value.lower().replace(" ", "_"),
-            "input_type": "folder",
-            "output_type": "folder",
-            "color": item.color or "#FFFFFF",
-        }
-
-        # Add to anatomy link_types
-        link_types_list = [lt.model_dump() for lt in anatomy.link_types]
-        link_types_list.append(new_link_type)
-
+        project_name = await normalize_project_name(project_name)
         async with Postgres.transaction():
             await Postgres.set_project_schema(project_name)
+            input_type = kwargs.get("input_type")
+            output_type = kwargs.get("output_type")
+            link_type = kwargs.get("link_type", item.value)
+            style   = kwargs.get("style", "solid")
+
+            if not all([input_type, output_type, link_type]):
+                raise ValueError(
+                    "Missing required parameters: input_type, output_type, link_type"
+                )
             await Postgres.execute(
                 """
-                UPDATE project_anatomy
-                SET data = jsonb_set(data, '{link_types}', to_jsonb($1::jsonb))
-                WHERE name = $2
+                INSERT INTO link_types 
+                    (name, input_type, output_type, link_type, data)
+                VALUES ($1, $2, $3, $4, $5)
                 """,
-                json.dumps(link_types_list),
-                project_name,
+                item.value,
+                input_type,
+                output_type,
+                link_type,
+                {
+                    "color": item.color or "#808080",
+                    "style": style
+                },
             )
-
         return item.value

--- a/ayon_server/enum/resolvers/enum_link_types.py
+++ b/ayon_server/enum/resolvers/enum_link_types.py
@@ -65,10 +65,11 @@ class LinkTypesEnumResolver(BaseEnumResolver):
         project_name = await normalize_project_name(project_name)
         async with Postgres.transaction():
             await Postgres.set_project_schema(project_name)
-            input_type = kwargs.get("input_type")
-            output_type = kwargs.get("output_type")
-            link_type = kwargs.get("link_type", item.value)
-            style = kwargs.get("style", "solid")
+            link_type_params = kwargs["link_type_params"]
+            input_type = link_type_params.get("input_type")
+            output_type = link_type_params.get("output_type")
+            link_type = link_type_params.get("link_type", item.value)
+            style = link_type_params.get("style", "solid")
 
             if not all([input_type, output_type, link_type]):
                 raise ValueError(

--- a/ayon_server/enum/resolvers/enum_link_types.py
+++ b/ayon_server/enum/resolvers/enum_link_types.py
@@ -8,6 +8,7 @@ from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.settings.anatomy import Anatomy
 from ayon_server.settings.anatomy.link_types import LinkType
+from ayon_server.types import SimpleValue
 
 
 def link_type_to_enum_item(link_type: LinkType) -> EnumItem:
@@ -57,8 +58,8 @@ class LinkTypesEnumResolver(BaseEnumResolver):
         self,
         item: EnumItem,
         project_name: str | None = None,
-        **kwargs
-    ) -> str:
+        **kwargs,
+    ) -> SimpleValue:
         if not project_name or project_name == "_":
             raise ValueError("Link types require a project name")
 
@@ -68,7 +69,7 @@ class LinkTypesEnumResolver(BaseEnumResolver):
             input_type = kwargs.get("input_type")
             output_type = kwargs.get("output_type")
             link_type = kwargs.get("link_type", item.value)
-            style   = kwargs.get("style", "solid")
+            style = kwargs.get("style", "solid")
 
             if not all([input_type, output_type, link_type]):
                 raise ValueError(
@@ -76,7 +77,7 @@ class LinkTypesEnumResolver(BaseEnumResolver):
                 )
             await Postgres.execute(
                 """
-                INSERT INTO link_types 
+                INSERT INTO link_types
                     (name, input_type, output_type, link_type, data)
                 VALUES ($1, $2, $3, $4, $5)
                 """,
@@ -84,10 +85,7 @@ class LinkTypesEnumResolver(BaseEnumResolver):
                 input_type,
                 output_type,
                 link_type,
-                {
-                    "color": item.color or "#808080",
-                    "style": style
-                },
+                {"color": item.color or "#808080", "style": style},
             )
         await Redis.delete("project-anatomy", project_name)
         return item.value

--- a/ayon_server/enum/resolvers/enum_link_types.py
+++ b/ayon_server/enum/resolvers/enum_link_types.py
@@ -6,6 +6,7 @@ from ayon_server.enum.enum_item import EnumItem
 from ayon_server.helpers.anatomy import get_project_anatomy
 from ayon_server.helpers.project_list import normalize_project_name
 from ayon_server.lib.postgres import Postgres
+from ayon_server.lib.redis import Redis
 from ayon_server.settings.anatomy import Anatomy
 from ayon_server.settings.anatomy.link_types import LinkType
 
@@ -89,4 +90,5 @@ class LinkTypesEnumResolver(BaseEnumResolver):
                     "style": style
                 },
             )
+        await Redis.delete("project-anatomy", project_name)
         return item.value

--- a/ayon_server/enum/resolvers/enum_link_types.py
+++ b/ayon_server/enum/resolvers/enum_link_types.py
@@ -1,4 +1,5 @@
 from typing import Any
+import json
 
 from ayon_server.enum.base_resolver import BaseEnumResolver
 from ayon_server.enum.enum_item import EnumItem
@@ -50,3 +51,49 @@ class LinkTypesEnumResolver(BaseEnumResolver):
         if not project_name or project_name == "_":
             return await _resolve_link_types_studio()
         return await _resolve_link_types_project(project_name)
+
+    async def create_item(
+        self,
+        item: EnumItem,
+        project_name: str | None = None,
+        **kwargs
+    ) -> str:
+        if not project_name or project_name == "_":
+            raise ValueError("Link types require a project name")
+
+        from ayon_server.settings.anatomy import Anatomy
+
+        # Get current anatomy
+        anatomy = await get_project_anatomy(project_name)
+
+        # Check if item with same name already exists
+        for lt in anatomy.link_types:
+            if lt.name == item.value:
+                return item.value
+
+        # Create new link type
+        new_link_type = {
+            "name": item.value,
+            "link_type": item.value.lower().replace(" ", "_"),
+            "input_type": "folder",
+            "output_type": "folder",
+            "color": item.color or "#FFFFFF",
+        }
+
+        # Add to anatomy link_types
+        link_types_list = [lt.model_dump() for lt in anatomy.link_types]
+        link_types_list.append(new_link_type)
+
+        async with Postgres.transaction():
+            await Postgres.set_project_schema(project_name)
+            await Postgres.execute(
+                """
+                UPDATE project_anatomy
+                SET data = jsonb_set(data, '{link_types}', to_jsonb($1::jsonb))
+                WHERE name = $2
+                """,
+                json.dumps(link_types_list),
+                project_name,
+            )
+
+        return item.value


### PR DESCRIPTION
## Description of changes

This PR adds new method to `BaseEnumResolver` and implements it for enums where it makes sense.

This provides at least some api for creation of new enum items, as the logic/format/destination might be different for each of the enums.

### Additional context

Logic in `enum_anatomy` could be refactored, maybe added as default behavior to `BaseEnumResolver` but that didn't seem right as current implemention is field tested by `data_import`.
