### PR TITLE
Fix skeleton project handling in inbox

### DIFF
--- a/schemas/schema.public.sql
+++ b/schemas/schema.public.sql
@@ -363,7 +363,7 @@ BEGIN
     FOR project IN
       SELECT p.name FROM projects AS p JOIN users AS u ON u.name = user_name
       WHERE (show_active_projects IS NULL OR p.active = show_active_projects)
-      AND p.data->>'isSkeleton' != 'true'
+      AND (p.data->>'isSkeleton' IS DISTINCT FROM  'true')
       AND (
         (
           (u.data->'isManager')::boolean


### PR DESCRIPTION
This pull request updates the SQL query logic for filtering projects in the `schemas/schema.public.sql` file. The change improves how projects marked as skeletons are excluded from the results.

Query logic improvement:

* Updated the condition that filters out skeleton projects to use `IS DISTINCT FROM 'true'` instead of a direct inequality check, which handles cases where the `isSkeleton` field is `NULL`.