### PR TITLE
BaseTypes:  Filter and grouping

### DIFF
--- a/api/grouping/grouping.py
+++ b/api/grouping/grouping.py
@@ -11,6 +11,7 @@ from ayon_server.entities.grouping.common import EntityGroup
 from ayon_server.entities.grouping.resolvers import (
     get_assignees_groups,
     get_attrib_groups,
+    get_product_base_type_groups,
     get_product_type_groups,
     get_status_or_type_groups,
     get_tags_groups,
@@ -27,6 +28,7 @@ TOP_LEVEL_GROUPING_KEYS = {
     "taskType": "task_type",
     "folderType": "folder_type",
     "productType": "product_type",
+    "productBaseType": "product_base_type",
     "assignees": "assignees",
     "status": "status",
     "tags": "tags",
@@ -110,6 +112,9 @@ async def get_entity_groups(
 
     elif key == "product_type":
         groups = await get_product_type_groups(project_name)
+
+    elif key == "product_base_type":
+        groups = await get_product_base_type_groups(project_name)
 
     elif key == "tags":
         groups = await get_tags_groups(

--- a/ayon_server/entities/grouping/resolvers.py
+++ b/ayon_server/entities/grouping/resolvers.py
@@ -271,3 +271,54 @@ async def get_product_type_groups(
         )
         groups.append(group)
     return groups
+
+
+async def get_product_base_type_groups(
+    project_name: str,
+) -> list[EntityGroup]:
+    """
+    Retrieve product groups based on product base types for the given project.
+
+    Returns one group per base type defined in the project anatomy
+    (with count=0 if unused), plus any orphan base type values present
+    in the products table that are not in the anatomy definitions.
+    """
+    anatomy = await get_project_anatomy(project_name)
+
+    query = f"""
+        SELECT count(*) AS count, product_base_type AS value
+        FROM project_{project_name}.products
+        WHERE product_base_type IS NOT NULL
+        GROUP BY product_base_type
+    """
+    result = await Postgres.fetch(query)
+    counts = {row["value"]: row["count"] for row in result}
+
+    groups: list[EntityGroup] = []
+    seen: set[str] = set()
+    for pt in anatomy.product_base_types.definitions:
+        groups.append(
+            EntityGroup(
+                value=pt.name,
+                label=pt.name,
+                icon=pt.icon or anatomy.product_base_types.default.icon,
+                color=pt.color or anatomy.product_base_types.default.color,
+                count=counts.get(pt.name, 0),
+            )
+        )
+        seen.add(pt.name)
+
+    for value, count in counts.items():
+        if value in seen:
+            continue
+        groups.append(
+            EntityGroup(
+                value=value,
+                label=value,
+                icon=anatomy.product_base_types.default.icon,
+                color=anatomy.product_base_types.default.color,
+                count=count,
+            )
+        )
+
+    return groups

--- a/ayon_server/entities/grouping/resolvers.py
+++ b/ayon_server/entities/grouping/resolvers.py
@@ -282,13 +282,20 @@ async def get_product_base_type_groups(
     Returns one group per base type defined in the project anatomy
     (with count=0 if unused), plus any orphan base type values present
     in the products table that are not in the anatomy definitions.
+
+    For backwards compatibility with projects not yet fully migrated,
+    products with a NULL product_base_type fall back to their product_type.
     """
     anatomy = await get_project_anatomy(project_name)
 
     query = f"""
+        WITH base_types_with_fallback AS (
+            SELECT
+                COALESCE(product_base_type, product_type) AS product_base_type
+            FROM project_{project_name}.products
+        )
         SELECT count(*) AS count, product_base_type AS value
-        FROM project_{project_name}.products
-        WHERE product_base_type IS NOT NULL
+        FROM base_types_with_fallback
         GROUP BY product_base_type
     """
     result = await Postgres.fetch(query)

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -524,6 +524,7 @@ async def get_versions(
             "updated_by",
             # virtual
             "product_type",
+            "product_base_type",
             "task_type",
             "folder_type",
             "hero_version_id",
@@ -537,6 +538,7 @@ async def get_versions(
             table_prefix="versions",
             column_map={
                 "product_type": "products.product_type",
+                "product_base_type": "products.product_base_type",
                 "task_type": "tasks.task_type",
                 "folder_type": "folders.folder_type",
                 "hero_version_id": "hero_versions.hero_version_id",
@@ -550,6 +552,7 @@ async def get_versions(
             "name",
             "folder_id",
             "product_type",
+            "product_base_type",
             "status",
             "attrib",
             "data",

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -506,6 +506,11 @@ async def get_versions(
     # Filter
     #
 
+    # Backwards-compat fallback for projects with NULL product_base_type
+    product_base_type_expr = (
+        "COALESCE(products.product_base_type, products.product_type)"
+    )
+
     if filter:
         column_whitelist = [
             "id",
@@ -538,7 +543,7 @@ async def get_versions(
             table_prefix="versions",
             column_map={
                 "product_type": "products.product_type",
-                "product_base_type": "products.product_base_type",
+                "product_base_type": product_base_type_expr,
                 "task_type": "tasks.task_type",
                 "folder_type": "folders.folder_type",
                 "hero_version_id": "hero_versions.hero_version_id",
@@ -570,6 +575,9 @@ async def get_versions(
             fq,
             column_whitelist=column_whitelist,
             table_prefix="products",
+            column_map={
+                "product_base_type": product_base_type_expr,
+            },
         ):
             sql_conditions.append(fcond)
 


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
Adds `productBaseType` as a top-level grouping key for entity groups. Versions GraphQL resolver now exposes `product_base_type` as a virtual/queryable field joined from the `products` table.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

- New resolver `get_product_base_type_groups` in `ayon_server/entities/grouping/resolvers.py`. Returns one group per base type defined in project anatomy (count=0 if unused), plus orphan values found in `products.product_base_type` that aren't in the anatomy. Icon/color sourced from anatomy definitions, falling back to `product_base_types.default`.
- `api/grouping/grouping.py`: registered `productBaseType` → `product_base_type` in `TOP_LEVEL_GROUPING_KEYS` and routed to the new resolver.                                      
- `ayon_server/graphql/resolvers/versions.py`: added `product_base_type` to allowed columns, column_map (`products.product_base_type`), and product subselect — mirrors existing `product_type` handling.

### Additional context
Frontend [#1939](https://github.com/ynput/ayon-frontend/pull/1939)
<!-- Add any other context or screenshots here. -->
