### PR TITLE
Added argument to filter support accounts

### DIFF
--- a/ayon_server/graphql/resolvers/users.py
+++ b/ayon_server/graphql/resolvers/users.py
@@ -99,9 +99,17 @@ async def get_users(
 
     # Filter by isSupport
     if is_support is not None:
-        sql_conditions.append(
-            f"users.data->>'isSupport' = '{'true' if is_support else 'false'}'"
-        )
+        if is_support:
+            # Only users with isSupport explicitly set to true
+            sql_conditions.append(
+                "users.data->>'isSupport' = 'true'"
+            )
+        else:
+            # Users where isSupport is false OR not set (NULL)
+            sql_conditions.append(
+                "(users.data->>'isSupport' = 'false' OR "
+                "users.data->>'isSupport' IS NULL)"
+            )
 
     # Filter by project
 

--- a/ayon_server/graphql/resolvers/users.py
+++ b/ayon_server/graphql/resolvers/users.py
@@ -56,6 +56,9 @@ async def get_users(
     projects: Annotated[
         list[str] | None, argdesc("List only users assigned to projects")
     ] = None,
+    is_support: Annotated[
+        bool | None, argdesc("Filter users by isSupport flag in data")
+    ] = None,
     first: ARGFirst = None,
     after: ARGAfter = None,
     last: ARGLast = None,
@@ -92,6 +95,12 @@ async def get_users(
         emails = [e.lower() for e in emails]
         sql_conditions.append(
             f"LOWER(users.attrib->>'email') IN {SQLTool.array(emails)}"
+        )
+
+    # Filter by isSupport
+    if is_support is not None:
+        sql_conditions.append(
+            f"users.data->>'isSupport' = '{'true' if is_support else 'false'}'"
         )
 
     # Filter by project


### PR DESCRIPTION
## PR Checklist


-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

Adds argument to allow filtering support (eg. AYON) users returned in graphQL query. Should be eventually used in `AssigneeSelect` (or else) to show only "real" users.