### PR TITLE
Fixed addon loading isolation

### DIFF
--- a/ayon_server/helpers/modules.py
+++ b/ayon_server/helpers/modules.py
@@ -1,17 +1,83 @@
+import builtins
 import importlib.util
 import inspect
 import os
 import sys
 from types import ModuleType
-from typing import TypeVar
+from typing import Any, TypeVar
 
 T = TypeVar("T", bound=type)
+
+# Registry of addon namespaces: unique_name -> addon_base_dir
+_ADDON_REGISTRY: dict[str, str] = {}
+_original_import = builtins.__import__
+
+
+def _isolated_import(
+    name: str,
+    globals: dict[str, Any] | None = None,
+    locals: dict[str, Any] | None = None,
+    fromlist: tuple[str, ...] = (),
+    level: int = 0,
+):
+    """
+    Custom __import__ that redirects 'server' and other addon-local imports
+    to the unique addon namespace.
+    """
+
+    if level > 0:
+        # Relative import, let it be
+        return _original_import(name, globals, locals, fromlist, level)
+
+    mod_name = globals.get("__name__") if globals else None
+    if not mod_name:
+        try:
+            f = sys._getframe(1)
+            while f:
+                mod_name = f.f_globals.get("__name__")
+                if mod_name:
+                    break
+                f = f.f_back
+        except ValueError:
+            pass
+
+    if mod_name:
+        addon_name = None
+        for name_key in _ADDON_REGISTRY:
+            if mod_name == name_key or mod_name.startswith(name_key + "."):
+                addon_name = name_key
+                break
+
+        if addon_name:
+            target_name = None
+            if name == "server" or name.startswith("server."):
+                target_name = f"{addon_name}.{name}"
+            else:
+                base_dir = _ADDON_REGISTRY[addon_name]
+                if os.path.exists(os.path.join(base_dir, name)) or os.path.exists(
+                    os.path.join(base_dir, name + ".py")
+                ):
+                    target_name = f"{addon_name}.{name}"
+
+            if target_name:
+                if fromlist:
+                    return _original_import(
+                        target_name, globals, locals, fromlist, level
+                    )
+                else:
+                    return importlib.import_module(target_name)
+
+    return _original_import(name, globals, locals, fromlist, level)
+
+
+# Global patch
+builtins.__import__ = _isolated_import
 
 
 def import_module(name: str, path: str) -> ModuleType:
     """
     Imports a plugin module into a unique namespace to prevent collisions.
-    Example: 'my_plugin.v1_0_0.server'
+    Example: 'my-addon-v1-0-0.server'
     """
 
     server_dir = os.path.dirname(os.path.abspath(path))
@@ -20,30 +86,34 @@ def import_module(name: str, path: str) -> ModuleType:
     else:
         base_dir = server_dir
 
-    # Add the dir containing the module (or its parent, for 'server' packages)
-    # to sys.path temporarily.
-    # This allows: 'from server.subfolder import module' in addons when appropriate.
-    sys.path.insert(0, base_dir)
+    # Only register for isolation if name is a valid python identifier
+    if name.replace("-", "_").replace(".", "_").isidentifier():
+        _ADDON_REGISTRY[name] = base_dir
 
-    try:
-        spec = importlib.util.spec_from_file_location(name, path)
-        if spec is None or spec.loader is None:
-            raise ImportError(f"Could not load spec for {name}")
+    # Ensure the root package for the unique name exists
+    if name not in sys.modules:
+        root_module = ModuleType(name)
+        root_module.__path__ = [base_dir]
+        sys.modules[name] = root_module
 
-        module = importlib.util.module_from_spec(spec)
+    # Load the actual entry point as name.server (or just name if not a server package)
+    if os.path.basename(server_dir) == "server":
+        module_name = f"{name}.server"
+    else:
+        module_name = name
 
-        # tell the module it belongs to our unique namespace
-        # Even if the file is physically in 'server/main.py'
-        sys.modules[name] = module
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load spec for {module_name}")
 
-        spec.loader.exec_module(module)
-        return module
+    if path.endswith("__init__.py"):
+        spec.submodule_search_locations = [server_dir]
 
-    finally:
-        # Clean up sys.path immediately so the next addon doesn't
-        # accidentally see this plugin's 'server' folder.
-        if base_dir in sys.path:
-            sys.path.remove(base_dir)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    return module
 
 
 def classes_from_module(superclass: T, module: ModuleType) -> list[T]:


### PR DESCRIPTION
This pull request introduces a new mechanism for isolating dynamically loaded addon modules to prevent namespace collisions and improve import safety. The main changes involve patching the Python import system to redirect certain imports to addon-specific namespaces, registering addon base directories, and restructuring how modules are loaded and registered in `sys.modules`.
