### PR TITLE
Cache API key 401 responses and brute force protection

### DIFF
--- a/ayon_server/api/auth.py
+++ b/ayon_server/api/auth.py
@@ -1,9 +1,11 @@
+import asyncio
 import time
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
-from ayon_server.auth.session import Session
+from ayon_server.api.clientinfo import get_real_ip
+from ayon_server.auth.session import Session, is_local_ip
 from ayon_server.auth.utils import hash_password
 from ayon_server.entities import UserEntity
 from ayon_server.exceptions import UnauthorizedException
@@ -45,7 +47,7 @@ async def get_logout_reason(token: str) -> str:
     return reason
 
 
-async def user_from_api_key(api_key: str) -> UserEntity:
+async def user_from_api_key(api_key: str, request: Request) -> UserEntity:
     """Return a user associated with the given API key.
 
     Hashed ApiKey may be stored in the database in two ways:
@@ -66,6 +68,16 @@ async def user_from_api_key(api_key: str) -> UserEntity:
        is the one we are looking for. We also need to check
        if the key is not expired.
     """
+
+    previous_attempts = 0
+    real_ip = get_real_ip(request)
+    if not is_local_ip(real_ip):
+        previous_attempts = await Redis.get_json("brute-force-attempts", real_ip) or 0
+        if previous_attempts >= 100:
+            raise UnauthorizedException(
+                "Too many failed authentication attempts. Please try again later."
+            )
+
     hashed_key = hash_password(api_key)
     query = """
         SELECT * FROM public.users
@@ -86,6 +98,16 @@ async def user_from_api_key(api_key: str) -> UserEntity:
                 return user
 
     await Session.mark_invalid(api_key)
+
+    if not is_local_ip(real_ip):
+        logger.trace(
+            f"Failed API key authentication attempt from {real_ip}. "
+            f"Total attempts: {previous_attempts + 1}"
+        )
+        await Redis.incr("brute-force-attempts", real_ip, ttl=600)
+
+    # if the API key is invalid, wait a little to prevent brute-force attacks
+    await asyncio.sleep(0.2)
     raise UnauthorizedException("Invalid API key. This shouldn't happen")
 
 
@@ -106,7 +128,7 @@ async def user_from_request(request: Request) -> UserEntity:
 
     if api_key:
         if (session_data := await Session.check(api_key, request)) is None:
-            user = await user_from_api_key(api_key)
+            user = await user_from_api_key(api_key, request)
             session_data = await Session.create(user, request, token=api_key)
         session_data.is_api_key = True
 

--- a/ayon_server/api/auth.py
+++ b/ayon_server/api/auth.py
@@ -4,14 +4,14 @@ import time
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 
-from ayon_server.api.clientinfo import get_real_ip
-from ayon_server.auth.session import Session, is_local_ip
+from ayon_server.auth.session import Session
 from ayon_server.auth.utils import hash_password
 from ayon_server.entities import UserEntity
 from ayon_server.exceptions import UnauthorizedException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.logging import logger
+from ayon_server.utils.server import get_real_ip_from_request, is_internal_ip
 from ayon_server.utils.strings import parse_access_token, parse_api_key
 
 
@@ -70,8 +70,8 @@ async def user_from_api_key(api_key: str, request: Request) -> UserEntity:
     """
 
     previous_attempts = 0
