### PR TITLE
GraphQL: add descendant entities counts to folder node

### DIFF
--- a/ayon_server/entities/grouping/resolvers.py
+++ b/ayon_server/entities/grouping/resolvers.py
@@ -187,34 +187,6 @@ async def get_attrib_groups(
     return groups
 
 
-async def get_folder_groups(project_name: str) -> list[EntityGroup]:
-    """Get task groups based on parent folder."""
-    groups: list[EntityGroup] = []
-
-    query = f"""
-        WITH folder_counts AS (
-            SELECT count(*) AS count, folder_id
-            FROM project_{project_name}.tasks
-            GROUP BY folder_id
-        )
-        SELECT
-            f.id AS value,
-            COALESCE(f.label, f.name) AS label,
-            COALESCE(folder_counts.count, 0) AS count
-        FROM project_{project_name}.folders f
-        LEFT JOIN folder_counts ON f.id = folder_counts.folder_id
-    """
-    result = await Postgres.fetch(query)
-    for row in result:
-        group = EntityGroup(
-            value=row["value"],
-            label=row["label"],
-            count=row["count"],
-        )
-        groups.append(group)
-    return groups
-
-
 async def get_tags_groups(
     project_name: str,
     entity_type: ProjectLevelEntityType,

--- a/ayon_server/entities/grouping/resolvers.py
+++ b/ayon_server/entities/grouping/resolvers.py
@@ -187,6 +187,34 @@ async def get_attrib_groups(
     return groups
 
 
+async def get_folder_groups(project_name: str) -> list[EntityGroup]:
+    """Get task groups based on parent folder."""
+    groups: list[EntityGroup] = []
+
+    query = f"""
+        WITH folder_counts AS (
+            SELECT count(*) AS count, folder_id
+            FROM project_{project_name}.tasks
+            GROUP BY folder_id
+        )
+        SELECT
+            f.id AS value,
+            COALESCE(f.label, f.name) AS label,
+            COALESCE(folder_counts.count, 0) AS count
+        FROM project_{project_name}.folders f
+        LEFT JOIN folder_counts ON f.id = folder_counts.folder_id
+    """
+    result = await Postgres.fetch(query)
+    for row in result:
+        group = EntityGroup(
+            value=row["value"],
+            label=row["label"],
+            count=row["count"],
+        )
+        groups.append(group)
+    return groups
+
+
 async def get_tags_groups(
     project_name: str,
     entity_type: ProjectLevelEntityType,

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -47,6 +47,8 @@ class FolderNode(BaseNode):
     task_count: int = strawberry.field(default=0)
     has_versions: bool = strawberry.field(default=False)
     has_reviewables: bool = strawberry.field(default=False)
+    descendant_count: int = strawberry.field(default=0)
+    descendant_task_count: int = strawberry.field(default=0)
 
     products: ProductsConnection = strawberry.field(
         resolver=get_products,
@@ -156,6 +158,8 @@ async def folder_from_record(
         task_count=record.get("task_count", 0),
         has_reviewables=has_reviewables,
         has_versions=record.get("has_versions", False),
+        descendant_count=record.get("descendant_count", 0),
+        descendant_task_count=record.get("descendant_task_count", 0),
         path=path,
         _folder_path=path,
         _attrib=record["attrib"] or {},

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -47,8 +47,10 @@ class FolderNode(BaseNode):
     task_count: int = strawberry.field(default=0)
     has_versions: bool = strawberry.field(default=False)
     has_reviewables: bool = strawberry.field(default=False)
-    descendant_count: int = strawberry.field(default=0)
-    descendant_task_count: int = strawberry.field(default=0)
+    total_folder_count: int = strawberry.field(default=0)
+    total_task_count: int = strawberry.field(default=0)
+    total_product_count: int = strawberry.field(default=0)
+    total_version_count: int = strawberry.field(default=0)
 
     products: ProductsConnection = strawberry.field(
         resolver=get_products,
@@ -158,8 +160,10 @@ async def folder_from_record(
         task_count=record.get("task_count", 0),
         has_reviewables=has_reviewables,
         has_versions=record.get("has_versions", False),
-        descendant_count=record.get("descendant_count", 0),
-        descendant_task_count=record.get("descendant_task_count", 0),
+        total_folder_count=record.get("total_folder_count", 0),
+        total_task_count=record.get("total_task_count", 0),
+        total_product_count=record.get("total_product_count", 0),
+        total_version_count=record.get("total_version_count", 0),
         path=path,
         _folder_path=path,
         _attrib=record["attrib"] or {},

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -179,6 +179,19 @@ async def get_folders(
             """
         )
 
+    if fields.has_any("descendantCount"):
+        sql_columns.append(
+            f"""(SELECT COUNT(*) FROM project_{project_name}.hierarchy h2
+            WHERE h2.path LIKE hierarchy.path || '/%') AS descendant_count"""
+        )
+
+    if fields.has_any("descendantTaskCount"):
+        sql_columns.append(
+            f"""(SELECT COUNT(*) FROM project_{project_name}.tasks t
+            JOIN project_{project_name}.hierarchy h2 ON t.folder_id = h2.id
+            WHERE h2.path LIKE hierarchy.path || '/%') AS descendant_task_count"""
+        )
+
     if fields.any_endswith("hasReviewables"):
         sql_cte.append(
             f"""

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -179,17 +179,25 @@ async def get_folders(
             """
         )
 
+    descendant_access_condition = ""
+    if access_list is not None:
+        descendant_access_condition = (
+            f" AND h2.path like ANY ('{{ {','.join(access_list)} }}')"
+        )
+
     if fields.has_any("descendantCount"):
         sql_columns.append(
             f"""(SELECT COUNT(*) FROM project_{project_name}.hierarchy h2
-            WHERE h2.path LIKE hierarchy.path || '/%') AS descendant_count"""
+            WHERE starts_with(h2.path, hierarchy.path || '/')
+            {descendant_access_condition}) AS descendant_count"""
         )
 
     if fields.has_any("descendantTaskCount"):
         sql_columns.append(
             f"""(SELECT COUNT(*) FROM project_{project_name}.tasks t
             JOIN project_{project_name}.hierarchy h2 ON t.folder_id = h2.id
-            WHERE h2.path LIKE hierarchy.path || '/%') AS descendant_task_count"""
+            WHERE starts_with(h2.path, hierarchy.path || '/')
+            {descendant_access_condition}) AS descendant_task_count"""
         )
 
     if fields.any_endswith("hasReviewables"):

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -179,26 +179,39 @@ async def get_folders(
             """
         )
 
-    descendant_access_condition = ""
-    if access_list is not None:
-        descendant_access_condition = (
-            f" AND h2.path like ANY ('{{ {','.join(access_list)} }}')"
-        )
+    # Total count fields (for delete info). Only computed when ids filter
+    # is provided to prevent expensive full-project scans.
+    if ids is not None:
+        if fields.has_any("totalFolderCount"):
+            sql_columns.append(
+                f"""(SELECT COUNT(*) FROM project_{project_name}.hierarchy h2
+                WHERE starts_with(h2.path, hierarchy.path || '/')) AS total_folder_count"""
+            )
 
-    if fields.has_any("descendantCount"):
-        sql_columns.append(
-            f"""(SELECT COUNT(*) FROM project_{project_name}.hierarchy h2
-            WHERE starts_with(h2.path, hierarchy.path || '/')
-            {descendant_access_condition}) AS descendant_count"""
-        )
+        if fields.has_any("totalTaskCount"):
+            sql_columns.append(
+                f"""(SELECT COUNT(*) FROM project_{project_name}.tasks t
+                JOIN project_{project_name}.hierarchy h2 ON t.folder_id = h2.id
+                WHERE h2.path = hierarchy.path
+                OR starts_with(h2.path, hierarchy.path || '/')) AS total_task_count"""
+            )
 
-    if fields.has_any("descendantTaskCount"):
-        sql_columns.append(
-            f"""(SELECT COUNT(*) FROM project_{project_name}.tasks t
-            JOIN project_{project_name}.hierarchy h2 ON t.folder_id = h2.id
-            WHERE starts_with(h2.path, hierarchy.path || '/')
-            {descendant_access_condition}) AS descendant_task_count"""
-        )
+        if fields.has_any("totalProductCount"):
+            sql_columns.append(
+                f"""(SELECT COUNT(*) FROM project_{project_name}.products p
+                JOIN project_{project_name}.hierarchy h2 ON p.folder_id = h2.id
+                WHERE h2.path = hierarchy.path
+                OR starts_with(h2.path, hierarchy.path || '/')) AS total_product_count"""
+            )
+
+        if fields.has_any("totalVersionCount"):
+            sql_columns.append(
+                f"""(SELECT COUNT(*) FROM project_{project_name}.versions v
+                JOIN project_{project_name}.products p ON v.product_id = p.id
+                JOIN project_{project_name}.hierarchy h2 ON p.folder_id = h2.id
+                WHERE h2.path = hierarchy.path
+                OR starts_with(h2.path, hierarchy.path || '/')) AS total_version_count"""
+            )
 
     if fields.any_endswith("hasReviewables"):
         sql_cte.append(


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes
 Add descendantCount and descendantTaskCount fields to the FolderNode GraphQL type. These fields provide recursive counts of all subfolder and task descendants for a given folder, enabling the frontend to display deletion impact info (e.g. "this will delete N subfolders containing M tasks").

 Fields are lazy — the underlying SQL subqueries only execute when the fields are requested in the GraphQL query, so there is zero performance impact on existing queries.
<!-- Please state what you've changed and how it might affect the user. -->

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

- Uses correlated subqueries on the existing hierarchy.path column (path prefix matching) instead of recursive CTEs, keeping the implementation lightweight
- Follows the same conditional pattern as existing childCount, productCount, taskCount fields
- Three files changed: FolderNode fields, folder_from_record mapping, resolver subquery injection

### Additional context

<!-- Add any other context or screenshots here. -->

 Frontend needs to include descendantCount / descendantTaskCount in its GraphQL query to utilize these fields (e.g. in a delete confirmation dialog).
 
 
 related [#frontend/1922](https://github.com/ynput/ayon-frontend/pull/1922)
