### PR TITLE
Project-wide links resolver

### DIFF
--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -108,11 +108,12 @@ class ProjectLinkEdge(BaseEdge):
 
     name: str | None = strawberry.field(default=None)
     author: str | None = strawberry.field(default=None)
+    created_at: datetime = strawberry.field()
 
     cursor: str | None = strawberry.field(default=None)
     data: JSON = strawberry.field(default_factory=dict)
 
-    @strawberry.field(description="Linked node")
+    @strawberry.field(description="Input node")
     async def input_node(self, info: Info) -> Optional["BaseNode"]:
         return await _get_entity(
             info,
@@ -121,7 +122,7 @@ class ProjectLinkEdge(BaseEdge):
             self.input_id,
         )
 
-    @strawberry.field(description="Linked node")
+    @strawberry.field(description="Output node")
     async def output_node(self, info: Info) -> Optional["BaseNode"]:
         return await _get_entity(
             info,

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -99,7 +99,7 @@ class ProjectLinkEdge(BaseEdge):
     id: str = strawberry.field()
     project_name: str = strawberry.field()
 
-    link_type: str = strawberry.field(default="something")
+    link_type: str = strawberry.field()
 
     input_type: str = strawberry.field()
     output_type: str = strawberry.field()

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -25,6 +25,46 @@ class ProductBaseType(BaseEdge):
     name: str = strawberry.field()
 
 
+async def _get_entity(
+    info: Info, project_name: str, entity_type: str, entity_id: str
+) -> Optional["BaseNode"]:
+    if entity_type == "folder":
+        loader = info.context["folder_loader"]
+        parser = info.context["folder_from_record"]
+    elif entity_type == "version":
+        loader = info.context["version_loader"]
+        parser = info.context["version_from_record"]
+    elif entity_type == "product":
+        loader = info.context["product_loader"]
+        parser = info.context["product_from_record"]
+    elif entity_type == "task":
+        loader = info.context["task_loader"]
+        parser = info.context["task_from_record"]
+    elif entity_type == "representation":
+        loader = info.context["representation_loader"]
+        parser = info.context["representation_from_record"]
+    elif entity_type == "workfile":
+        loader = info.context["workfile_loader"]
+        parser = info.context["workfile_from_record"]
+    else:
+        msg = f"Unsupported entity type '{entity_type}' for link node"
+        logger.error(msg)
+        raise AyonException(msg)
+
+    record = await loader.load((project_name, entity_id))
+    if not record:
+        return None
+
+    entity_node = await parser(project_name, record, info.context)
+    access_checker = info.context.get("access_checker")
+    if access_checker:
+        entity_folder_path = (entity_node._folder_path or "").strip("/")
+        if not access_checker[entity_folder_path]:
+            # No access to the folder containing the linked entity
+            return None
+    return entity_node
+
+
 @strawberry.type
 class LinkEdge(BaseEdge):
     id: str = strawberry.field()
@@ -41,46 +81,59 @@ class LinkEdge(BaseEdge):
 
     @strawberry.field(description="Linked node")
     async def node(self, info: Info) -> Optional["BaseNode"]:
-        if self.entity_type == "folder":
-            loader = info.context["folder_loader"]
-            parser = info.context["folder_from_record"]
-        elif self.entity_type == "version":
-            loader = info.context["version_loader"]
-            parser = info.context["version_from_record"]
-        elif self.entity_type == "product":
-            loader = info.context["product_loader"]
-            parser = info.context["product_from_record"]
-        elif self.entity_type == "task":
-            loader = info.context["task_loader"]
-            parser = info.context["task_from_record"]
-        elif self.entity_type == "representation":
-            loader = info.context["representation_loader"]
-            parser = info.context["representation_from_record"]
-        elif self.entity_type == "workfile":
-            loader = info.context["workfile_loader"]
-            parser = info.context["workfile_from_record"]
-        else:
-            msg = f"Unsupported entity type '{self.entity_type}' for link node"
-            logger.error(msg)
-            raise AyonException(msg)
-
-        record = await loader.load((self.project_name, self.entity_id))
-        if not record:
-            return None
-
-        entity_node = await parser(self.project_name, record, info.context)
-        access_checker = info.context.get("access_checker")
-        if access_checker:
-            entity_folder_path = (entity_node._folder_path or "").strip("/")
-            if not access_checker[entity_folder_path]:
-                # No access to the folder containing the linked entity
-                return None
-        return entity_node
+        return await _get_entity(
+            info,
+            self.project_name,
+            self.entity_type,
+            self.entity_id,
+        )
 
 
 @strawberry.type
 class LinksConnection(BaseConnection):
     edges: list[LinkEdge] = strawberry.field(default_factory=list)
+
+
+@strawberry.type
+class ProjectLinkEdge(BaseEdge):
+    id: str = strawberry.field()
+    project_name: str = strawberry.field()
+
+    link_type: str = strawberry.field(default="something")
+
+    input_type: str = strawberry.field()
+    output_type: str = strawberry.field()
+    input_id: str = strawberry.field()
+    output_id: str = strawberry.field()
+
+    name: str | None = strawberry.field(default=None)
+    author: str | None = strawberry.field(default=None)
+
+    cursor: str | None = strawberry.field(default=None)
+    data: JSON = strawberry.field(default_factory=dict)
+
+    @strawberry.field(description="Linked node")
+    async def input_node(self, info: Info) -> Optional["BaseNode"]:
+        return await _get_entity(
+            info,
+            self.project_name,
+            self.input_type,
+            self.input_id,
+        )
+
+    @strawberry.field(description="Linked node")
+    async def output_node(self, info: Info) -> Optional["BaseNode"]:
+        return await _get_entity(
+            info,
+            self.project_name,
+            self.output_type,
+            self.output_id,
+        )
+
+
+@strawberry.type
+class ProjectLinksConnection(BaseConnection):
+    edges: list[ProjectLinkEdge] = strawberry.field(default_factory=list)
 
 
 @strawberry.type

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -7,11 +7,17 @@ from ayon_server.entities import ProjectEntity
 from ayon_server.entities.user import UserEntity
 from ayon_server.exceptions import ForbiddenException
 from ayon_server.graphql.connections import ActivitiesConnection, EntityListsConnection
-from ayon_server.graphql.nodes.common import ProductBaseType, ProductType, ThumbnailInfo
+from ayon_server.graphql.nodes.common import (
+    ProductBaseType,
+    ProductType,
+    ProjectLinksConnection,
+    ThumbnailInfo,
+)
 from ayon_server.graphql.resolvers.activities import get_activities
 from ayon_server.graphql.resolvers.entity_lists import get_entity_list, get_entity_lists
 from ayon_server.graphql.resolvers.folders import get_folder, get_folders
 from ayon_server.graphql.resolvers.products import get_product, get_products
+from ayon_server.graphql.resolvers.project_links import get_project_links
 from ayon_server.graphql.resolvers.representations import (
     get_representation,
     get_representations,
@@ -243,6 +249,11 @@ class ProjectNode:
     activities: ActivitiesConnection = strawberry.field(
         resolver=get_activities,
         description=get_activities.__doc__,
+    )
+
+    links: ProjectLinksConnection = strawberry.field(
+        resolver=get_project_links,
+        description=get_project_links.__doc__,
     )
 
     @strawberry.field(description="List of project's task types")

--- a/ayon_server/graphql/resolvers/project_links.py
+++ b/ayon_server/graphql/resolvers/project_links.py
@@ -20,6 +20,9 @@ async def get_project_links(
     names: list[str] | None = None,
     name_ex: str | None = None,
 ) -> ProjectLinksConnection:
+    """List all links in the project, with optional filters."""
+
+    first = max(first, 0)
 
     project_name = root.project_name
     user = info.context["user"]
@@ -100,7 +103,7 @@ async def get_project_links(
         JOIN matching_link_types m ON l.link_type = m.name
         {SQLTool.conditions(sql_conditions)}
         ORDER BY creation_order
-        LIMIT {max(first, 0) + 1}
+        LIMIT {first + 1}
     """
 
     edges: list[ProjectLinkEdge] = []
@@ -124,7 +127,8 @@ async def get_project_links(
                 name=row["name"],
                 link_type=link_type,
                 cursor=cursor,
-                author=row["author"],
+                author=row["author"] if user.is_manager else None,
+                created_at=row["created_at"],
                 data=row["data"],
             )
         )

--- a/ayon_server/graphql/resolvers/project_links.py
+++ b/ayon_server/graphql/resolvers/project_links.py
@@ -8,6 +8,10 @@ from ayon_server.utils import SQLTool
 async def get_project_links(
     root,
     info: Info,
+    ids: list[str] | None = None,
+    entity_ids: list[str] | None = None,
+    input_ids: list[str] | None = None,
+    output_ids: list[str] | None = None,
     link_types: list[str] | None = None,
     input_types: list[str] | None = None,
     output_types: list[str] | None = None,
@@ -42,6 +46,23 @@ async def get_project_links(
         args.append(output_types)
 
     sql_conditions = []
+
+    if ids:
+        sql_conditions.append(f"l.id = ANY({next_idx()})")
+        args.append(ids)
+
+    if entity_ids:
+        idx = next_idx()
+        sql_conditions.append(f"(l.input_id = ANY({idx}) OR l.output_id = ANY({idx}))")
+        args.append(entity_ids)
+
+    if input_ids:
+        sql_conditions.append(f"l.input_id = ANY({next_idx()})")
+        args.append(input_ids)
+
+    if output_ids:
+        sql_conditions.append(f"l.output_id = ANY({next_idx()})")
+        args.append(output_ids)
 
     if after is not None and after.isdigit():
         sql_conditions.append(f"l.creation_order > {next_idx()}")

--- a/ayon_server/graphql/resolvers/project_links.py
+++ b/ayon_server/graphql/resolvers/project_links.py
@@ -1,0 +1,109 @@
+from ayon_server.access.utils import AccessChecker
+from ayon_server.graphql.nodes.common import ProjectLinkEdge, ProjectLinksConnection
+from ayon_server.graphql.types import Info, PageInfo
+from ayon_server.lib.postgres import Postgres
+from ayon_server.utils import SQLTool
+
+
+async def get_project_links(
+    root,
+    info: Info,
+    link_types: list[str] | None = None,
+    input_types: list[str] | None = None,
+    output_types: list[str] | None = None,
+    first: int = 100,
+    after: str | None = None,
+    names: list[str] | None = None,
+    name_ex: str | None = None,
+) -> ProjectLinksConnection:
+
+    project_name = root.project_name
+    user = info.context["user"]
+    if not user.is_manager:
+        access_checker = AccessChecker()
+        await access_checker.load(user, project_name)
+        info.context["access_checker"] = access_checker
+
+    cte_conds = []
+    if link_types:
+        cte_conds.append(f"link_type IN {SQLTool.array(link_types)}")
+    if input_types:
+        cte_conds.append(f"input_type IN {SQLTool.array(input_types)}")
+    if output_types:
+        cte_conds.append(f"output_type IN {SQLTool.array(output_types)}")
+
+    sql_conditions = []
+
+    if after is not None and after.isdigit():
+        sql_conditions.append(f"l.creation_order > {after}")
+
+    if names is not None:
+        sql_conditions.append(f"l.name in {SQLTool.array(names)}")
+
+    if name_ex is not None:
+        sql_conditions.append(f"l.name ~ '{name_ex}'")
+
+    query = f"""
+        WITH matching_link_types AS (
+            SELECT name, input_type, output_type, link_type
+            FROM project_{project_name}.link_types
+            {SQLTool.conditions(cte_conds)}
+        )
+
+        SELECT
+            l.id,
+            l.name,
+            l.input_id,
+            l.output_id,
+            l.author,
+            l.data,
+            l.created_at,
+            l.creation_order,
+            m.link_type,
+            m.input_type,
+            m.output_type
+
+        FROM project_{project_name}.links l
+        JOIN matching_link_types m ON l.link_type = m.name
+        {SQLTool.conditions(sql_conditions)}
+        ORDER BY creation_order
+        LIMIT {first + 1}
+    """
+
+    edges: list[ProjectLinkEdge] = []
+
+    async for row in Postgres.iterate(query):
+        input_id = row["input_id"]
+        output_id = row["output_id"]
+        cursor = str(row["creation_order"])
+        input_type = row["input_type"]
+        output_type = row["output_type"]
+        link_type = row["link_type"]
+
+        edges.append(
+            ProjectLinkEdge(
+                id=row["id"],
+                input_id=input_id,
+                output_id=output_id,
+                input_type=input_type,
+                output_type=output_type,
+                project_name=project_name,
+                name=row["name"],
+                link_type=link_type,
+                cursor=cursor,
+                author=row["author"],
+                data=row["data"],
+            )
+        )
+
+    has_next_page = len(edges) > first
+    if has_next_page:
+        edges = edges[:first]
+    end_cursor = edges[-1].cursor if edges else None
+
+    page_info = PageInfo(
+        has_next_page=has_next_page,
+        end_cursor=end_cursor,
+    )
+
+    return ProjectLinksConnection(edges=edges, page_info=page_info)

--- a/ayon_server/graphql/resolvers/project_links.py
+++ b/ayon_server/graphql/resolvers/project_links.py
@@ -24,24 +24,36 @@ async def get_project_links(
         await access_checker.load(user, project_name)
         info.context["access_checker"] = access_checker
 
+    args = []
+
+    def next_idx():
+        idx = len(args) + 1
+        return f"${idx}"
+
     cte_conds = []
     if link_types:
-        cte_conds.append(f"link_type IN {SQLTool.array(link_types)}")
+        cte_conds.append(f"link_type = ANY({next_idx()})")
+        args.append(link_types)
     if input_types:
-        cte_conds.append(f"input_type IN {SQLTool.array(input_types)}")
+        cte_conds.append(f"input_type = ANY({next_idx()})")
+        args.append(input_types)
     if output_types:
-        cte_conds.append(f"output_type IN {SQLTool.array(output_types)}")
+        cte_conds.append(f"output_type = ANY({next_idx()})")
+        args.append(output_types)
 
     sql_conditions = []
 
     if after is not None and after.isdigit():
-        sql_conditions.append(f"l.creation_order > {after}")
+        sql_conditions.append(f"l.creation_order > {next_idx()}")
+        args.append(after)
 
-    if names is not None:
-        sql_conditions.append(f"l.name in {SQLTool.array(names)}")
+    if names:
+        sql_conditions.append(f"l.name = ANY({next_idx()})")
+        args.append(names)
 
-    if name_ex is not None:
-        sql_conditions.append(f"l.name ~ '{name_ex}'")
+    if name_ex:
+        sql_conditions.append(f"l.name ~ {next_idx()}")
+        args.append(name_ex)
 
     query = f"""
         WITH matching_link_types AS (
@@ -67,12 +79,12 @@ async def get_project_links(
         JOIN matching_link_types m ON l.link_type = m.name
         {SQLTool.conditions(sql_conditions)}
         ORDER BY creation_order
-        LIMIT {first + 1}
+        LIMIT {max(first, 0) + 1}
     """
 
     edges: list[ProjectLinkEdge] = []
 
-    async for row in Postgres.iterate(query):
+    async for row in Postgres.iterate(query, *args):
         input_id = row["input_id"]
         output_id = row["output_id"]
         cursor = str(row["creation_order"])

--- a/ayon_server/graphql/resolvers/project_links.py
+++ b/ayon_server/graphql/resolvers/project_links.py
@@ -66,7 +66,7 @@ async def get_project_links(
 
     if after is not None and after.isdigit():
         sql_conditions.append(f"l.creation_order > {next_idx()}")
-        args.append(after)
+        args.append(int(after))
 
     if names:
         sql_conditions.append(f"l.name = ANY({next_idx()})")


### PR DESCRIPTION
This pull request introduces new support for querying project-level links in the GraphQL API, enabling clients to fetch and filter project links with flexible options. The main changes include the addition of new types and resolvers for project links, refactoring of entity resolution logic, and integration of the new project links connection into the `Project` node.


<img width="1359" height="653" alt="image" src="https://github.com/user-attachments/assets/7aecf4fe-38dc-4bd7-aa6f-61295b4fd75f" />