### PR TITLE
Added allowStagingMode to attributes

### DIFF
--- a/ayon_server/graphql/__init__.py
+++ b/ayon_server/graphql/__init__.py
@@ -140,6 +140,7 @@ class Query:
             is_manager=user.is_manager,
             is_service=user.is_service,
             is_developer=user.is_developer,
+            is_staging_enabled=user.is_staging_enabled,
             is_guest=user.is_guest,
             user_pool=user.data.get("userPool"),
             default_access_groups=user.data.get("defaultAccessGroups", []),

--- a/ayon_server/graphql/__init__.py
+++ b/ayon_server/graphql/__init__.py
@@ -140,7 +140,7 @@ class Query:
             is_manager=user.is_manager,
             is_service=user.is_service,
             is_developer=user.is_developer,
-            is_staging_enabled=user.is_staging_enabled,
+            is_staging_allowed=user.is_staging_allowed,
             is_guest=user.is_guest,
             user_pool=user.data.get("userPool"),
             default_access_groups=user.data.get("defaultAccessGroups", []),

--- a/ayon_server/graphql/nodes/user.py
+++ b/ayon_server/graphql/nodes/user.py
@@ -40,6 +40,7 @@ class UserNode:
     is_service: bool
     is_guest: bool
     is_developer: bool
+    is_staging_enabled: bool
     invite_sent_at: datetime | None = None
     invite_accepted_at: datetime | None = None
     has_password: bool
@@ -88,6 +89,7 @@ async def user_from_record(
     is_guest = data.get("isGuest", False)
     user_pool = data.get("userPool")
     disable_password_login = data.get("disablePasswordLogin", False)
+    is_staging_enabled = data.get("isStagingEnabled", False)
 
     invite_sent_at = None
     invite_accepted_at = None
@@ -121,6 +123,7 @@ async def user_from_record(
         is_service=is_service,
         is_guest=is_guest,
         is_developer=is_developer,
+        is_staging_enabled=is_staging_enabled,
         invite_sent_at=invite_sent_at,
         invite_accepted_at=invite_accepted_at,
         user_pool=user_pool,

--- a/ayon_server/graphql/nodes/user.py
+++ b/ayon_server/graphql/nodes/user.py
@@ -40,7 +40,7 @@ class UserNode:
     is_service: bool
     is_guest: bool
     is_developer: bool
-    is_staging_enabled: bool
+    is_staging_allowed: bool
     invite_sent_at: datetime | None = None
     invite_accepted_at: datetime | None = None
     has_password: bool
@@ -89,7 +89,7 @@ async def user_from_record(
     is_guest = data.get("isGuest", False)
     user_pool = data.get("userPool")
     disable_password_login = data.get("disablePasswordLogin", False)
-    is_staging_enabled = data.get("isStagingEnabled", False)
+    is_staging_allowed = data.get("isStagingEnabled", False)
 
     invite_sent_at = None
     invite_accepted_at = None
@@ -123,7 +123,7 @@ async def user_from_record(
         is_service=is_service,
         is_guest=is_guest,
         is_developer=is_developer,
-        is_staging_enabled=is_staging_enabled,
+        is_staging_allowed=is_staging_allowed,
         invite_sent_at=invite_sent_at,
         invite_accepted_at=invite_accepted_at,
         user_pool=user_pool,

--- a/setup/attributes.py
+++ b/setup/attributes.py
@@ -151,13 +151,6 @@ DEFAULT_ATTRIBUTES: dict[str, dict[str, Any]] = {
         "title": "Developer mode",
         "example": True,
     },
-    "isStagingAllowed": {
-        "scope": "U",
-        "type": "boolean",
-        "title": "Allow staging mode",
-        "example": False,
-        "description": "Allow frontend staging mode to be enabled by this user to access staging web actions.",
-    },
     "productGroup": {
         "scope": "S",
         "type": "string",

--- a/setup/attributes.py
+++ b/setup/attributes.py
@@ -151,7 +151,7 @@ DEFAULT_ATTRIBUTES: dict[str, dict[str, Any]] = {
         "title": "Developer mode",
         "example": True,
     },
-    "allowStagingMode": {
+    "isStagingAllowed ": {
         "scope": "U",
         "type": "boolean",
         "title": "Allow staging mode",

--- a/setup/attributes.py
+++ b/setup/attributes.py
@@ -156,6 +156,7 @@ DEFAULT_ATTRIBUTES: dict[str, dict[str, Any]] = {
         "type": "boolean",
         "title": "Allow staging mode",
         "example": False,
+        "description": "Allow frontend staging mode to be enabled by this user to access staging web actions.",
     },
     "productGroup": {
         "scope": "S",

--- a/setup/attributes.py
+++ b/setup/attributes.py
@@ -151,6 +151,12 @@ DEFAULT_ATTRIBUTES: dict[str, dict[str, Any]] = {
         "title": "Developer mode",
         "example": True,
     },
+    "allowStagingMode": {
+        "scope": "U",
+        "type": "boolean",
+        "title": "Allow staging mode",
+        "example": False,
+    },
     "productGroup": {
         "scope": "S",
         "type": "string",

--- a/setup/attributes.py
+++ b/setup/attributes.py
@@ -151,7 +151,7 @@ DEFAULT_ATTRIBUTES: dict[str, dict[str, Any]] = {
         "title": "Developer mode",
         "example": True,
     },
-    "isStagingAllowed ": {
+    "isStagingAllowed": {
         "scope": "U",
         "type": "boolean",
         "title": "Allow staging mode",


### PR DESCRIPTION
## Description of changes

New `allowStagingMode` User attribute added. Currently will be used by FE to control which Web Actions should be triggered.

Not used/exposed in backend in any further way.

### Technical details

`.manage.ps1 setup` must be run on existing installations!

