### PR TITLE
Per-addon api documentation

### DIFF
--- a/ayon_server/addons/addon.py
+++ b/ayon_server/addons/addon.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
-from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
 
 from ayon_server.actions.config import get_action_config, set_action_config
 from ayon_server.actions.context import ActionContext
@@ -25,14 +25,12 @@ from ayon_server.addons.models import (
     SourceInfo,
     SSOOption,
 )
+from ayon_server.addons.openapi import get_addon_api_docs, get_addon_openapi
 from ayon_server.addons.settings_caching import AddonSettingsCache
-from ayon_server.api.context import get_request_context
-from ayon_server.config import ayonconfig
 from ayon_server.entities.user import UserEntity
 from ayon_server.exceptions import (
     AyonException,
     BadRequestException,
-    ForbiddenException,
     NotFoundException,
 )
 from ayon_server.lib.postgres import Postgres
@@ -229,53 +227,10 @@ class BaseServerAddon:
         )
 
     def get_openapi(self) -> dict[str, Any]:
+        return get_addon_openapi(self)
 
-        if ayonconfig.disable_rest_docs:
-            raise ForbiddenException("OpenAPI documentation is disabled")
-
-        if ayonconfig.openapi_require_authentication:
-            ctx = get_request_context()
-            user = ctx.user
-
-            if user is None:
-                raise ForbiddenException(
-                    "You must be logged in to access addon OpenAPI schema"
-                )
-
-            if not user.is_manager:
-                raise ForbiddenException(
-                    "You are not allowed to access addon OpenAPI schema"
-                )
-
-        prefix = f"/api/addons/{self.name}/{self.version}"
-        temp_app = FastAPI(
-            title=self.definition.friendly_name,
-            version=self.version,
-        )
-        for endpoint in self.endpoints:
-            path = endpoint["path"].lstrip("/")
-            path = f"{prefix}/{path}"
-            temp_app.add_api_route(
-                path,
-                endpoint["handler"],
-                methods=[endpoint["method"]],
-                name=endpoint["name"],
-                description=endpoint["description"],
-                operation_id=endpoint["name"],
-            )
-
-        def generate_unique_id(route):
-            return route.name
-
-        for router in self.routers:
-            temp_app.include_router(
-                router,
-                prefix=prefix,
-                generate_unique_id_function=generate_unique_id,
-            )
-
-        router_openapi = temp_app.openapi()
-        return router_openapi
+    def get_api_docs(self) -> HTMLResponse:
+        return get_addon_api_docs(self)
 
     async def get_frontend_scopes(self) -> FrontendScopes:
         return self.frontend_scopes

--- a/ayon_server/addons/openapi.py
+++ b/ayon_server/addons/openapi.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI
 from fastapi.openapi.docs import get_redoc_html
@@ -60,7 +60,7 @@ def _get_temp_app(addon: "BaseServerAddon") -> FastAPI:
     return temp_app
 
 
-def get_addon_openapi(addon: "BaseServerAddon") -> dict[str, str]:
+def get_addon_openapi(addon: "BaseServerAddon") -> dict[str, Any]:
     """Get OpenAPI schema for the addon"""
     temp_app = _get_temp_app(addon)
     router_openapi = temp_app.openapi()

--- a/ayon_server/addons/openapi.py
+++ b/ayon_server/addons/openapi.py
@@ -1,0 +1,80 @@
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI
+from fastapi.openapi.docs import get_redoc_html
+from fastapi.responses import HTMLResponse
+
+from ayon_server.api.context import get_request_context
+from ayon_server.config import ayonconfig
+from ayon_server.exceptions import ForbiddenException
+
+if TYPE_CHECKING:
+    from .addon import BaseServerAddon
+
+
+def _get_temp_app(addon: "BaseServerAddon") -> FastAPI:
+    if ayonconfig.disable_rest_docs:
+        raise ForbiddenException("OpenAPI documentation is disabled")
+
+    if ayonconfig.openapi_require_authentication:
+        ctx = get_request_context()
+        user = ctx.user
+
+        if user is None:
+            raise ForbiddenException(
+                "You must be logged in to access addon OpenAPI schema"
+            )
+
+        if not user.is_manager:
+            raise ForbiddenException(
+                "You are not allowed to access addon OpenAPI schema"
+            )
+
+    prefix = f"/api/addons/{addon.name}/{addon.version}"
+    temp_app = FastAPI(
+        title=addon.definition.friendly_name,
+        version=addon.version,
+    )
+    for endpoint in addon.endpoints:
+        path = endpoint["path"].lstrip("/")
+        path = f"{prefix}/{path}"
+        temp_app.add_api_route(
+            path,
+            endpoint["handler"],
+            methods=[endpoint["method"]],
+            name=endpoint["name"],
+            description=endpoint["description"],
+            operation_id=endpoint["name"],
+        )
+
+    def generate_unique_id(route):
+        return route.name
+
+    for router in addon.routers:
+        temp_app.include_router(
+            router,
+            prefix=prefix,
+            generate_unique_id_function=generate_unique_id,
+        )
+
+    return temp_app
+
+
+def get_addon_openapi(addon: "BaseServerAddon") -> dict[str, str]:
+    """Get OpenAPI schema for the addon"""
+    temp_app = _get_temp_app(addon)
+    router_openapi = temp_app.openapi()
+    return router_openapi
+
+
+def get_addon_api_docs(addon: "BaseServerAddon") -> HTMLResponse:
+    """Get API docs for the addon"""
+
+    openapi_url = f"/api/addons/{addon.name}/{addon.version}/openapi.json"
+    title = addon.friendly_name
+
+    return get_redoc_html(
+        openapi_url=openapi_url,
+        title=title,
+        redoc_js_url="/docs/redoc.standalone.js",
+    )

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -95,6 +95,17 @@ def init_addon_endpoints(target_app: "FastAPI") -> None:
                     ),
                 )
 
+                target_app.add_api_route(
+                    f"/api/addons/{addon_name}/{version}/api-docs",
+                    addon.get_api_docs,
+                    include_in_schema=False,
+                    methods=["GET"],
+                    name=f"{addon_name}_{version}_docs",
+                    operation_id=slugify(
+                        f"{addon_name}_{version}_api_docs", separator="_"
+                    ),
+                )
+
 
 def init_addon_static(target_app: "FastAPI") -> None:
     """Serve static files for addon frontends."""


### PR DESCRIPTION
This pull request refactors how OpenAPI schema and API documentation are generated and served for addons. The main change is moving the logic for generating OpenAPI docs and API documentation HTML from the `BaseServerAddon` class into a new module, improving code organization and maintainability. Additionally, it introduces a dedicated API route for serving API docs for each addon.

**Refactoring and code organization:**
* Moved the logic for generating OpenAPI schema and API documentation HTML from `BaseServerAddon` in `addon.py` to a new module `openapi.py`, encapsulating this functionality in `get_addon_openapi` and `get_addon_api_docs` functions.
* 
**API documentation improvements:**
* Added a new API route `/api/addons/{addon_name}/{version}/api-docs` for each addon, which serves the API documentation using the new `get_api_docs` method.
* The new implementation ensures that OpenAPI docs respect configuration flags for disabling docs and requiring authentication, and checks user permissions before serving docs

**Dependency and import updates:**
* Updated imports in `addon.py` to use the new `openapi` module and removed now-unnecessary imports.