### PR TITLE
Fix cursor for links resolver in GraphQL

### DIFF
--- a/ayon_server/graphql/resolvers/links.py
+++ b/ayon_server/graphql/resolvers/links.py
@@ -51,21 +51,27 @@ async def get_links(
         sql_conditions.append(f"name ~ '{name_ex}'")
 
     query = f"""
-        SELECT id, name, input_id, output_id, link_type, author, data, created_at
+        SELECT
+            id,
+            name,
+            input_id,
+            output_id,
+            link_type,
+            author,
+            data,
+            created_at,
+            creation_order
         FROM project_{project_name}.links
         {SQLTool.conditions(sql_conditions)}
         ORDER BY creation_order
-        LIMIT {first}
+        LIMIT {first + 1}
     """
 
     async for row in Postgres.iterate(query):
-        if first <= len(edges):
-            break
-
         link_type, input_type, output_type = row["link_type"].split("|")
         input_id = row["input_id"]
         output_id = row["output_id"]
-        link_id = row["id"]
+        cursor = str(row["creation_order"])
 
         if root.id == output_id:
             direction = "in"
@@ -89,14 +95,16 @@ async def get_links(
                 entity_type=entity_type,
                 name=row["name"],
                 link_type=link_type,
-                cursor=link_id,
+                cursor=cursor,
                 description=description,
                 author=row["author"],
                 data=row["data"],
             )
         )
 
-    has_next_page = len(edges) >= first
+    has_next_page = len(edges) > first
+    if has_next_page:
+        edges = edges[:first]
     end_cursor = edges[-1].cursor if edges else None
 
     page_info = PageInfo(


### PR DESCRIPTION
## Description of changes

Fix cursor/pagination for links in GraphQL.

### Technical details

The previous `id` is not a digit but uuid, and hence the `after` part to the query was never added, and the same cursor ended up always being returned resulting in always paginating the same thing, infinitely. The `creation_order` is unique, hence we can use that to paginate - especially because we already order by that anyway.

### Additional context

We were facing issues in AYON publishing for versions that had 300+ links because the `ayon_api` pagination on the query wasn't expecting that always the same page would get returned, and hence it would remain in while loop forever (until server would decline the connection).
