### PR TITLE
Latest comments on entity resolvers

### DIFF
--- a/ayon_server/graphql/nodes/entity_comment.py
+++ b/ayon_server/graphql/nodes/entity_comment.py
@@ -5,3 +5,5 @@ import strawberry
 class EntityComment:
     activity_id: str = strawberry.field()
     body: str = strawberry.field()
+    author: str | None = strawberry.field(default=None)
+    created_at: str = strawberry.field()

--- a/ayon_server/graphql/nodes/entity_comment.py
+++ b/ayon_server/graphql/nodes/entity_comment.py
@@ -1,0 +1,7 @@
+import strawberry
+
+
+@strawberry.type
+class EntityComment:
+    activity_id: str = strawberry.field()
+    body: str = strawberry.field()

--- a/ayon_server/graphql/nodes/folder.py
+++ b/ayon_server/graphql/nodes/folder.py
@@ -4,10 +4,11 @@ import strawberry
 
 from ayon_server.entities import FolderEntity
 from ayon_server.graphql.nodes.common import BaseNode, ThumbnailInfo
+from ayon_server.graphql.nodes.entity_comment import EntityComment
 from ayon_server.graphql.resolvers.products import get_products
 from ayon_server.graphql.resolvers.tasks import get_tasks
 from ayon_server.graphql.types import Info
-from ayon_server.utils import json_dumps
+from ayon_server.utils import json_dumps, json_loads
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import ProductsConnection, TasksConnection
@@ -40,6 +41,8 @@ class FolderNode(BaseNode):
     _project_attrib: strawberry.Private[dict[str, Any]]
     _inherited_attrib: strawberry.Private[dict[str, Any]]
     _folder_path: strawberry.Private[str | None] = None
+
+    latest_comments: list[EntityComment] | None = strawberry.field(default=None)
 
     # GraphQL specifics
 
@@ -139,6 +142,11 @@ async def folder_from_record(
             relation=thumb_data.get("relation"),
         )
 
