### PR TITLE
Extended text search in graphql

### DIFF
--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -352,14 +352,21 @@ async def get_folders(
         sql_conditions.append(cond)
 
     if search:
-        terms = slugify(search, make_set=True)
-        for term in terms:
-            term = term.replace("'", "''")
-            sql_conditions.append(
-                f"(folders.name ILIKE '%{term}%' OR "
-                f"folders.label ILIKE '%{term}%' OR "
-                f"hierarchy.path ILIKE '%{term}%')"
-            )
+        parts = search.split(",")
+        t1_conds = []
+
+        for part in parts:
+            terms = slugify(part, make_set=True)
+            t2_conds = []
+            for term in terms:
+                term = term.replace("'", "''")
+                t2_conds.append(
+                    f"(folders.name ILIKE '%{term}%' OR "
+                    f"folders.label ILIKE '%{term}%' OR "
+                    f"hierarchy.path ILIKE '%{term}%')"
+                )
+            t1_conds.append(SQLTool.conditions(t2_conds, "AND", add_where=False))
+        sql_conditions.append(SQLTool.conditions(t1_conds, "OR", add_where=False))
 
     #
     # Filter

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -359,7 +359,6 @@ async def get_folders(
             terms = slugify(part, make_set=True)
             t2_conds = []
             for term in terms:
-                term = term.replace("'", "''")
                 t2_conds.append(
                     f"(folders.name ILIKE '%{term}%' OR "
                     f"folders.label ILIKE '%{term}%' OR "

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -431,16 +431,21 @@ async def get_tasks(
 
     if search:
         use_folder_query = True
-        terms = slugify(search, make_set=True)
-        # isn't it nice that slugify effectively prevents sql injections?
-        for term in terms:
-            cond = f"""(
-            tasks.name ILIKE '%{term}%'
-            OR tasks.label ILIKE '%{term}%'
-            OR tasks.task_type ILIKE '%{term}%'
-            OR hierarchy.path ILIKE '%{term}%'
-            )"""
-            sql_conditions.append(cond)
+        parts = search.split(",")
+        t1_conds = []
+
+        for part in parts:
+            terms = slugify(part, make_set=True)
+            t2_conds = []
+            for term in terms:
+                t2_conds.append(
+                    f"(tasks.name ILIKE '%{term}%'"
+                    f"OR tasks.label ILIKE '%{term}%'"
+                    f"OR tasks.task_type ILIKE '%{term}%'"
+                    f"OR hierarchy.path ILIKE '%{term}%')"
+                )
+            t1_conds.append(SQLTool.conditions(t2_conds, "AND", add_where=False))
+        sql_conditions.append(SQLTool.conditions(t1_conds, "OR", add_where=False))
 
     #
     # Additional joins


### PR DESCRIPTION
This pull request improves the search functionality in both the `get_folders` and `get_tasks` GraphQL resolver functions. The main change is to support searching with multiple comma-separated terms, making the search more flexible and powerful.

Search string is split by a coma and those parts are evaluated using OR operator, and each part is slugified and evaluated using AND operator. That extends the search, so it is possible to search for multiple folders/tasks at once while maintaining 100% backwards compatibility

<img width="925" height="421" alt="image" src="https://github.com/user-attachments/assets/6f94b069-71a0-493d-b477-8e62686b9258" />