### PR TITLE
Implement latestDone filter for usd resolve

### DIFF
--- a/api/resolve/__init__.py
+++ b/api/resolve/__init__.py
@@ -167,6 +167,21 @@ def get_version_conditions(version_name: str | None) -> list[str]:
         """
         ]
 
+    if version_name == "latestdone":
+        return [
+            """
+            v.id in (
+                    SELECT vv.id
+                    FROM versions vv
+                    JOIN statuses st ON st.name = vv.status
+                    WHERE vv.product_id = s.id
+                      AND st.data->>'state' = 'done'
+                    ORDER BY vv.version DESC
+                    LIMIT 1
+            )
+        """
+        ]
+
     if version_name == "hero":
         return ["v.version < 0"]
 


### PR DESCRIPTION
## Description of changes

Implements simple `latestDone` filter for USD resolve to return last `Approved` version for particular product_id.

Aside of the already existing versions, you can now also specify `latestDone` in the AYON Entity URI.

Like:
```
ayon+entity://project/assets/hero?product=modelMain&version=latestDone
ayon+entity://project/assets/hero?product=modelMain&version=latest
ayon+entity://project/assets/hero?product=modelMain&version=v001
```

### Technical details

Replacing [https://github.com/ynput/ayon-backend/pull/963](https://github.com/ynput/ayon-backend/pull/963#pullrequestreview-4459954889) which used too much complicated approach and got messed up by unnecessary merges and reverts.

