### PR TITLE
Views: Add `display_style` property to ReviewsSettings model

### DIFF
--- a/ayon_server/views/models.py
+++ b/ayon_server/views/models.py
@@ -92,6 +92,8 @@ FViewVisibility = Annotated[
     ),
 ]
 
+FDisplayStyle = Literal["cards", "table", "playlist"] | None
+
 
 # Shared submodels
 
@@ -153,6 +155,7 @@ class ListsSettings(OPModel):
 
 class ReviewsSettings(ListsSettings):
     grid_height: int | None = None
+    display_style: FDisplayStyle = None
 
 
 class VersionsSettings(OPModel):


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

Adds a `display_style` property to the `ReviewsSettings` model which allows us to store the chosen display style (grid/table/playlist) in Views.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

The Grid style is internally called `cards` for historical reasons.

### Additional context

<!-- Add any other context or screenshots here. -->

https://github.com/ynput/ayon-frontend/issues/1914
