### PR TITLE
Operations: avoid loguru format errors when logging validation details

### DIFF
--- a/ayon_server/operations/project_level/__init__.py
+++ b/ayon_server/operations/project_level/__init__.py
@@ -35,6 +35,24 @@ from .entity_update import update_project_level_entity
 from .models import OperationModel, OperationResponseModel, OperationsResponseModel
 
 
+def _log_validation_error(
+    op_tag: str,
+    validation_errors: list[dict[str, Any]],
+    *,
+    project_name: str,
+    operation_id: str,
+) -> None:
+    """Log pydantic validation errors without exposing loguru formatting bugs."""
+
+    logger.debug(
+        "{} Validation error: {}",
+        op_tag,
+        validation_errors,
+        project=project_name,
+        operation_id=operation_id,
+    )
+
+
 async def _process_events(
     events: list[dict[str, Any]],
     *,
@@ -205,7 +223,12 @@ async def _process_operations(
                 project=project_name,
                 operation_id=operation.id,
             ):
-                logger.debug(f"{op_tag} Validation error: {e.errors()}")
+                _log_validation_error(
+                    op_tag,
+                    e.errors(),
+                    project_name=project_name,
+                    operation_id=operation.id,
+                )
             result.append(
                 OperationResponseModel(
                     success=False,

--- a/tests/operations_logging_test.py
+++ b/tests/operations_logging_test.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from ayon_server.operations.project_level.__init__ import _log_validation_error
+
+
+def test_log_validation_error_handles_braces_in_payload():
+    validation_errors = [
+        {
+            "loc": ("attrib", "customAttrib", 2),
+            "msg": "unexpected value",
+            "type": "value_error",
+            "ctx": {"value": "4"},
+        }
+    ]
+
+    _log_validation_error(
+        "[FOLDER UPDATE]",
+        validation_errors,
+        project_name="demo",
+        operation_id="operation-1",
+    )


### PR DESCRIPTION
## Summary
- log validation errors with parameterized formatting so brace characters in payloads do not break loguru
- keep the existing project and operation metadata on the log entry
- add a focused regression test for validation errors that include JSON-like values

Closes #794