### PR TITLE
Actions: gate staging variant behind allowStagingMode

### DIFF
--- a/api/actions/actions.py
+++ b/api/actions/actions.py
@@ -8,6 +8,7 @@ from ayon_server.actions.context import ActionContext
 from ayon_server.actions.execute import ActionExecutor, ExecuteResponseModel
 from ayon_server.actions.listing import (
     AvailableActionsListModel,
+    can_access_staging_actions,
     get_action_whitelist,
     get_dynamic_actions,
     get_simple_actions,
@@ -22,6 +23,11 @@ from ayon_server.types import Field, OPModel
 from .router import router
 
 ActionListMode = Literal["simple", "dynamic", "all"]
+
+
+def ensure_action_variant_access(user: CurrentUser, variant: str | None) -> None:
+    if variant == "staging" and not can_access_staging_actions(user):
+        raise ForbiddenException("You are not allowed to access staging actions")
 
 
 @router.post("/list", response_model_exclude_none=True, dependencies=[AllowGuests])
@@ -54,6 +60,8 @@ async def list_available_actions_for_context(
         # Guests cannot see actions, but we don't want to
         # throw 403 here
         return AvailableActionsListModel(actions=[])
+
+    ensure_action_variant_access(user, variant)
 
     if mode == "simple":
         r = await get_simple_actions(user, context, variant)
@@ -106,6 +114,7 @@ async def configure_action(
     variant: str = Query("production", title="Action Variant"),
     identifier: str = Query(..., title="Action Identifier"),
 ) -> dict[str, Any]:
+    ensure_action_variant_access(user, variant)
     addon = AddonLibrary.addon(addon_name, addon_version)
     config_dict = config.dict()
     config_value = config_dict.pop("value", None)
@@ -145,6 +154,7 @@ async def execute_action(
     This endpoint is used to run an action on a context.
     This is called from the frontend when the user selects an action to run.
     """
+    ensure_action_variant_access(user, variant)
 
     action_whitelist = await get_action_whitelist(user, context.project_name)
     if action_whitelist is not None:

--- a/ayon_server/actions/listing.py
+++ b/ayon_server/actions/listing.py
@@ -96,6 +96,7 @@ async def get_relevant_addons(
 
     returns a tuple of variant and list of addons
     """
+    variant = sanitize_action_variant(variant, user)
     is_developer = user.is_developer and user.attrib.developerMode
     user_last_modified = str(user.updated_at)
 
@@ -105,6 +106,20 @@ async def get_relevant_addons(
         is_developer,
         user_last_modified,
     )
+
+
+def can_access_staging_actions(user: UserEntity) -> bool:
+    attrib = getattr(user, "attrib", None)
+    return bool(
+        (user.is_developer and getattr(attrib, "developerMode", False))
+        or getattr(attrib, "allowStagingMode", False)
+    )
+
+
+def sanitize_action_variant(variant: str | None, user: UserEntity) -> str | None:
+    if variant == "staging" and not can_access_staging_actions(user):
+        return "production"
+    return variant
 
 
 def match_list_subtypes(

--- a/tests/staging_actions_test.py
+++ b/tests/staging_actions_test.py
@@ -1,0 +1,103 @@
+import asyncio
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from api.actions.actions import ensure_action_variant_access
+from ayon_server.actions import listing
+from ayon_server.exceptions import ForbiddenException
+
+
+def make_user(
+    *,
+    is_developer: bool = False,
+    developer_mode: bool = False,
+    allow_staging_mode: bool = False,
+):
+    return SimpleNamespace(
+        is_developer=is_developer,
+        name="artist",
+        updated_at="2026-06-08T00:00:00Z",
+        attrib=SimpleNamespace(
+            developerMode=developer_mode,
+            allowStagingMode=allow_staging_mode,
+        ),
+    )
+
+
+def test_can_access_staging_actions_for_developer_mode():
+    user = make_user(is_developer=True, developer_mode=True)
+
+    assert listing.can_access_staging_actions(user) is True
+
+
+def test_can_access_staging_actions_for_allow_staging_flag():
+    user = make_user(allow_staging_mode=True)
+
+    assert listing.can_access_staging_actions(user) is True
+
+
+def test_sanitize_action_variant_falls_back_to_production():
+    user = make_user()
+
+    assert listing.sanitize_action_variant("staging", user) == "production"
+
+
+def test_ensure_action_variant_access_rejects_unauthorized_staging():
+    user = make_user()
+
+    try:
+        ensure_action_variant_access(user, "staging")
+    except ForbiddenException as exc:
+        assert exc.status == 403
+        assert "staging actions" in exc.detail
+    else:
+        raise AssertionError("Expected unauthorized staging access to fail")
+
+
+def test_ensure_action_variant_access_allows_flagged_user():
+    user = make_user(allow_staging_mode=True)
+
+    ensure_action_variant_access(user, "staging")
+
+
+def test_get_relevant_addons_preserves_staging_for_allowed_user():
+    user = make_user(allow_staging_mode=True)
+    captured: list[str | None] = []
+
+    async def fake_load_relevant_addons(user_name, variant, is_developer, user_last_modified):
+        captured.append(variant)
+        return variant or "production", []
+
+    original = listing._load_relevant_addons
+    listing._load_relevant_addons = fake_load_relevant_addons
+    try:
+        variant, addons = asyncio.run(listing.get_relevant_addons("staging", user))
+    finally:
+        listing._load_relevant_addons = original
+
+    assert variant == "staging"
+    assert addons == []
+    assert captured == ["staging"]
+
+
+def test_get_relevant_addons_downgrades_staging_for_unauthorized_user():
+    user = make_user()
+    captured: list[str | None] = []
+
+    async def fake_load_relevant_addons(user_name, variant, is_developer, user_last_modified):
+        captured.append(variant)
+        return variant or "production", []
+
+    original = listing._load_relevant_addons
+    listing._load_relevant_addons = fake_load_relevant_addons
+    try:
+        variant, addons = asyncio.run(listing.get_relevant_addons("staging", user))
+    finally:
+        listing._load_relevant_addons = original
+
+    assert variant == "production"
+    assert addons == []
+    assert captured == ["production"]


### PR DESCRIPTION
## Description of changes

Adds backend gating for action access when ariant=staging, using the new llowStagingMode user flag as an alternative to developer mode.

## Technical details

- adds a shared helper to detect whether a user may access staging actions
- blocks unauthorized staging access for action listing, configuration and execution
- falls back to production addons when staging is requested internally without permission
- adds focused tests for the new staging access behavior

Closes #935