-    real_ip = get_real_ip(request)
-    if not is_local_ip(real_ip):
+    real_ip = get_real_ip_from_request(request)
+    if not is_internal_ip(real_ip):
         previous_attempts = await Redis.get_json("brute-force-attempts", real_ip) or 0
         if previous_attempts >= 100:
             raise UnauthorizedException(
@@ -99,7 +99,7 @@ async def user_from_api_key(api_key: str, request: Request) -> UserEntity:
 
     await Session.mark_invalid(api_key)
 
-    if not is_local_ip(real_ip):
+    if not is_internal_ip(real_ip):
         logger.trace(
             f"Failed API key authentication attempt from {real_ip}. "
             f"Total attempts: {previous_attempts + 1}"

--- a/ayon_server/api/auth.py
+++ b/ayon_server/api/auth.py
@@ -110,6 +110,7 @@ async def user_from_api_key(api_key: str, request: Request) -> UserEntity:
     await asyncio.sleep(0.2)
     raise UnauthorizedException("Invalid API key")
 
+
 async def user_from_request(request: Request) -> UserEntity:
     """Get user from request"""
 

--- a/ayon_server/api/auth.py
+++ b/ayon_server/api/auth.py
@@ -75,17 +75,17 @@ async def user_from_api_key(api_key: str) -> UserEntity:
             WHERE ak->>'key' = $1
         )
     """
-    if not (result := await Postgres.fetch(query, hashed_key)):
-        raise UnauthorizedException("Invalid API key")
-    user = UserEntity.from_record(result[0])
-    if user.data.get("apiKey") == hashed_key:
-        return user
-    for key_data in user.data.get("apiKeys", []):
-        if key_data.get("key") != hashed_key:
-            continue
-        if key_data.get("expires") and key_data["expires"] < time.time():
-            raise UnauthorizedException("API key has expired")
-        return user
+    if result := await Postgres.fetch(query, hashed_key):
+        user = UserEntity.from_record(result[0])
+        if user.data.get("apiKey") == hashed_key:
+            return user
+        for key_data in user.data.get("apiKeys", []):
+            if key_data.get("key") != hashed_key:
+                continue
+            if not key_data.get("expires") or key_data["expires"] > time.time():
+                return user
+
+    await Session.mark_invalid(api_key)
     raise UnauthorizedException("Invalid API key. This shouldn't happen")
 
 
@@ -112,6 +112,7 @@ async def user_from_request(request: Request) -> UserEntity:
 
     elif access_token := access_token_from_request(request):
         session_data = await Session.check(access_token, request)
+
     else:
         raise UnauthorizedException("Access token is missing")
 

--- a/ayon_server/api/auth.py
+++ b/ayon_server/api/auth.py
@@ -108,8 +108,7 @@ async def user_from_api_key(api_key: str, request: Request) -> UserEntity:
 
     # if the API key is invalid, wait a little to prevent brute-force attacks
     await asyncio.sleep(0.2)
-    raise UnauthorizedException("Invalid API key. This shouldn't happen")
-
+    raise UnauthorizedException("Invalid API key")
 
 async def user_from_request(request: Request) -> UserEntity:
     """Get user from request"""

--- a/ayon_server/api/clientinfo.py
+++ b/ayon_server/api/clientinfo.py
@@ -1,5 +1,3 @@
-import contextlib
-import ipaddress
 import os
 
 import geoip2
@@ -9,6 +7,7 @@ from fastapi import Request
 from pydantic import BaseModel, Field
 
 from ayon_server.config import ayonconfig
+from ayon_server.utils.server import get_real_ip_from_request, is_internal_ip
 
 
 class LocationInfo(BaseModel):
@@ -32,10 +31,8 @@ class ClientInfo(BaseModel):
 
 
 def get_real_ip(request: Request) -> str:
-    if request.client is None:
-        return "0.0.0.0"
-    xff = request.headers.get("x-forwarded-for", request.client.host)
-    return xff.split(",")[0].strip()
+    # deprecated, use get_real_ip_from_request instead
+    return get_real_ip_from_request(request)
 
 
 def geo_lookup(ip: str):
@@ -53,17 +50,6 @@ def geo_lookup(ip: str):
         subdivision=response.subdivisions.most_specific.name,
         city=response.city.name,
     )
-
-
-def is_internal_ip(ip: str) -> bool:
-    with contextlib.suppress(ValueError):
-        if ipaddress.IPv4Address(ip).is_private:
-            return True
-
-    with contextlib.suppress(ValueError):
-        if ipaddress.IPv6Address(ip).is_private:
-            return True
-    return False
 
 
 def parse_ayon_headers(request: Request) -> dict[str, str]:
@@ -123,7 +109,7 @@ def get_preferred_languages(request: Request) -> list[str]:
 
 
 def get_client_info(request: Request) -> ClientInfo:
-    ip = get_real_ip(request)
+    ip = get_real_ip_from_request(request)
     if is_internal_ip(ip):
         location = None
     else:

--- a/ayon_server/auth/password.py
+++ b/ayon_server/auth/password.py
@@ -2,7 +2,6 @@ import time
 
 from fastapi import Request
 
-from ayon_server.api.clientinfo import get_real_ip
 from ayon_server.auth.session import Session, SessionModel
 from ayon_server.auth.utils import (
     create_password,
@@ -17,6 +16,7 @@ from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.logging import logger
 from ayon_server.utils import json_dumps
+from ayon_server.utils.server import get_real_ip_from_request
 
 
 async def check_failed_login(ip_address: str) -> None:
@@ -73,7 +73,7 @@ class PasswordAuth:
         # TODO: this should raise 401, not 403
 
         if request is not None:
-            await check_failed_login(get_real_ip(request))
+            await check_failed_login(get_real_ip_from_request(request))
 
         name = name.strip()
 
@@ -100,11 +100,11 @@ class PasswordAuth:
 
         if pass_hash != hash_password(password, pass_salt):
             if request is not None:
-                await set_failed_login(get_real_ip(request))
+                await set_failed_login(get_real_ip_from_request(request))
             raise ForbiddenException("Invalid login/password combination")
 
         if request is not None:
-            await clear_failed_login(get_real_ip(request))
+            await clear_failed_login(get_real_ip_from_request(request))
         return await Session.create(user, request)
 
     @classmethod

--- a/ayon_server/auth/session.py
+++ b/ayon_server/auth/session.py
@@ -66,9 +66,9 @@ class Session:
             return None
 
         if data.get("isInvalid", False):
-            # this is to cache invalid api keys
-            logger.trace(f"Session {token} is marked as invalid")
-            return None
+            # if a session is marked as invalid, raise Unauthorized immediately
+            # without giving the user a chance to refresh the token.
+            raise UnauthorizedException("Invalid session")
 
         session = SessionModel(**data)
 
@@ -210,7 +210,8 @@ class Session:
 
     @classmethod
     async def list(
-        cls, user_name: str | None = None
+        cls,
+        user_name: str | None = None,
     ) -> AsyncGenerator[SessionModel, None]:
         """List active sessions for all or given user
 
@@ -222,7 +223,11 @@ class Session:
             if data is None:
                 continue  # this should never happen, but keeps mypy happy
 
-            session = SessionModel(**json_loads(data))
+            payload = json_loads(data)
+            if payload.get("isInvalid", False):
+                # skip invalid sessions
+                continue
+            session = SessionModel(**payload)
             if cls.is_expired(session):
                 await cls.delete(session.token, message="Session expired")
                 continue

--- a/ayon_server/auth/session.py
+++ b/ayon_server/auth/session.py
@@ -68,6 +68,7 @@ class Session:
         if data.get("isInvalid", False):
             # if a session is marked as invalid, raise Unauthorized immediately
             # without giving the user a chance to refresh the token.
+            await asyncio.sleep(0.2)
             raise UnauthorizedException("Invalid session")
 
         session = SessionModel(**data)

--- a/ayon_server/auth/session.py
+++ b/ayon_server/auth/session.py
@@ -298,7 +298,10 @@ class Session:
         else:
             logger.trace(f"Updating user {user.name} sessions after save")
             async for session in Session.list(user.name):
-                await Session.update(session.token, user)
+                if session.is_service:
+                    await Session.delete(session.token, message="Service session reset")
+                else:
+                    await Session.update(session.token, user)
 
 
 UserEntity.save_hooks.append(Session.user_save_hook)

--- a/ayon_server/auth/session.py
+++ b/ayon_server/auth/session.py
@@ -70,6 +70,7 @@ class Session:
 
         if data.get("isInvalid", False):
             # this is to cache invalid api keys
+            logger.trace(f"Session {token} is marked as invalid")
             return None
 
         session = SessionModel(**data)

--- a/ayon_server/auth/session.py
+++ b/ayon_server/auth/session.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from fastapi import Request
 
-from ayon_server.api.clientinfo import ClientInfo, get_client_info, get_real_ip
+from ayon_server.api.clientinfo import ClientInfo, get_client_info
 from ayon_server.config import ayonconfig
 from ayon_server.entities import UserEntity
 from ayon_server.events import EventStream
@@ -18,6 +18,12 @@ from ayon_server.lib.redis import Redis
 from ayon_server.logging import logger
 from ayon_server.types import OPModel
 from ayon_server.utils import json_dumps, json_loads
+from ayon_server.utils.server import get_real_ip_from_request, is_internal_ip
+
+
+def is_local_ip(ip: str) -> bool:
+    # Deprecated, but still used for backward compatibility.
+    return is_internal_ip(ip)
 
 
 class SessionModel(OPModel):
@@ -35,15 +41,6 @@ class SessionModel(OPModel):
             payload=self.user.dict(),
             exists=True,
         )
