### PR TITLE
Validate user access groups

### DIFF
--- a/ayon_server/entities/user.py
+++ b/ayon_server/entities/user.py
@@ -84,7 +84,10 @@ async def validate_access_groups(user_data: dict[str, Any]) -> None:
 
         groups = access_groups[pname]
         groups = [g for g in groups if g in existing_access_groups]
-        access_groups[pname] = groups
+        if not groups:
+            access_groups.pop(pname, None)
+        else:
+            access_groups[pname] = groups
 
     #
     # Put back cleaned up groups to data, or remove empty lists

--- a/ayon_server/entities/user.py
+++ b/ayon_server/entities/user.py
@@ -59,10 +59,8 @@ async def validate_access_groups(user_data: dict[str, Any]) -> None:
     # if there are no groups, we don't need to do anything
     if not (access_groups or default_access_groups):
         # we don't need empty lists in data
-        if not access_groups:
-            user_data.pop("accessGroups", None)
-        if not default_access_groups:
-            user_data.pop("defaultAccessGroups", None)
+        user_data.pop("accessGroups", None)
+        user_data.pop("defaultAccessGroups", None)
         return
 
     # fetch existing groups and projects from DB

--- a/ayon_server/entities/user.py
+++ b/ayon_server/entities/user.py
@@ -48,6 +48,37 @@ class SessionInfo:
         return f"SessionInfo(is_api_key={self.is_api_key})"
 
 
+async def validate_access_groups(user_data: dict[str, Any]) -> None:
+    """
+    Validate defaultAccessGroups and accessGroups in user data
+    and do in-place clean-up (delete non-existing groups and projects)
+    """
+    access_groups = user_data.get("accessGroups", {})
+    default_access_groups = user_data.get("defaultAccessGroups", [])
+
+    if not access_groups and not default_access_groups:
+        return
+
+    res = await Postgres.fetch("SELECT name FROM public.access_groups")
+    existing_access_groups = [row["name"] for row in res]
+    existing_projects = [p.name for p in await get_project_list(with_skeleton=True)]
+
+    default_access_groups = [
+        g for g in default_access_groups if g in existing_access_groups
+    ]
+    for pname in list(access_groups.keys()):
+        if pname not in existing_projects:
+            del access_groups[pname]
+            continue
+
+        groups = access_groups[pname]
+        groups = [g for g in groups if g in existing_access_groups]
+        access_groups[pname] = groups
+
+    user_data["defaultAccessGroups"] = default_access_groups
+    user_data["accessGroups"] = access_groups
+
+
 class UserEntity(TopLevelEntity):
     entity_type: str = "user"
     model = ModelSet("user", attribute_library["user"], has_id=False)
@@ -164,6 +195,8 @@ class UserEntity(TopLevelEntity):
                 if res:
                     msg = "This email is already used by another user"
                     raise ConstraintViolationException(msg)
+
+            await validate_access_groups(self.data)
 
             if do_con_check:
                 logger.info(f"Activating user {self.name}")

--- a/ayon_server/entities/user.py
+++ b/ayon_server/entities/user.py
@@ -60,8 +60,8 @@ async def validate_access_groups(user_data: dict[str, Any]) -> None:
         return
 
     res = await Postgres.fetch("SELECT name FROM public.access_groups")
-    existing_access_groups = [row["name"] for row in res]
-    existing_projects = [p.name for p in await get_project_list(with_skeleton=True)]
+    existing_access_groups = {row["name"] for row in res}
+    existing_projects = {p.name for p in await get_project_list(with_skeleton=True)}
 
     default_access_groups = [
         g for g in default_access_groups if g in existing_access_groups

--- a/ayon_server/entities/user.py
+++ b/ayon_server/entities/user.py
@@ -56,16 +56,27 @@ async def validate_access_groups(user_data: dict[str, Any]) -> None:
     access_groups = user_data.get("accessGroups", {})
     default_access_groups = user_data.get("defaultAccessGroups", [])
 
-    if not access_groups and not default_access_groups:
+    # if there are no groups, we don't need to do anything
+    if not (access_groups or default_access_groups):
+        # we don't need empty lists in data
+        if not access_groups:
+            user_data.pop("accessGroups", None)
+        if not default_access_groups:
+            user_data.pop("defaultAccessGroups", None)
         return
 
+    # fetch existing groups and projects from DB
+
     res = await Postgres.fetch("SELECT name FROM public.access_groups")
-    existing_access_groups = [row["name"] for row in res]
-    existing_projects = [p.name for p in await get_project_list(with_skeleton=True)]
+    existing_access_groups = {row["name"] for row in res}
+    existing_projects = {p.name for p in await get_project_list(with_skeleton=True)}
+
+    # clean up non-existing groups and projects
 
     default_access_groups = [
         g for g in default_access_groups if g in existing_access_groups
     ]
+
     for pname in list(access_groups.keys()):
         if pname not in existing_projects:
             del access_groups[pname]
@@ -75,8 +86,19 @@ async def validate_access_groups(user_data: dict[str, Any]) -> None:
         groups = [g for g in groups if g in existing_access_groups]
         access_groups[pname] = groups
 
-    user_data["defaultAccessGroups"] = default_access_groups
-    user_data["accessGroups"] = access_groups
+    #
+    # Put back cleaned up groups to data, or remove empty lists
+    #
+
+    if not access_groups:
+        user_data.pop("accessGroups", None)
+    else:
+        user_data["accessGroups"] = access_groups
+
+    if not default_access_groups:
+        user_data.pop("defaultAccessGroups", None)
+    else:
+        user_data["defaultAccessGroups"] = default_access_groups
 
 
 class UserEntity(TopLevelEntity):

--- a/ayon_server/helpers/preview.py
+++ b/ayon_server/helpers/preview.py
@@ -22,7 +22,7 @@ FILE_PREVIEW_SIZE = (600, None)
 PREVIEW_CACHE_TTL = 3600 * 24
 
 
-VIDEO_THUMBNAIL_STATUS = set()
+VIDEO_THUMBNAIL_STATUS: set[str] = set()
 
 
 async def create_video_thumbnail(

--- a/ayon_server/metrics/__init__.py
+++ b/ayon_server/metrics/__init__.py
@@ -1,6 +1,7 @@
 __all__ = ["Metrics", "get_metrics"]
 
 import time
+from typing import Any
 
 import httpx
 
@@ -134,7 +135,7 @@ class Metrics(OPModel):
     user_stats: list[UserStat] | None = Field(None, title="User stats")
 
 
-METRICS_SNAPSHOT = {}
+METRICS_SNAPSHOT: dict[str, Any] = {}
 METRICS_SETUP = [
     {
         "name": "project_counts",


### PR DESCRIPTION
This pull request adds validation and cleanup logic for user access groups in the `ayon_server/entities/user.py` file. The main improvement is the introduction of the `validate_access_groups` function, which ensures that only existing groups and projects are referenced in user data, and integrates this validation into the user save process.

User access group validation and cleanup:

* Added the `validate_access_groups` async function to clean up and validate `defaultAccessGroups` and `accessGroups` in user data, removing references to non-existing groups and projects.
* Integrated the `validate_access_groups` function into the user `save` method, ensuring user access groups are validated before saving.