### PR TITLE
Bugfix: Implemented passing icon/color in project graphQL

### DIFF
--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -16,6 +16,8 @@ from ayon_server.utils import json_dumps
 @strawberry.type
 class ProductType(BaseEdge):
     name: str = strawberry.field()
+    icon: None = strawberry.field(default=None)
+    color: None = strawberry.field(default=None)
 
 
 @strawberry.type

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -16,8 +16,6 @@ from ayon_server.utils import json_dumps
 @strawberry.type
 class ProductType(BaseEdge):
     name: str = strawberry.field()
-    icon: str | None = strawberry.field(default=None)
-    color: str | None = strawberry.field(default=None)
 
 
 @strawberry.type

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -25,8 +25,8 @@ class ProductType(BaseEdge):
 @strawberry.type
 class ProductBaseType(BaseEdge):
     name: str = strawberry.field()
-    icon: str | None = strawberry.field(default=None)
-    color: str | None = strawberry.field(default=None)
+    icon: str = strawberry.field()
+    color: str = strawberry.field()
 
 
 async def _get_entity(

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -23,6 +23,8 @@ class ProductType(BaseEdge):
 @strawberry.type
 class ProductBaseType(BaseEdge):
     name: str = strawberry.field()
+    icon: str | None = strawberry.field(default=None)
+    color: str | None = strawberry.field(default=None)
 
 
 async def _get_entity(

--- a/ayon_server/graphql/nodes/common.py
+++ b/ayon_server/graphql/nodes/common.py
@@ -16,6 +16,8 @@ from ayon_server.utils import json_dumps
 @strawberry.type
 class ProductType(BaseEdge):
     name: str = strawberry.field()
+    # TODO remove 'icon' and 'color' for ayon_api compatibility
+    #     PR https://github.com/ynput/ayon-python-api/pull/332
     icon: None = strawberry.field(default=None)
     color: None = strawberry.field(default=None)
 

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -345,17 +345,11 @@ class ProjectNode:
 
     @strawberry.field(description="List of project's product types")
     async def product_types(self) -> list[ProductType]:
-        # TODO separate from productBaseTypes definitions when available
-        # in Anatomy
-        default_color, default_icon, definitions = \
-            await self._get_product_base_type_defs()
         if self.skeleton:
             return []  # TODO: load from skeleton data instead of returning empty list
         return [
             ProductType(
-                name=row["name"],
-                icon=definitions.get(row["name"],{}).get("icon") or default_icon,
-                color=definitions.get(row["name"],{}).get("color") or default_color,
+                name=row["name"]
             )
             async for row in Postgres.iterate(
                 f"""

--- a/ayon_server/graphql/nodes/project.py
+++ b/ayon_server/graphql/nodes/project.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any
 
@@ -344,13 +345,17 @@ class ProjectNode:
 
     @strawberry.field(description="List of project's product types")
     async def product_types(self) -> list[ProductType]:
+        # TODO separate from productBaseTypes definitions when available
+        # in Anatomy
+        default_color, default_icon, definitions = \
+            await self._get_product_base_type_defs()
         if self.skeleton:
             return []  # TODO: load from skeleton data instead of returning empty list
         return [
             ProductType(
                 name=row["name"],
-                icon=row["data"].get("icon"),
-                color=row["data"].get("color"),
+                icon=definitions.get(row["name"],{}).get("icon") or default_icon,
+                color=definitions.get(row["name"],{}).get("color") or default_color,
             )
             async for row in Postgres.iterate(
                 f"""
@@ -366,11 +371,15 @@ class ProjectNode:
 
     @strawberry.field(description="List of project's product base types")
     async def product_base_types(self) -> list[ProductBaseType]:
+        default_color, default_icon, definitions = \
+            await self._get_product_base_type_defs()
         if self.skeleton:
             return []  # TODO: load from skeleton data instead of returning empty list
         return [
             ProductBaseType(
                 name=row["name"],
+                icon=definitions.get(row["name"],{}).get("icon") or default_icon,
+                color=definitions.get(row["name"],{}).get("color") or default_color,
             )
             async for row in Postgres.iterate(
                 f"""
@@ -381,6 +390,16 @@ class ProjectNode:
             """
             )
         ]
+
+    async def _get_product_base_type_defs(self) -> tuple[dict[Any, Any], Any, Any]:
+        config = json.loads(self.config)
+        definitions = {
+            type_def["name"]: type_def
+            for type_def in config["productBaseTypes"]["definitions"]
+        }
+        default_icon = config["productBaseTypes"]["default"]["icon"]
+        default_color = config["productBaseTypes"]["default"]["color"]
+        return default_color, default_icon, definitions
 
     @strawberry.field(description="List of project's statuses")
     async def statuses(self) -> list[Status]:


### PR DESCRIPTION
## Description of changes

`icon` and `color` of `productTypes` and `productBaseTypes` weren't passed in graphQL query.

This PR fixes this, at least for `project` query.

<img width="1030" height="588" alt="image" src="https://github.com/user-attachments/assets/445eb70c-26fb-4609-8d24-9a5b96226b01" />


### Technical details

Same code is replicated for `productTypes` and `productBaseTypes` as there is no differentation between them in Settings, eg. Anatomy. I am not sure, if there will be as `productTypes` will be dynamic inherently. Anatomy would need to collect all defined keys from all Settings which seems as a hassle. 

There is also separate `productTypes` which should be removed, imho. This query has description "Studio-wide product type configuration", but there are no 'studio' only `productTypes`/`productBaseTypes` which could store `icon`/`color` information.

There is `public.product_types` table, but it seems it contains only keys of published products (eg. it grows with new type of published product). There is no `data` values currently which could hold information (icon/color) for these. And even if there would be, what should be stored there as `icon`/`color` could be set differently for each of the `productTypes` in each project.
I don't understand purpose of this table.

[GraphQl: Project productTypes and productBaseTypes](https://github.com/ynput/ayon-backend/issues/869)