-
-
-def is_local_ip(ip: str) -> bool:
-    return (
-        ip.startswith("127.")
-        or ip.startswith("10.")
-        or ip.startswith("192.168.")
-        or ip.startswith("172.")
-    )
 
 
 class Session:
@@ -88,8 +85,8 @@ class Session:
                 session.last_used = time.time()
                 await Redis.set(cls.ns, token, session.json())
             elif not ayonconfig.disable_check_session_ip:
-                real_ip = get_real_ip(request)
-                if not is_local_ip(real_ip):
+                real_ip = get_real_ip_from_request(request)
+                if not is_internal_ip(real_ip):
                     if session.client_info.ip != real_ip:
                         r = f"Stored: {session.client_info.ip}, current: {real_ip}"
                         await cls.delete(token, f"Client IP mismatch: {r}")

--- a/ayon_server/auth/session.py
+++ b/ayon_server/auth/session.py
@@ -122,7 +122,7 @@ class Session:
         database lookups for them.
         """
         data = {"isInvalid": True}
-        await Redis.set_json(cls.ns, token, data)
+        await Redis.set_json(cls.ns, token, data, ttl=60)
 
     @classmethod
     async def create(

--- a/ayon_server/auth/session.py
+++ b/ayon_server/auth/session.py
@@ -63,12 +63,16 @@ class Session:
         If it's not expired, update the last_used field and extend
         its lifetime.
         """
