### PR TITLE
Version review activities

### DIFF
--- a/api/activities/activity.py
+++ b/api/activities/activity.py
@@ -32,7 +32,7 @@ from ayon_server.types import Field, OPModel
 from .router import router
 
 
-human_activity_types = ['comment', 'guest_review']
+human_activity_types = ['comment', 'version.review']
 
 async def delete_unused_files(project_name: str) -> None:
     storage = await Storages.project(project_name)

--- a/api/activities/activity.py
+++ b/api/activities/activity.py
@@ -32,6 +32,8 @@ from ayon_server.types import Field, OPModel
 from .router import router
 
 
+human_activity_types = ['comment', 'guest_review']
+
 async def delete_unused_files(project_name: str) -> None:
     storage = await Storages.project(project_name)
     await storage.delete_unused_files()
@@ -62,8 +64,8 @@ async def post_project_activity(
     """
 
     if not user.is_service:
-        if activity.activity_type not in ["comment"]:
-            raise BadRequestException("Humans can only create comments")
+        if activity.activity_type not in human_activity_types:
+            raise BadRequestException("Humans can only create comments/guest reviews")
 
     project = await ProjectEntity.load(project_name)
 

--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -40,6 +40,9 @@ from ayon_server.logging import logger
 from ayon_server.utils import create_uuid
 
 
+restricted_activity_types = ["comment", "reviewable", "guest_review"]
+
+
 async def create_activity(
     entity: ProjectLevelEntity,
     activity_type: ActivityType,
@@ -67,7 +70,7 @@ async def create_activity(
     if (
         user is None
         and user_name is not None
-        and activity_type in ["comment", "reviewable"]  # we need acl for these
+        and activity_type in restricted_activity_types  # we need acl for these
     ):
         user = await UserEntity.load(user_name)
 
@@ -76,7 +79,7 @@ async def create_activity(
 
     if (
         user is not None
-        and activity_type in ["comment", "reviewable"]
+        and activity_type in restricted_activity_types
         and not user.is_manager
         and not user.is_guest  # guest permissions are checked in the endpoint
     ):

--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -40,7 +40,7 @@ from ayon_server.logging import logger
 from ayon_server.utils import create_uuid
 
 
-restricted_activity_types = ["comment", "reviewable", "guest_review"]
+restricted_activity_types = ["comment", "reviewable", "version.review"]
 
 
 async def create_activity(

--- a/ayon_server/activities/models.py
+++ b/ayon_server/activities/models.py
@@ -12,6 +12,7 @@ ActivityType = Literal[
     "assignee.add",
     "assignee.remove",
     "version.publish",
+    "guest_review",
 ]
 
 ActivityReferenceType = Literal[

--- a/ayon_server/activities/models.py
+++ b/ayon_server/activities/models.py
@@ -12,7 +12,7 @@ ActivityType = Literal[
     "assignee.add",
     "assignee.remove",
     "version.publish",
-    "guest_review",
+    "version.review",
 ]
 
 ActivityReferenceType = Literal[


### PR DESCRIPTION
- added a new human activity type 'version.review'. This will be used in review sessions.
- added a `mine` argument to the `get_activities` resolver which lets us filter for activities of current user

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

related to https://github.com/ynput/ayon-review/issues/213
