### PR TITLE
Fix: use the same text search logic in graphql and taskFolders endpoint

### DIFF
--- a/api/tasks_folders/tasks_folders.py
+++ b/api/tasks_folders/tasks_folders.py
@@ -83,16 +83,21 @@ async def query_tasks_folders(
             conditions.append(filter)
 
     if request.search:
-        terms = slugify(request.search, make_set=True)
-        # isn't it nice that slugify effectively prevents sql injections?
-        for term in terms:
-            cond = f"""(
-            tasks.name ILIKE '{term}%'
-            OR tasks.label ILIKE '{term}%'
-            OR tasks.task_type ILIKE '{term}%'
-            OR f.path ILIKE '%{term}%'
-            )"""
-            conditions.append(cond)
+        parts = request.search.split(",")
+        t1_conds = []
+
+        for part in parts:
+            terms = slugify(part, make_set=True)
+            t2_conds = []
+            for term in terms:
+                t2_conds.append(
+                    f"(tasks.name ILIKE '%{term}%'"
+                    f"OR tasks.label ILIKE '%{term}%'"
+                    f"OR tasks.task_type ILIKE '%{term}%'"
+                    f"OR f.path ILIKE '%{term}%')"
+                )
+            t1_conds.append(SQLTool.conditions(t2_conds, "AND", add_where=False))
+        conditions.append(SQLTool.conditions(t1_conds, "OR", add_where=False))
 
     if not conditions:
         raise BadRequestException("No filter or search term provided")


### PR DESCRIPTION
This pull request updates the search functionality in the `query_tasks_folders` endpoint to support more flexible and powerful search queries. The main improvement is the ability to handle multiple comma-separated search terms, applying each as a group of ANDed conditions, and then combining these groups with OR logic. This allows users to perform more complex searches across tasks and folders.

**Improvements to search logic:**

* Enhanced the search filter in `query_tasks_folders` to support comma-separated search terms, where each comma-separated part is treated as an AND group, and all groups are combined with OR logic for more flexible querying.
* Changed the search to match terms anywhere in the field values (using `%{term}%` instead of `{term}%`), making searches more comprehensive and user-friendly.