### PR TITLE
Resolve: support latestApproved version alias

### DIFF
--- a/api/resolve/__init__.py
+++ b/api/resolve/__init__.py
@@ -167,6 +167,21 @@ def get_version_conditions(version_name: str | None) -> list[str]:
         """
         ]
 
+    if version_name == "latestapproved":
+        return [
+            """
+            v.id in (
+                SELECT approved_versions.id
+                FROM (
+                    SELECT DISTINCT ON (product_id) id
+                    FROM versions
+                    WHERE version >= 0 AND lower(status) = 'approved'
+                    ORDER BY product_id, version DESC
+                ) AS approved_versions
+            )
+        """
+        ]
+
     if version_name == "hero":
         return ["v.version < 0"]
 

--- a/tests/resolve_latest_approved_test.py
+++ b/tests/resolve_latest_approved_test.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from api.resolve.__init__ import get_version_conditions, parse_uri
+
+
+def test_parse_uri_accepts_latest_approved_alias():
+    parsed = parse_uri(
+        "ayon+entity://myproject/assets/asset?product=renderMain&version=latestApproved"
+    )
+
+    assert parsed.version_name == "latestApproved"
+
+
+def test_get_version_conditions_supports_latest_approved():
+    conditions = get_version_conditions("latestApproved")
+
+    assert len(conditions) == 1
+    condition = conditions[0]
+    assert "SELECT DISTINCT ON (product_id) id" in condition
+    assert "lower(status) = 'approved'" in condition
+    assert "ORDER BY product_id, version DESC" in condition
+
+
+def test_get_version_conditions_normalizes_latest_approved_casing():
+    assert get_version_conditions("LatestApproved") == get_version_conditions(
+        "latestApproved"
+    )


### PR DESCRIPTION
## Description of changes

Adds support for ersion=latestApproved in the resolve endpoint so URI resolution can target the newest approved version for each product.

## Technical details

- extends get_version_conditions() with a latestApproved alias
- resolves against the highest non-hero version whose status is pproved (case-insensitive)
- adds focused tests for URI parsing and condition generation

Closes #944