### PR TITLE
Installer and Dependency package metadata

### DIFF
--- a/ayon_server/installer/models.py
+++ b/ayon_server/installer/models.py
@@ -70,6 +70,14 @@ class BasePackageModel(OPModel):
             example="3.11",
         ),
     ] = None
+    distro_short: Annotated[
+        str | None,
+        Field(
+            title="Short distribution name",
+            description="Short name of the Linux distribution",
+            example="rocky9",
+        ),
+    ] = None
 
 
 class SourcesPatchModel(OPModel):

--- a/ayon_server/installer/models.py
+++ b/ayon_server/installer/models.py
@@ -62,6 +62,14 @@ class BasePackageModel(OPModel):
     checksum: str | None = None
     checksum_algorithm: Literal["md5", "sha1", "sha256"] | None = None
     sources: list[SourceModel] = SOURCES_META
+    python_version: Annotated[
+        str | None,
+        Field(
+            title="Python version",
+            description="Used Python version",
+            example="3.11",
+        ),
+    ] = None
 
 
 class SourcesPatchModel(OPModel):
@@ -104,14 +112,6 @@ class InstallerManifest(BasePackageModel):
             title="Version",
             description="Version of the installer",
             example="1.2.3",
-        ),
-    ]
-    python_version: Annotated[
-        str,
-        Field(
-            title="Python version",
-            description="Version of Python that the installer is created with",
-            example="3.11",
         ),
     ]
     python_modules: Annotated[


### PR DESCRIPTION
## Description of changes
Added python version and distro short name into installer and dependency package models.
Both Installer and Dependency Package now can have filled `python_path` and `distro_short` which can be used for validation of compatibility.

### Technical details
Moved `python_version` from `InstallerManifest` to `BasePackageModel` which is also used for `DependencyPackageManifest`. With that both can have the value filled, it is optional as old dependency packages don't have it filled. Also added `distro_short` to the manifest as additional information to `platform`.

### Additional context
The goal is to be able to check if installer is compatible with dependency package before it is used in production.