-        data = await Redis.get(cls.ns, token)
+        data = await Redis.get_json(cls.ns, token)
         if not data:
             logger.trace(f"Session {token} not found")
             return None
 
-        session = SessionModel(**json_loads(data))
+        if data.get("isInvalid", False):
+            # this is to cache invalid api keys
+            return None
+
+        session = SessionModel(**data)
 
         if cls.is_expired(session):
             await cls.delete(token, "Session expired")
@@ -109,6 +113,16 @@ class Session:
     @classmethod
     async def on_extend(cls, session: SessionModel) -> None:
         pass
+
+    @classmethod
+    async def mark_invalid(cls, token: str) -> None:
+        """Mark a session as invalid without deleting it.
+
+        This is used to cache invalid API keys and prevent repeated
+        database lookups for them.
+        """
+        data = {"isInvalid": True}
+        await Redis.set_json(cls.ns, token, data)
 
     @classmethod
     async def create(

--- a/ayon_server/entities/user.py
+++ b/ayon_server/entities/user.py
@@ -307,6 +307,10 @@ class UserEntity(TopLevelEntity):
                 except Postgres.UndefinedTableError:
                     continue
 
+        from ayon_server.auth.session import Session
+
+        await Session.logout_user(self.name, message="Account has been deleted")
+
         return res[0]["count"]
 
     #

--- a/ayon_server/lib/redis.py
+++ b/ayon_server/lib/redis.py
@@ -161,11 +161,13 @@ class Redis:
         await cls.redis_pool.delete(f"{cls.prefix}{namespace}-{key}")
 
     @classmethod
-    async def incr(cls, namespace: str, key: str) -> int:
+    async def incr(cls, namespace: str, key: str, *, ttl: int = 0) -> int:
         """Increment a value in Redis"""
         if not cls.connected:
             await cls.connect()
         res = await cls.redis_pool.incr(f"{cls.prefix}{namespace}-{key}")
+        if ttl:
+            await cls.redis_pool.expire(f"{cls.prefix}{namespace}-{key}", ttl)
         return res
 
     @classmethod

--- a/ayon_server/utils/server.py
+++ b/ayon_server/utils/server.py
@@ -1,6 +1,28 @@
+import contextlib
+import ipaddress
 from urllib.parse import urlparse
 
 from fastapi import Request
+
+
+def is_internal_ip(ip: str) -> bool:
+    """Check if the given IP address is internal (private)"""
+    with contextlib.suppress(ValueError):
+        if ipaddress.IPv4Address(ip).is_private:
+            return True
+
+    with contextlib.suppress(ValueError):
+        if ipaddress.IPv6Address(ip).is_private:
+            return True
+    return False
+
+
+def get_real_ip_from_request(request: Request) -> str:
+    """Get the real client IP address from the request, considering possible proxies."""
+    if request.client is None:
+        return "0.0.0.0"
+    xff = request.headers.get("x-forwarded-for", request.client.host)
+    return xff.split(",")[0].strip()
 
 
 def server_url_from_request(request: Request) -> str:


### PR DESCRIPTION
This pull request refactors and centralizes logic related to client IP address detection and internal IP checks, and adds new security measures to prevent brute-force attacks on API keys. The most significant changes include introducing utility functions for IP handling, updating authentication and session logic to use these utilities, and implementing brute-force protection for API key authentication.

**Security and Authentication Improvements:**

* Added brute-force protection to `user_from_api_key` by tracking failed attempts per IP in Redis, limiting to 100 attempts, logging failures, and introducing a delay on invalid attempts. Also, invalid API keys are now cached as invalid sessions to reduce database load. 
* Updated session validation to immediately reject tokens marked as invalid and to use the new IP utility functions for more consistent IP checks. 

**Utility Function Refactoring:**

* Introduced `get_real_ip_from_request` and `is_internal_ip` in a new utility module `ayon_server/utils/server.py`, replacing scattered and duplicated IP logic across the codebase. 
* Refactored all usages of client IP and internal IP checks in authentication, session, and client info modules to use these new utility functions.
* Removed deprecated or duplicated IP functions from `clientinfo.py` and replaced them with calls to the new utility functions.


These changes improve security, reduce code duplication, and make IP-related logic more reliable and easier to maintain.