+    try:
+        latest_comments = json_loads(record.get("latest_comments") or "[]")
+    except Exception:
+        latest_comments = []
+
     path = "/" + record.get("path", "").strip("/")
     return FolderNode(
         project_name=project_name,
@@ -166,6 +174,7 @@ async def folder_from_record(
         total_task_count=record.get("total_task_count", 0),
         total_product_count=record.get("total_product_count", 0),
         total_version_count=record.get("total_version_count", 0),
+        latest_comments=[EntityComment(**comment) for comment in latest_comments],
         thumbnail_hash=thumbnail_hash,
         path=path,
         _folder_path=path,

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -5,11 +5,12 @@ import strawberry
 
 from ayon_server.entities import TaskEntity
 from ayon_server.graphql.nodes.common import BaseNode, ThumbnailInfo
+from ayon_server.graphql.nodes.entity_comment import EntityComment
 from ayon_server.graphql.resolvers.versions import get_versions
 from ayon_server.graphql.resolvers.workfiles import get_workfiles
 from ayon_server.graphql.types import Info
 from ayon_server.logging import logger
-from ayon_server.utils import json_dumps
+from ayon_server.utils import json_dumps, json_loads
 
 if TYPE_CHECKING:
     from ..connections import VersionsConnection, WorkfilesConnection
@@ -64,6 +65,7 @@ class TaskNode(BaseNode):
     data: str | None
     path: str | None = None
     subtasks: list[SubTaskNode] = strawberry.field(default_factory=list)
+    latest_comments: list[EntityComment] | None = strawberry.field(default=None)
 
     _inherited_attrib: strawberry.Private[dict[str, Any]]
     _folder_path: strawberry.Private[str | None] = None
@@ -206,6 +208,11 @@ async def task_from_record(
         folder_path = "/" + record["_folder_path"].strip("/")
         path = f"{folder_path}/{record['name']}"
 
+    try:
+        latest_comments = json_loads(record.get("latest_comments") or "[]")
+    except Exception:
+        latest_comments = []
+
     return TaskNode(
         project_name=project_name,
         id=record["id"],
@@ -224,6 +231,7 @@ async def task_from_record(
         subtasks=subtasks,
         active=record["active"],
         path=path,
+        latest_comments=[EntityComment(**comment) for comment in latest_comments],
         created_at=record["created_at"],
         updated_at=record["updated_at"],
         created_by=record.get("created_by"),

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -2,13 +2,12 @@ from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
 
-# from strawberry import LazyType
 from ayon_server.entities import VersionEntity
-from ayon_server.graphql.nodes.activity import ActivityNode
 from ayon_server.graphql.nodes.common import BaseNode, ThumbnailInfo
+from ayon_server.graphql.nodes.entity_comment import EntityComment
 from ayon_server.graphql.resolvers.representations import get_representations
 from ayon_server.graphql.types import Info
-from ayon_server.utils import json_dumps
+from ayon_server.utils import json_dumps, json_loads
 
 if TYPE_CHECKING:
     from ayon_server.graphql.connections import RepresentationsConnection
@@ -48,7 +47,7 @@ class VersionNode(BaseNode):
     is_latest: bool = False
     is_latest_done: bool = False
 
-    latest_comments: list[ActivityNode] | None = strawberry.field(default=None)
+    latest_comments: list[EntityComment] | None = strawberry.field(default=None)
 
     _folder_path: strawberry.Private[str | None] = None
 
@@ -134,6 +133,11 @@ async def version_from_record(
         product_name = record["_product_name"]
         path = f"{folder_path}/{product_name}/{name}"
 
+    try:
+        latest_comments = json_loads(record.get("latest_comments") or "[]")
+    except Exception:
+        latest_comments = []
+
     return VersionNode(
         project_name=project_name,
         id=record["id"],
@@ -159,7 +163,7 @@ async def version_from_record(
         featured_version_type=record.get("featured_version_type"),
         is_latest=record.get("is_latest", False),
         is_latest_done=record.get("is_latest_done", False),
-        latest_comments=[],
+        latest_comments=[EntityComment(**comment) for comment in latest_comments],
         _folder_path=folder_path,
         _attrib=record["attrib"] or {},
         _user=current_user,

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -4,6 +4,7 @@ import strawberry
 
 # from strawberry import LazyType
 from ayon_server.entities import VersionEntity
+from ayon_server.graphql.nodes.activity import ActivityNode
 from ayon_server.graphql.nodes.common import BaseNode, ThumbnailInfo
 from ayon_server.graphql.resolvers.representations import get_representations
 from ayon_server.graphql.types import Info
@@ -46,6 +47,8 @@ class VersionNode(BaseNode):
     featured_version_type: str | None = None
     is_latest: bool = False
     is_latest_done: bool = False
+
+    latest_comments: list[ActivityNode] | None = strawberry.field(default=None)
 
     _folder_path: strawberry.Private[str | None] = None
 
@@ -156,6 +159,7 @@ async def version_from_record(
         featured_version_type=record.get("featured_version_type"),
         is_latest=record.get("is_latest", False),
         is_latest_done=record.get("is_latest_done", False),
+        latest_comments=[],
         _folder_path=folder_path,
         _attrib=record["attrib"] or {},
         _user=current_user,

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -220,6 +220,62 @@ async def get_entity_list_items(
 
     allowed_parent_keys = []
 
+    #
+    # Common CTEs
+    #
+
+    if fields.any_endswith("latestComments"):
+        sql_cte.append(
+            f"""
+            comments AS (
+                SELECT
+                    entity_id,
+                    json_agg(
+                        json_build_object(
+                            'activity_id', activity_id,
+                            'body', body,
+                            'author', author,
+                            'created_at', created_at
+                        )
+                        ORDER BY created_at DESC
+                    ) AS comments
+                FROM (
+                    SELECT
+                        activity_id,
+                        entity_id,
+                        body,
+                        activity_data->>'author' AS author,
+                        created_at,
+                        row_number() OVER (
+                            PARTITION BY entity_id
+                            ORDER BY created_at DESC
+                        ) AS rn
+                    FROM project_{project_name}.activity_feed
+                    WHERE activity_type = 'comment'
+                    AND entity_type = '{entity_type}'
+                    AND reference_type = 'origin'
+                ) x
+                WHERE rn <= 5
+                GROUP BY entity_id
+            )
+            """
+        )
+        sql_columns.append(
+            """
+            c.comments AS _entity_latest_comments
+            """
+        )
+        sql_joins.append(
+            """
+            LEFT JOIN comments c
+            ON c.entity_id = e.id
+            """
+        )
+
+    #
+    # Per-entity type CTEs, joins and columns
+    #
+
     if entity_type == "task":
         if fields.any_endswith("hasReviewables"):
             sql_cte.append(

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -298,6 +298,50 @@ async def get_folders(
 
         sql_group_by.append("fwv.ancestor_id")
 
+    if fields.any_endswith("latestComments"):
+        sql_cte.append(
+            f"""
+            comments AS (
+                SELECT
+                    entity_id,
+                    json_agg(
+                        json_build_object(
+                            'activity_id', activity_id,
+                            'body', body,
+                            'author', author,
+                            'created_at', created_at
+                        )
+                        ORDER BY created_at DESC
+                    ) AS comments
+                FROM (
+                    SELECT
+                        activity_id,
+                        entity_id,
+                        body,
+                        activity_data->>'author' AS author,
+                        created_at,
+                        row_number() OVER (
+                            PARTITION BY entity_id
+                            ORDER BY created_at DESC
+                        ) AS rn
+                    FROM project_{project_name}.activity_feed
+                    WHERE activity_type = 'comment'
+                    AND entity_type = 'folder'
+                    AND reference_type = 'origin'
+                ) x
+                WHERE rn <= 5
+                GROUP BY entity_id
+            )
+            """
+        )
+        sql_columns.append("MIN(c.comments::text) AS latest_comments")
+        sql_joins.append(
+            """
+            LEFT JOIN comments c
+            ON c.entity_id = folders.id
+            """
+        )
+
     #
     # Conditions
     #

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -236,6 +236,50 @@ async def get_tasks(
             "AS has_reviewables"
         )
 
+    if fields.any_endswith("latestComments"):
+        sql_cte.append(
+            f"""
+            comments AS (
+                SELECT
+                    entity_id,
+                    json_agg(
+                        json_build_object(
+                            'activity_id', activity_id,
+                            'body', body,
+                            'author', author,
+                            'created_at', created_at
+                        )
+                        ORDER BY created_at DESC
+                    ) AS comments
+                FROM (
+                    SELECT
+                        activity_id,
+                        entity_id,
+                        body,
+                        activity_data->>'author' AS author,
+                        created_at,
+                        row_number() OVER (
+                            PARTITION BY entity_id
+                            ORDER BY created_at DESC
+                        ) AS rn
+                    FROM project_{project_name}.activity_feed
+                    WHERE activity_type = 'comment'
+                    AND entity_type = 'task'
+                    AND reference_type = 'origin'
+                ) x
+                WHERE rn <= 5
+                GROUP BY entity_id
+            )
+            """
+        )
+        sql_columns.append("c.comments AS latest_comments")
+        sql_joins.append(
+            """
+            LEFT JOIN comments c
+            ON c.entity_id = tasks.id
+            """
+        )
+
     if ids is not None:
         if not ids:
             return TasksConnection()

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -188,6 +188,50 @@ async def get_versions(
         "products.name AS _product_name",
     ]
 
+    if fields.any_endswith("latestComments"):
+        sql_cte.append(
+            f"""
+            comments AS (
+                SELECT
+                    entity_id,
+                    json_agg(
+                        json_build_object(
+                            'activity_id', activity_id,
+                            'body', body,
+                            'author', author,
+                            'created_at', created_at
+                        )
+                        ORDER BY created_at DESC
+                    ) AS comments
+                FROM (
+                    SELECT
+                        activity_id,
+                        entity_id,
+                        body,
+                        activity_data->>'author' AS author,
+                        created_at,
+                        row_number() OVER (
+                            PARTITION BY entity_id
+                            ORDER BY created_at DESC
+                        ) AS rn
+                    FROM project_{project_name}.activity_feed
+                    WHERE activity_type = 'comment'
+                    AND entity_type = 'version'
+                    AND reference_type = 'origin'
+                ) x
+                WHERE rn <= 5
+                GROUP BY entity_id
+            )
+            """
+        )
+        sql_joins.append(
+            """
+            LEFT JOIN comments
+            ON comments.entity_id = versions.id
+            """
+        )
+        sql_columns.append("comments.comments AS latest_comments")
+
     if fields.any_endswith("hasReviewables") or (has_reviewables is not None):
         sql_cte.append(
             f"""


### PR DESCRIPTION
This pull request adds support for fetching and exposing the latest comments on folders, tasks, and versions in the GraphQL API. It introduces a new `EntityComment` type and updates the relevant nodes and resolvers to include a `latestComments` field, which retrieves up to the five most recent comments for each entity. The implementation ensures efficient loading of comments via SQL queries and robust parsing of comment data.
