### PR TITLE
GraphQL sorting optimization

### DIFF
--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -76,12 +76,10 @@ def create_pagination(
 
         if ctype and not is_jsonb:
             # Known non-nullable top-level field
-
             keys.append(f"{ob}")
             if ctype == "text":
                 val_str = str(val).replace("'", "''") if val is not None else ""
                 sql_val = f"'{val_str}'::text"
-
             elif ctype == "timestamptz":
                 sql_val = f"'{val}'::timestamptz"
                 if not isinstance(val, str) or not re.match(
@@ -90,7 +88,6 @@ def create_pagination(
                     raise BadRequestException(
                         f"Invalid value for timestamptz field: {val}"
                     )
-
             else:  # numeric
                 if not isinstance(val, (int, float)):
                     raise BadRequestException(f"Invalid value for numeric field: {val}")
@@ -103,45 +100,43 @@ def create_pagination(
             cast = "numeric"
             # default = "'0'"
             sql_val = f"{val}::numeric"
-
         elif isinstance(val, str) and re.match(
             r"^\d{4}-\d{2}-\d{2}T[0-9:\.\+\-Z]+$", val
         ):
             cast = "timestamptz"
             # default = "'1970-01-01T00:00:00Z'"
             sql_val = f"'{val}'::timestamptz"
-
         else:
             cast = "text"
             # default = "'\"\"'"
             v_str = str(val).replace("'", "''") if val is not None else ""
             sql_val = f"'{v_str}'::text"
 
-        keys.append(f"({ob})::{cast}")
-
-        # Probably not needed, just handle nulls as-is
         # if is_jsonb:
         #     keys.append(f"COALESCE({ob}, {default}::jsonb)::{cast}")
         # else:
         #     keys.append(f"COALESCE({ob}, {default})::{cast}")
+
+        keys.append(f"({ob})::{cast}")
         cursor_values.append(sql_val)
 
     for i, c in enumerate(order_by):
-        cursor_arr.append(f"{c} AS cursor_{i}")
         ordering_arr.append(f"{c} {'DESC' if last else 'ASC'}")
+        cursor_arr.append(f"{c} AS cursor_{i}")
+
+    #
+    # Create cursor conditions
+    #
 
     if not keys:
         conditions = ""
     else:
-        cond_parts = []
-        for i in range(len(keys)):
-            line = []
-            for j in range(i):
-                line.append(f"{keys[j]} = {cursor_values[j]}")
-            line.append(f"{keys[i]} {operator} {cursor_values[i]}")
-            cond_parts.append(f"({' AND '.join(line)})")
-
-        conditions = f"({' OR '.join(cond_parts)})"
+        if len(keys) > 1:
+            keys_str = ", ".join(keys)
+            vals_str = ", ".join(cursor_values)
+            conditions = f"({keys_str}) {operator} ({vals_str})"
+        else:
+            conditions = f"{keys[0]} {operator} {cursor_values[0]}"
 
     limit = (first or last or 500) * 2
 

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -85,7 +85,7 @@ def create_pagination(
         # Fallback for nullable fields or JSONB
         if isinstance(val, (int, float)):
             cast = "numeric"
-            default = "0"
+            default = "'0'"
             sql_val = f"{val}::numeric"
         elif isinstance(val, str) and re.match(
             r"^\d{4}-\d{2}-\d{2}T[0-9:\.\+\-Z]+$", val
@@ -95,7 +95,7 @@ def create_pagination(
             sql_val = f"'{val}'::timestamptz"
         else:
             cast = "text"
-            default = "''"
+            default = "'\"\"'"
             v_str = str(val).replace("'", "''") if val is not None else ""
             sql_val = f"'{v_str}'::text"
 

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -2,6 +2,7 @@ import re
 from base64 import b64decode, b64encode
 from typing import Any
 
+from ayon_server.exceptions import BadRequestException
 from ayon_server.logging import logger
 from ayon_server.utils import json_dumps, json_loads
 
@@ -14,6 +15,7 @@ COLUMN_TYPES = {
     "updated_at": "timestamptz",
     "status": "text",
     "creation_order": "numeric",
+    "path": "text",
 }
 
 
@@ -21,7 +23,10 @@ def decode_cursor(cursor: str | None) -> list[Any]:
     if not cursor:
         return []
     try:
-        return json_loads(b64decode(cursor).decode())
+        cur = json_loads(b64decode(cursor).decode())
+        if not isinstance(cur, list):
+            raise BadRequestException("Cursor must decode to a list")
+        return cur
     except Exception as e:
         logger.debug(f"Invalid cursor {e}")
         return []
@@ -71,14 +76,22 @@ def create_pagination(
 
         if ctype and not is_jsonb:
             # Known non-nullable top-level field
-            keys.append(f"{ob}::{ctype}")
+            keys.append(f"{ob}")
             if ctype == "text":
                 val_str = str(val).replace("'", "''") if val is not None else ""
                 sql_val = f"'{val_str}'::text"
             elif ctype == "timestamptz":
                 sql_val = f"'{val}'::timestamptz"
+                if not isinstance(val, str) or not re.match(
+                    r"^\d{4}-\d{2}-\d{2}T[0-9:\.\+\-Z]+$", val
+                ):
+                    raise BadRequestException(
+                        f"Invalid value for timestamptz field: {val}"
+                    )
             else:  # numeric
-                sql_val = f"{val or 0}::numeric"
+                sql_val = f"{val or 0}"
+                if not isinstance(val, (int, float)):
+                    raise BadRequestException(f"Invalid value for numeric field: {val}")
             cursor_values.append(sql_val)
             continue
 

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -76,10 +76,12 @@ def create_pagination(
 
         if ctype and not is_jsonb:
             # Known non-nullable top-level field
+
             keys.append(f"{ob}")
             if ctype == "text":
                 val_str = str(val).replace("'", "''") if val is not None else ""
                 sql_val = f"'{val_str}'::text"
+
             elif ctype == "timestamptz":
                 sql_val = f"'{val}'::timestamptz"
                 if not isinstance(val, str) or not re.match(
@@ -88,6 +90,7 @@ def create_pagination(
                     raise BadRequestException(
                         f"Invalid value for timestamptz field: {val}"
                     )
+
             else:  # numeric
                 if not isinstance(val, (int, float)):
                     raise BadRequestException(f"Invalid value for numeric field: {val}")
@@ -98,24 +101,29 @@ def create_pagination(
         # Fallback for nullable fields or JSONB
         if isinstance(val, (int, float)):
             cast = "numeric"
-            default = "'0'"
+            # default = "'0'"
             sql_val = f"{val}::numeric"
+
         elif isinstance(val, str) and re.match(
             r"^\d{4}-\d{2}-\d{2}T[0-9:\.\+\-Z]+$", val
         ):
             cast = "timestamptz"
-            default = "'1970-01-01T00:00:00Z'"
+            # default = "'1970-01-01T00:00:00Z'"
             sql_val = f"'{val}'::timestamptz"
+
         else:
             cast = "text"
-            default = "'\"\"'"
+            # default = "'\"\"'"
             v_str = str(val).replace("'", "''") if val is not None else ""
             sql_val = f"'{v_str}'::text"
 
-        if is_jsonb:
-            keys.append(f"COALESCE({ob}, {default}::jsonb)::{cast}")
-        else:
-            keys.append(f"COALESCE({ob}, {default})::{cast}")
+        keys.append(f"({ob})::{cast}")
+
+        # Probably not needed, just handle nulls as-is
+        # if is_jsonb:
+        #     keys.append(f"COALESCE({ob}, {default}::jsonb)::{cast}")
+        # else:
+        #     keys.append(f"COALESCE({ob}, {default})::{cast}")
         cursor_values.append(sql_val)
 
     for i, c in enumerate(order_by):

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -64,16 +64,15 @@ def create_pagination(
         which the resolver uses to construct the actual cursor.
     """
 
-    if len(order_by) > 2:
-        raise ValueError("Order by can have only two fields")
     cursor_arr = []
     ordering_arr = []
     decoded_cursor, casts = decode_cursor(before or after)
     operator = "<" if before else ">"
 
     keys = []
-    for i, cast in enumerate(casts):
+    for i in range(min(len(order_by), len(decoded_cursor))):
         ob = order_by[i]
+        cast = casts[i]
         if "->" in ob:
             if cast == "::numeric":
                 keys.append(f"COALESCE({ob}, '0'::jsonb){cast}")
@@ -93,27 +92,18 @@ def create_pagination(
         cursor_arr.append(f"{c} AS cursor_{i}")
         ordering_arr.append(f"{c} {'DESC NULLS LAST' if last else 'ASC NULLS FIRST'}")
 
-    # Okay. I know this looks like something a 5YO would write, but hear me out.
-    # We don't need to support more than two cursors. Hopefully.
-    # So trust me, even if this is a mess, it is still MUCH more readable than
-    # doing it a loop for every cursor element. We just cover two cases,
-    # (or three if you're counting 'no cursor').
-
-    if len(decoded_cursor) == 1:
-        conditions = f"""
-        ({keys[0]} {operator} {decoded_cursor[0]})
-        """
-    elif len(decoded_cursor) == 2:
-        conditions = f"""
-        (
-            {keys[0]} {operator} {decoded_cursor[0]}
-        OR (
-            {keys[0]} = {decoded_cursor[0]}
-            AND {keys[1]} {operator} {decoded_cursor[1]}
-           )
-        )"""
-    else:
+    if not keys:
         conditions = ""
+    else:
+        cond_parts = []
+        for i in range(len(keys)):
+            line = []
+            for j in range(i):
+                line.append(f"{keys[j]} = {decoded_cursor[j]}")
+            line.append(f"{keys[i]} {operator} {decoded_cursor[i]}")
+            cond_parts.append(f"({' AND '.join(line)})")
+
+        conditions = f"({' OR '.join(cond_parts)})"
 
     ordering = "ORDER BY " + ", ".join(ordering_arr)
     cursor = ", ".join(cursor_arr)

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -5,36 +5,26 @@ from typing import Any
 from ayon_server.logging import logger
 from ayon_server.utils import json_dumps, json_loads
 
+# Top-level non-nullable fields.
+# We don't need COALESCE for these.
+COLUMN_TYPES = {
+    "id": "text",
+    "name": "text",
+    "created_at": "timestamptz",
+    "updated_at": "timestamptz",
+    "status": "text",
+    "creation_order": "numeric",
+}
 
-def decode_cursor(cursor: str | None) -> tuple[list[str], list[str]]:
-    """
-    returns a list of cursor values and casts
-    """
 
+def decode_cursor(cursor: str | None) -> list[Any]:
     if not cursor:
-        return ([], [])
+        return []
     try:
-        cur_data = json_loads(b64decode(cursor).decode())
-        vals = []
-        casts = []
-        for c in cur_data:
-            if isinstance(c, str):
-                # Check if the value is a timestamp in ISO format
-                if re.match(r"^\d{4}-\d{2}-\d{2}T[0-9:\.\+\-Z]+$", c):
-                    # Convert to timestamp
-                    vals.append(f"'{c}'::timestamptz")
-                    casts.append("::timestamptz")
-                else:
-                    val = c.replace("'", "''") if c else ""
-                    vals.append(f"'{val}'::text")
-                    casts.append("::text")
-            else:
-                vals.append(f"{c or 0}::numeric")
-                casts.append("::numeric")
-        return vals, casts
+        return json_loads(b64decode(cursor).decode())
     except Exception as e:
         logger.debug(f"Invalid cursor {e}")
-        return ([], [])
+        return []
 
 
 def encode_cursor(decoded_cursor: list[Any]) -> str:
@@ -66,31 +56,58 @@ def create_pagination(
 
     cursor_arr = []
     ordering_arr = []
-    decoded_cursor, casts = decode_cursor(before or after)
+    decoded_cursor = decode_cursor(before or after)
     operator = "<" if before else ">"
 
     keys = []
+    cursor_values = []
     for i in range(min(len(order_by), len(decoded_cursor))):
         ob = order_by[i]
-        cast = casts[i]
-        if "->" in ob:
-            if cast == "::numeric":
-                keys.append(f"COALESCE({ob}, '0'::jsonb){cast}")
-            elif cast == "::timestamptz":
-                keys.append(f"COALESCE({ob}, '1970-01-01T00:00:00Z'::jsonb){cast}")
-            else:
-                keys.append(f"COALESCE({ob}, ''::jsonb){cast}")
+        val = decoded_cursor[i]
+        col_name = ob.split(".")[-1]
+
+        is_jsonb = "->" in ob
+        ctype = COLUMN_TYPES.get(col_name)
+
+        if ctype and not is_jsonb:
+            # Known non-nullable top-level field
+            keys.append(f"{ob}::{ctype}")
+            if ctype == "text":
+                val_str = str(val).replace("'", "''") if val is not None else ""
+                sql_val = f"'{val_str}'::text"
+            elif ctype == "timestamptz":
+                sql_val = f"'{val}'::timestamptz"
+            else:  # numeric
+                sql_val = f"{val or 0}::numeric"
+            cursor_values.append(sql_val)
+            continue
+
+        # Fallback for nullable fields or JSONB
+        if isinstance(val, (int, float)):
+            cast = "numeric"
+            default = "0"
+            sql_val = f"{val}::numeric"
+        elif isinstance(val, str) and re.match(
+            r"^\d{4}-\d{2}-\d{2}T[0-9:\.\+\-Z]+$", val
+        ):
+            cast = "timestamptz"
+            default = "'1970-01-01T00:00:00Z'"
+            sql_val = f"'{val}'::timestamptz"
         else:
-            if cast == "::numeric":
-                keys.append(f"COALESCE({ob}, 0){cast}")
-            elif cast == "::timestamptz":
-                keys.append(f"COALESCE({ob}, '1970-01-01T00:00:00Z'){cast}")
-            else:
-                keys.append(f"COALESCE({ob}, ''){cast}")
+            cast = "text"
+            default = "''"
+            v_str = str(val).replace("'", "''") if val is not None else ""
+            sql_val = f"'{v_str}'::text"
+
+        if is_jsonb:
+            keys.append(f"COALESCE({ob}, {default}::jsonb)::{cast}")
+        else:
+            keys.append(f"COALESCE({ob}, {default})::{cast}")
+        cursor_values.append(sql_val)
 
     for i, c in enumerate(order_by):
         cursor_arr.append(f"{c} AS cursor_{i}")
-        ordering_arr.append(f"{c} {'DESC NULLS LAST' if last else 'ASC NULLS FIRST'}")
+        ordering_arr.append(f"{c} {'DESC' if last else 'ASC'}")
 
     if not keys:
         conditions = ""
@@ -99,8 +116,8 @@ def create_pagination(
         for i in range(len(keys)):
             line = []
             for j in range(i):
-                line.append(f"{keys[j]} = {decoded_cursor[j]}")
-            line.append(f"{keys[i]} {operator} {decoded_cursor[i]}")
+                line.append(f"{keys[j]} = {cursor_values[j]}")
+            line.append(f"{keys[i]} {operator} {cursor_values[i]}")
             cond_parts.append(f"({' AND '.join(line)})")
 
         conditions = f"({' OR '.join(cond_parts)})"

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -89,9 +89,9 @@ def create_pagination(
                         f"Invalid value for timestamptz field: {val}"
                     )
             else:  # numeric
-                sql_val = f"{val or 0}"
                 if not isinstance(val, (int, float)):
                     raise BadRequestException(f"Invalid value for numeric field: {val}")
+                sql_val = f"{val or 0}"
             cursor_values.append(sql_val)
             continue
 

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -71,7 +71,7 @@ def create_pagination(
         val = decoded_cursor[i]
         col_name = ob.split(".")[-1]
 
-        is_jsonb = "->" in ob
+        is_jsonb = ("->" in ob) and ("->>" not in ob) and ("::" not in ob)
         ctype = COLUMN_TYPES.get(col_name)
 
         if ctype and not is_jsonb:

--- a/ayon_server/graphql/resolvers/pagination.py
+++ b/ayon_server/graphql/resolvers/pagination.py
@@ -122,6 +122,8 @@ def create_pagination(
 
         conditions = f"({' OR '.join(cond_parts)})"
 
-    ordering = "ORDER BY " + ", ".join(ordering_arr)
+    limit = (first or last or 500) * 2
+
+    ordering = "ORDER BY " + ", ".join(ordering_arr) + f" LIMIT {limit}"
     cursor = ", ".join(cursor_arr)
     return ordering, conditions, cursor

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -34,7 +34,6 @@ from .sorting import get_attrib_sort_case, get_status_sort_case
 
 SORT_OPTIONS = {
     "name": "products.name",
-    "path": "hierarchy.path || '/' || products.name",
     "productType": "products.product_type",
     "productBaseType": "products.product_base_type",
     "folderName": "folders.name",
@@ -45,6 +44,8 @@ SORT_OPTIONS = {
     "createdBy": "products.created_by",
     "updatedBy": "products.updated_by",
     "tags": "array_to_string(products.tags, '')",
+    "path": "",  # for docs only
+    "version": "",  # for docs only
 }
 
 
@@ -606,14 +607,10 @@ async def get_products(
         if sort_by == "status":
             status_type_case = get_status_sort_case(project, "products.status")
             order_by.insert(0, status_type_case)
-        elif sort_by in SORT_OPTIONS:
-            order_by.insert(0, SORT_OPTIONS[sort_by])
+
         elif sort_by == "path":
             order_by = ["hierarchy.path", "products.name"]
-        elif sort_by.startswith("attrib."):
-            attr_name = sort_by[7:]
-            attr_case = await get_attrib_sort_case(attr_name, "products.attrib")
-            order_by.insert(0, attr_case)
+
         elif sort_by == "version":
             # count by product version count
             sql_cte.append(
@@ -635,6 +632,14 @@ async def get_products(
                 """
             )
             order_by.insert(0, "COALESCE(pvc.version_count, 0)")
+
+        elif sort_by.startswith("attrib."):
+            attr_name = sort_by[7:]
+            attr_case = await get_attrib_sort_case(attr_name, "products.attrib")
+            order_by.insert(0, attr_case)
+
+        elif sort_by in SORT_OPTIONS:
+            order_by.insert(0, SORT_OPTIONS[sort_by])
 
         else:
             raise ValueError(f"Invalid sort_by value: {sort_by}")

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -670,10 +670,10 @@ async def get_products(
         {ordering}
     """
 
-    print()
-    print("Products query:")
-    print(query)
-    print()
+    # print()
+    # print("Products query:")
+    # print(query)
+    # print()
 
     return await resolve(
         ProductsConnection,

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -608,6 +608,8 @@ async def get_products(
             order_by.insert(0, status_type_case)
         elif sort_by in SORT_OPTIONS:
             order_by.insert(0, SORT_OPTIONS[sort_by])
+        elif sort_by == "path":
+            order_by = ["hierarchy.path", "products.name"]
         elif sort_by.startswith("attrib."):
             attr_name = sort_by[7:]
             attr_case = await get_attrib_sort_case(attr_name, "products.attrib")
@@ -668,10 +670,11 @@ async def get_products(
         {ordering}
     """
 
-    # print()
-    # print (query)
-    # print()
-    #
+    print()
+    print("Products query:")
+    print(query)
+    print()
+
     return await resolve(
         ProductsConnection,
         ProductEdge,

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -213,7 +213,6 @@ async def get_representations(
         {ordering}
     """
 
-    print(query)
 
     return await resolve(
         RepresentationsConnection,

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -213,7 +213,6 @@ async def get_representations(
         {ordering}
     """
 
-
     return await resolve(
         RepresentationsConnection,
         RepresentationEdge,

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -213,6 +213,8 @@ async def get_representations(
         {ordering}
     """
 
+    print(query)
+
     return await resolve(
         RepresentationsConnection,
         RepresentationEdge,

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -563,9 +563,9 @@ FROM project_{project_name}.tasks AS tasks
     """
 
     # Keep it here for debugging :)
-    # from ayon_server.logging import logger
-    #
-    # logger.debug(f"Task query\n{query}")
+    from ayon_server.logging import logger
+
+    logger.debug(f"Task query\n{query}")
 
     return await resolve(
         TasksConnection,

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -562,10 +562,10 @@ FROM project_{project_name}.tasks AS tasks
 {ordering}
     """
 
-    # Keep it here for debugging :)
-    from ayon_server.logging import logger
-
-    logger.debug(f"Task query\n{query}")
+    # print()
+    # print("Tasks query:")
+    # print(query)
+    # print()
 
     return await resolve(
         TasksConnection,

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -528,7 +528,7 @@ async def get_tasks(
         # to have stable sorting when multiple items have the same value
         # In this case we don't want to use creation order as secondary sort,
         # because sorting is mainly invoked from the GUI and path makes more sense
-        order_by.append("hierarchy.path || '/' || tasks.name")
+        order_by.extend(["hierarchy.path", "tasks.name"])
 
     ordering, paging_conds, cursor = create_pagination(
         order_by,

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -656,10 +656,10 @@ async def get_versions(
         {ordering}
     """
 
-    # print()
-    # print("Versions query:")
-    # print(query)
-    # print()
+    print()
+    print("Versions query:")
+    print(query)
+    print()
 
     return await resolve(
         VersionsConnection,

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -47,6 +47,7 @@ SORT_OPTIONS = {
     "folderType": "folders.folder_type",
     "taskName": "tasks.name",
     "taskType": "tasks.task_type",
+    "path": "",  # special case handled in the code (is here for docs)
 }
 
 
@@ -656,10 +657,10 @@ async def get_versions(
         {ordering}
     """
 
-    print()
-    print("Versions query:")
-    print(query)
-    print()
+    # print()
+    # print("Versions query:")
+    # print(query)
+    # print()
 
     return await resolve(
         VersionsConnection,

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -655,10 +655,10 @@ async def get_versions(
         {ordering}
     """
 
-    print()
-    print("Versions query:")
-    print(query)
-    print()
+    # print()
+    # print("Versions query:")
+    # print(query)
+    # print()
 
     return await resolve(
         VersionsConnection,

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -655,10 +655,10 @@ async def get_versions(
         {ordering}
     """
 
-    # print()
-    # print("Versions query:")
-    # print(query)
-    # print()
+    print()
+    print("Versions query:")
+    print(query)
+    print()
 
     return await resolve(
         VersionsConnection,

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -40,7 +40,6 @@ SORT_OPTIONS = {
     "createdBy": "versions.created_by",
     "updatedBy": "versions.updated_by",
     "tags": "array_to_string(versions.tags, '')",
-    "path": "hierarchy.path || '/' || products.name || '/' || LPAD(versions.version::text, 5, '0')",  # noqa 501
     "productType": "products.product_type",
     "productName": "products.name",
     "folderName": "folders.name",
@@ -617,6 +616,8 @@ async def get_versions(
         if sort_by == "status":
             status_type_case = get_status_sort_case(project, "versions.status")
             order_by.insert(0, status_type_case)
+        elif sort_by == "path":
+            order_by = ["hierarchy.path", "products.name", "versions.version"]
         elif sort_by in SORT_OPTIONS:
             order_by.insert(0, SORT_OPTIONS[sort_by])
         elif sort_by.startswith("attrib."):

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -41,6 +41,7 @@ SORT_OPTIONS = {
     "updatedBy": "versions.updated_by",
     "tags": "array_to_string(versions.tags, '')",
     "productType": "products.product_type",
+    "productBaseType": "products.product_base_type",
     "productName": "products.name",
     "folderName": "folders.name",
     "folderType": "folders.folder_type",

--- a/maintenance/tasks/add_missing_project_indexes.py
+++ b/maintenance/tasks/add_missing_project_indexes.py
@@ -6,6 +6,7 @@ INDEXES = {
     "folder_attrib_idx": "folders USING gin(attrib);",
     "folder_type_idx": "folders(folder_type);",
     "folder_status_idx": "folders(status);",
+    "hierarchy_path_idx": "hierarchy(path);",
     "task_type_idx": "tasks(task_type);",
     "task_status_idx": "tasks(status);",
     "task_assignees_idx": "tasks USING gin(assignees);",

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -220,6 +220,7 @@ AS
    SELECT base_id AS id, path FROM htable;
 
 CREATE UNIQUE INDEX hierarchy_id ON hierarchy (id);
+CREATE INDEX hierarchy_path ON hierarchy(path);
 
 
 CREATE TABLE exported_attributes(

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -220,7 +220,7 @@ AS
    SELECT base_id AS id, path FROM htable;
 
 CREATE UNIQUE INDEX hierarchy_id ON hierarchy (id);
-CREATE INDEX hierarchy_path ON hierarchy(path);
+CREATE INDEX hierarchy_path_idx ON hierarchy(path);
 
 
 CREATE TABLE exported_attributes(


### PR DESCRIPTION
This pull request refactors and improves the pagination and sorting logic for GraphQL resolvers, particularly enhancing cursor handling, query ordering, and debugging output. The changes simplify cursor decoding, generalize SQL condition generation for pagination, and add support for more flexible sorting options.

* Refactored the `decode_cursor` function in `pagination.py` to return a simple list of values instead of a tuple, and removed type-casting logic from this function. The new approach uses a `COLUMN_TYPES` mapping to determine SQL type casting in the query-building phase instead.
* Generalized the SQL condition generation for pagination in `create_pagination`, allowing for any number of cursor fields (not just one or two) and building the conditions dynamically. This makes pagination more robust and future-proof.
* Added support for sorting by the `"path"` field in both `get_products` and `get_versions` resolvers, updating the `order_by` fields accordingly to support complex path-based sorting.