### PR TITLE
Fix user enum access

### DIFF
--- a/ayon_server/enum/resolvers/enum_users.py
+++ b/ayon_server/enum/resolvers/enum_users.py
@@ -24,49 +24,57 @@ class UsersEnumResolver(BaseEnumResolver):
 
         project_name = context.get("project_name")
         current_user = context.get("user")
-        if current_user and not current_user.is_manager:
+
+        skip_if_not_ag = None
+        has_all_user_access = False
+
+        if not current_user:
+            # If there is no current user, we assume this is a system process
+            # that has access to all users.
+            has_all_user_access = True
+        else:
+            try:
+                current_user.check_permissions("studio.list_all_users")
+            except ForbiddenException:
+                # normal user without studio-wide access
+                if ayonconfig.limit_user_visibility:
+                    skip_if_not_ag = current_user.data.get("accessGroups", {}).get(
+                        project_name, []
+                    )
+            else:
+                has_all_user_access = True
+
+        if not has_all_user_access:
             if not project_name:
                 # Non-managers can only query users within a project
                 # they have access to.
-                raise ForbiddenException("Project name is required for non-admins")
+                raise ForbiddenException(
+                    "You don't have access to studio-wide user list"
+                )
 
+            assert current_user is not None  # for mypy
             current_user_ags = current_user.data.get("accessGroups", {}).get(
                 project_name, []
             )
             if not current_user_ags:
                 raise ForbiddenException("You don't have access to this project")
 
-        skip_if_not_ag = None
-        if (
-            ayonconfig.limit_user_visibility
-            and current_user
-            and not current_user.is_manager
-        ):
-            skip_if_not_ag = current_user.data.get("accessGroups", {}).get(
-                project_name, []
-            )
-
         def should_show_user(udata: dict[str, Any]) -> bool:
             is_admin = udata.get("isAdmin", False)
             is_manager = udata.get("isManager", False)
 
             if is_admin or is_manager:
-                return True
-
-            if not current_user:
+                # we always show admins and managers
                 return True
 
             if not project_name:
-                return current_user.is_manager
+                return has_all_user_access
 
             # now we are in project scope
 
             ags = udata.get("accessGroups", {}).get(project_name, [])
             if not ags:
                 return False
-
-            if current_user.is_manager:
-                return True
 
             if not skip_if_not_ag:
                 return True

--- a/ayon_server/enum/resolvers/enum_users.py
+++ b/ayon_server/enum/resolvers/enum_users.py
@@ -3,6 +3,7 @@ from typing import Any
 from ayon_server.config import ayonconfig
 from ayon_server.enum.base_resolver import BaseEnumResolver
 from ayon_server.enum.enum_item import EnumItem
+from ayon_server.exceptions import ForbiddenException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.models import IconModel
 
@@ -23,33 +24,62 @@ class UsersEnumResolver(BaseEnumResolver):
 
         project_name = context.get("project_name")
         current_user = context.get("user")
-        if current_user and not current_user.is_manager and not project_name:
-            # Non-managers can only query users within a project
-            # they have access to.
-            return []
+        if current_user and not current_user.is_manager:
+            if not project_name:
+                # Non-managers can only query users within a project
+                # they have access to.
+                raise ForbiddenException("Project name is required for non-admins")
+
+            current_user_ags = current_user.data.get("accessGroups", {}).get(
+                project_name, []
+            )
+            if not current_user_ags:
+                raise ForbiddenException("You don't have access to this project")
 
         skip_if_not_ag = None
-        if ayonconfig.limit_user_visibility and current_user:
+        if (
+            ayonconfig.limit_user_visibility
+            and current_user
+            and not current_user.is_manager
+        ):
             skip_if_not_ag = current_user.data.get("accessGroups", {}).get(
                 project_name, []
             )
+
+        def should_show_user(udata: dict[str, Any]) -> bool:
+            is_admin = udata.get("isAdmin", False)
+            is_manager = udata.get("isManager", False)
+
+            if is_admin or is_manager:
+                return True
+
+            if not current_user:
+                return True
+
+            if not project_name:
+                return current_user.is_manager
+
+            # now we are in project scope
+
+            ags = udata.get("accessGroups", {}).get(project_name, [])
+            if not ags:
+                return False
+
+            if current_user.is_manager:
+                return True
+
+            if not skip_if_not_ag:
+                return True
+
+            return bool(set(ags).intersection(set(skip_if_not_ag)))
 
         async with Postgres.transaction():
             stmt = await Postgres.prepare(query)
             async for row in stmt.cursor():
                 name, attrib, udata = row
 
-                is_admin = udata.get("isAdmin", False)
-                is_manager = udata.get("isManager", False)
-
-                if not (is_admin or is_manager):
-                    ags = udata.get("accessGroups", {}).get(project_name, [])
-                    if not ags:
-                        continue
-
-                    if skip_if_not_ag is not None:
-                        if not set(ags).intersection(set(skip_if_not_ag)):
-                            continue
+                if not should_show_user(udata):
+                    continue
 
                 item = EnumItem(
                     value=name,


### PR DESCRIPTION
This pull request updates the user enumeration logic in `enum_users.py` to strengthen access control and improve code clarity. The main changes revolve around enforcing project-based access restrictions for non-manager users and refactoring the user visibility logic into a dedicated function.

**Access control improvements:**

* Non-manager users are now explicitly required to specify a `project_name` when querying users; if not provided, a `ForbiddenException` is raised to prevent unauthorized access.
* If a non-manager user does not have access groups for the specified project, a `ForbiddenException` is raised, further tightening security.
* The logic that determines whether a user should be visible is now encapsulated in a new `should_show_user` function, making the code more readable and maintainable.
* The previous inline logic for filtering users based on access groups and roles has been replaced by calls to this new function, reducing duplication and potential errors.

**Exception handling:**

* Added import for `ForbiddenException` to support the new access control checks.