### PR TITLE
Renamed parent_folder_attrib to inherited_attributes

### DIFF
--- a/ayon_server/graphql/dataloaders/__init__.py
+++ b/ayon_server/graphql/dataloaders/__init__.py
@@ -106,7 +106,7 @@ async def task_loader(keys: list[KeyType]) -> list[dict[str, Any] | None]:
     query = f"""
         SELECT
             tasks.*,
-            pf.attrib AS parent_folder_attrib,
+            pf.attrib AS inherited_attributes,
             hierarchy.path AS _folder_path
         FROM project_{project_name}.tasks as tasks
 

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -230,7 +230,7 @@ async def task_from_record(
         updated_by=record.get("updated_by"),
         _folder=folder,
         _attrib=record["attrib"],
-        _inherited_attrib=record["parent_folder_attrib"],
+        _inherited_attrib=record["inherited_attributes"],
         _user=current_user,
         _folder_path=folder_path,
     )

--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -245,7 +245,7 @@ async def get_entity_list_items(
 
         # when querying tasks, we need the parent folder attributes
         # as well because of the inheritance
-        sql_columns.append("px.attrib as _entity_parent_folder_attrib")
+        sql_columns.append("px.attrib as _entity_inherited_attributes")
         sql_columns.append("pf.folder_type as _parent_folder_type")
         sql_columns.append("hierarchy.path AS _entity__folder_path")
         sql_joins.extend(

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -204,7 +204,7 @@ async def get_tasks(
     sql_columns = [
         "tasks.*",
         "hierarchy.path AS _folder_path",
-        "f_ex.attrib as parent_folder_attrib",
+        "f_ex.attrib as inherited_attributes",
     ]
 
     sql_joins = [


### PR DESCRIPTION
## Description of changes

FE must access inherited attributes, they were called differently in folder/tasks graphQl endpoints. This PR standardizes them.

