### PR TITLE
Implemented check of installer Python version vs dependency package

### DIFF
--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -6,7 +6,7 @@ from api.desktop.deps import get_manifest
 from api.desktop.installers import get_installers
 from api.desktop.installers import get_manifest as get_installer_manifest
 from ayon_server.addons.library import AddonLibrary
-from ayon_server.exceptions import NotFoundException
+from ayon_server.exceptions import AyonException, NotFoundException
 from ayon_server.types import Field, OPModel
 from ayon_server.version import __version__ as ayon_version
 
@@ -201,13 +201,17 @@ async def check_bundle(
                 )
 
     # Check for Python version installer compatibility with dependency packs
-    if bundle.dependency_packages:
-        variant: Literal["production", "staging"] | None = (
-            "production" if bundle.is_production
-            else "staging" if bundle.is_staging
-            else None
+    if not bundle.dependency_packages:
+        issues.append(
+            BundleIssueModel(
+                severity="error",
+                addon=None,
+                message=(f"Bundle {bundle.name} doesn't have dependency packages."),
+                required_addon=None,
+            )
         )
-
+    else:
+        # check pythons in all packages
         for platform_name, package_filename in bundle.dependency_packages.items():
             if package_filename is None:
                 continue
@@ -220,7 +224,8 @@ async def check_bundle(
                         severity="error",
                         addon=None,
                         message=(
-                            f"Dependency package '{package_filename}' manifest could not be loaded."
+                            f"Dependency package '{package_filename}' manifest "
+                            f"could not be loaded."
                         ),
                         required_addon=None,
                     )
@@ -232,36 +237,37 @@ async def check_bundle(
                 continue
 
             installer_list = await get_installers(
-                bundle.installer_version, platform_name, variant
+                bundle.installer_version, platform_name
             )
-            if not installer_list or not installer_list.installers:
+            if not installer_list or len(installer_list.installers) != 1:
+                raise AyonException(
+                    f"Found {len(installer_list.installers)} "
+                    f"installers for {bundle.name} "
+                )
+
+            installer = installer_list.installers[0]
+            installer_manifest = get_installer_manifest(installer.filename)
+            installer_python_version = installer_manifest.python_version
+            if not installer_python_version:
                 continue
 
-            for installer in installer_list.installers:
-                installer_manifest = get_installer_manifest(installer.filename)
-                installer_python_version = installer_manifest.python_version
-                if not installer_python_version:
-                    continue
-            
-                if is_compatible(
-                    package_python_version, installer_python_version
-                ):
-                    continue
+            if is_compatible(package_python_version, installer_python_version):
+                continue
 
-                msg = (
-                    f"Dependency package '{package_filename}' requires Python"
-                    f" {package_python_version}, but installer"
-                    f" '{installer.filename}' uses {installer_python_version}"
-                    f" on platform '{platform_name}'."
+            msg = (
+                f"Dependency package '{package_filename}' requires Python"
+                f" {package_python_version}, but installer"
+                f" '{installer.filename}' uses {installer_python_version}"
+                f" on platform '{platform_name}'."
+            )
+            issues.append(
+                BundleIssueModel(
+                    severity="error",
+                    addon=None,
+                    message=msg,
+                    required_addon=None,
                 )
-                issues.append(
-                    BundleIssueModel(
-                        severity="error",
-                        addon=None,
-                        message=msg,
-                        required_addon=None,
-                    )
-                )
+            )
 
     has_errors = any(issue.severity == "error" for issue in issues)
     return CheckBundleResponseModel(success=not has_errors, issues=issues)

--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -212,62 +212,73 @@ async def check_bundle(
         )
     else:
         # check pythons in all packages
-        for platform_name, package_filename in bundle.dependency_packages.items():
-            if package_filename is None:
+        for platform, filename in bundle.dependency_packages.items():
+            if not filename:
                 continue
 
-            try:
-                manifest = get_manifest(package_filename)
-            except Exception:
-                issues.append(
-                    BundleIssueModel(
-                        severity="error",
-                        addon=None,
-                        message=(
-                            f"Dependency package '{package_filename}' manifest "
-                            f"could not be loaded."
-                        ),
-                        required_addon=None,
-                    )
-                )
-                continue
-
-            package_python_version = manifest.python_version
-            if not package_python_version:
-                continue
-
-            installer_list = await get_installers(
-                bundle.installer_version, platform_name
+            # The complex inner logic is neatly tucked into this helper
+            package_issue = await _validate_python_package_compatibility(
+                bundle, platform, filename
             )
-            if not installer_list or len(installer_list.installers) != 1:
-                raise AyonException(
-                    f"Found {len(installer_list.installers)} "
-                    f"installers for {bundle.name} "
-                )
-
-            installer = installer_list.installers[0]
-            installer_manifest = get_installer_manifest(installer.filename)
-            installer_python_version = installer_manifest.python_version
-            if not installer_python_version:
-                continue
-
-            if is_compatible(package_python_version, installer_python_version):
-                continue
-
-            msg = (
-                f"Dependency package '{package_filename}' requires Python"
-                f" {package_python_version}, but installer"
-                f" '{installer.filename}' uses {installer_python_version}"
-                f" on platform '{platform_name}'."
-            )
-            issues.append(
-                BundleIssueModel(
-                    severity="error",
-                    addon=None,
-                    message=msg,
-                    required_addon=None,
-                )
-            )
+            if package_issue:
+                issues.append(package_issue)
 
     has_errors = any(issue.severity == "error" for issue in issues)
     return CheckBundleResponseModel(success=not has_errors, issues=issues)
+
+
+async def _validate_python_package_compatibility(
+    bundle, platform_name: Literal["windows", "linux", "darwin"], package_filename: str
+) -> BundleIssueModel | None:
+    """Validates a single package's Python compatibility against the installer.
+
+    Returns a BundleIssueModel if an issue is found, otherwise None.
+    """
+    try:
+        manifest = get_manifest(package_filename)
+    except Exception:
+        return BundleIssueModel(
+            severity="error",
+            addon=None,
+            message=f"Dependency package '{package_filename}' "
+            f"manifest could not be loaded.",
+            required_addon=None,
+        )
+
+    package_python_version = manifest.python_version
+    import pprint
+
+    print(f"package_manifest::{pprint.pformat(manifest, indent=4)}")
+    if not package_python_version:
+        return None
+
+    # 2. Fetch and validate installer
+    installer_list = await get_installers(bundle.installer_version, platform_name)
+    if not installer_list or len(installer_list.installers) != 1:
+        num_found = len(installer_list.installers) if installer_list else 0
+        raise AyonException(
+            f"Found {num_found} installers for {bundle.name} "
+            f"on platform {platform_name}"
+        )
+
+    installer = installer_list.installers[0]
+    installer_manifest = get_installer_manifest(installer.filename)
+    print(f"installer_manifest::{pprint.pformat(installer_manifest, indent=4)}")
+    installer_python_version = installer_manifest.python_version
+    if not installer_python_version:
+        return None
+
+    if is_compatible(package_python_version, installer_python_version):
+        return None
+
+    return BundleIssueModel(
+        severity="error",
+        addon=None,
+        message=(
+            f"Dependency package '{package_filename}' "
+            f"requires Python {package_python_version}, "
+            f"but installer '{installer.filename}' uses {installer_python_version} "
+            f"on platform '{platform_name}'."
+        ),
+        required_addon=None,
+    )

--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -202,7 +202,7 @@ async def check_bundle(
 
     # Check for Python version installer compatibility with dependency packs
     if bundle.dependency_packages:
-        variant = (
+        variant: Literal["production", "staging"] | None = (
             "production" if bundle.is_production
             else "staging" if bundle.is_staging
             else None

--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -237,19 +237,22 @@ async def check_bundle(
             if not installer_list or not installer_list.installers:
                 continue
 
-            installer = installer_list.installers[0]
-            installer_manifest = get_installer_manifest(installer.filename)
-            installer_python_version = installer_manifest.python_version
-            if not installer_python_version:
-                continue
+            for installer in installer_list.installers:
+                installer_manifest = get_installer_manifest(installer.filename)
+                installer_python_version = installer_manifest.python_version
+                if not installer_python_version:
+                    continue
+            
+                if is_compatible(
+                    package_python_version, installer_python_version
+                ):
+                    continue
 
-            if not is_compatible(
-                package_python_version, installer_python_version
-            ):
                 msg = (
-                    f"Dependency package '{package_filename}' requires Python "
-                    f"{package_python_version}, but installer '{installer.filename}' "
-                    f"uses {installer_python_version} on platform '{platform_name}'."
+                    f"Dependency package '{package_filename}' requires Python"
+                    f" {package_python_version}, but installer"
+                    f" '{installer.filename}' uses {installer_python_version}"
+                    f" on platform '{platform_name}'."
                 )
                 issues.append(
                     BundleIssueModel(

--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -223,11 +223,9 @@ async def check_bundle(
             if not installer_list or not installer_list.installers:
                 continue
 
-            installer_python_version = None
-            for installer in installer_list.installers:
-                installer_manifest = get_installer_manifest(installer.filename)
-                installer_python_version = installer_manifest.python_version
-
+            installer = installer_list.installers[0]
+            installer_manifest = get_installer_manifest(installer.filename)
+            installer_python_version = installer_manifest.python_version
             if not installer_python_version:
                 continue
 

--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -8,6 +8,11 @@ from ayon_server.types import Field, OPModel
 from ayon_server.version import __version__ as ayon_version
 
 from .models import BundleModel, BundlePatchModel
+from api.desktop.deps import get_manifest
+from api.desktop.installers import (
+    get_manifest as get_installer_manifest,
+    get_installers
+)
 
 if TYPE_CHECKING:
     pass
@@ -194,6 +199,57 @@ async def check_bundle(
                         addon=addon_name,
                         message=msg,
                         required_addon=r_name,
+                    )
+                )
+
+    # Check for Python version installer compatibility with dependency packs
+    if bundle.dependency_packages:
+        variant = (
+            "production" if bundle.is_production
+            else "staging" if bundle.is_staging
+            else None
+        )
+
+        for platform_name, package_filename in bundle.dependency_packages.items():
+            if variant is None:
+                continue
+
+            if package_filename is None:
+                continue
+
+            manifest = get_manifest(package_filename)
+            package_python_version = manifest.python_version
+            if not package_python_version:
+                continue
+
+            installer_list = await get_installers(
+                bundle.installer_version, platform_name, variant
+            )
+            if not installer_list or not installer_list.installers:
+                continue
+
+            installer_python_version = None
+            for installer in installer_list.installers:
+                installer_manifest = get_installer_manifest(installer.filename)
+                installer_python_version = installer_manifest.python_version
+
+            if not installer_python_version:
+                continue
+
+            if not is_compatible(
+                package_python_version, installer_python_version
+            ):
+                msg = (
+                    f"Dependency package '{package_filename}' requires Python "
+                    f"{package_python_version}, but installer '{installer.filename}' "
+                    f"uses {installer_python_version} on platform '{platform_name}'."
+                )
+                issues.append(
+                    BundleIssueModel(
+                        severity="error",
+                        addon=None,
+                        message=msg,
+                        required_addon=None,
                     )
                 )
 

--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -2,17 +2,15 @@ from typing import TYPE_CHECKING, Literal
 
 import semver
 
+from api.desktop.deps import get_manifest
+from api.desktop.installers import get_installers
+from api.desktop.installers import get_manifest as get_installer_manifest
 from ayon_server.addons.library import AddonLibrary
 from ayon_server.exceptions import NotFoundException
 from ayon_server.types import Field, OPModel
 from ayon_server.version import __version__ as ayon_version
 
 from .models import BundleModel, BundlePatchModel
-from api.desktop.deps import get_manifest
-from api.desktop.installers import (
-    get_manifest as get_installer_manifest,
-    get_installers
-)
 
 if TYPE_CHECKING:
     pass

--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -211,9 +211,6 @@ async def check_bundle(
         )
 
         for platform_name, package_filename in bundle.dependency_packages.items():
-            if variant is None:
-                continue
-
             if package_filename is None:
                 continue
 

--- a/api/bundles/check_bundle.py
+++ b/api/bundles/check_bundle.py
@@ -212,7 +212,21 @@ async def check_bundle(
             if package_filename is None:
                 continue
 
-            manifest = get_manifest(package_filename)
+            try:
+                manifest = get_manifest(package_filename)
+            except Exception:
+                issues.append(
+                    BundleIssueModel(
+                        severity="error",
+                        addon=None,
+                        message=(
+                            f"Dependency package '{package_filename}' manifest could not be loaded."
+                        ),
+                        required_addon=None,
+                    )
+                )
+                continue
+
             package_python_version = manifest.python_version
             if not package_python_version:
                 continue

--- a/api/desktop/installers.py
+++ b/api/desktop/installers.py
@@ -95,9 +95,7 @@ async def list_installers(
     platform: Platform | None = Query(None, description="Platform of the package"),
     variant: Literal["production", "staging"] | None = Query(None),
 ) -> InstallerListModel:
-    return await get_installers(
-        version=version, platform=platform, variant=variant
-    )
+    return await get_installers(version=version, platform=platform, variant=variant)
 
 
 @router.post("/installers", status_code=201)

--- a/api/desktop/installers.py
+++ b/api/desktop/installers.py
@@ -95,43 +95,9 @@ async def list_installers(
     platform: Platform | None = Query(None, description="Platform of the package"),
     variant: Literal["production", "staging"] | None = Query(None),
 ) -> InstallerListModel:
-    result: list[Installer] = []
-
-    if variant in ["production", "staging"]:
-        r = await Postgres.fetch(
-            f"""
-            SELECT data->>'installer_version' as v
-            FROM bundles WHERE is_{variant} IS TRUE
-            """
-        )
-        if r:
-            version = r[0]["v"]
-        else:
-            raise NotFoundException(f"No {variant} bundle found")
-
-    for filename in iter_names("installers"):
-        try:
-            manifest = get_manifest(filename)
-        except Exception as e:
-            logger.warning(f"Failed to load manifest file {filename}: {e}")
-            continue
-
-        if filename != manifest.filename:
-            logger.warning(
-                f"Filenames in manifest don't match: {filename} != {manifest.filename}"
-            )
-            continue
-
-        # Filtering
-
-        if platform is not None and platform != manifest.platform:
-            continue
-
-        if version is not None and version != manifest.version:
-            continue
-
-        result.append(manifest)
-    return InstallerListModel(installers=result)
+    return await get_installers(
+        version=version, platform=platform, variant=variant
+    )
 
 
 @router.post("/installers", status_code=201)
@@ -263,3 +229,47 @@ async def patch_installer(user: CurrentUser, filename: str, payload: SourcesPatc
     async with aiofiles.open(manifest.path, "w") as f:
         await f.write(manifest.json(exclude_none=True))
     return EmptyResponse(status_code=204)
+
+
+async def get_installers(
+    version: str | None = None,
+    platform: Platform | None = None,
+    variant: Literal["production", "staging"] | None = None,
+) -> InstallerListModel:
+    result: list[Installer] = []
+
+    if variant in ["production", "staging"]:
+        r = await Postgres.fetch(
+            f"""
+            SELECT data->>'installer_version' as v
+            FROM bundles WHERE is_{variant} IS TRUE
+            """
+        )
+        if r:
+            version = r[0]["v"]
+        else:
+            raise NotFoundException(f"No {variant} bundle found")
+
+    for filename in iter_names("installers"):
+        try:
+            manifest = get_manifest(filename)
+        except Exception as e:
+            logger.warning(f"Failed to load manifest file {filename}: {e}")
+            continue
+
+        if filename != manifest.filename:
+            logger.warning(
+                f"Filenames in manifest don't match: {filename} != {manifest.filename}"
+            )
+            continue
+
+        # Filtering
+
+        if platform is not None and platform != manifest.platform:
+            continue
+
+        if version is not None and version != manifest.version:
+            continue
+
+        result.append(manifest)
+    return InstallerListModel(installers=result)


### PR DESCRIPTION
## Description of changes

As Python version changes in recent installers (launchers) this adds check for compatibility of launcher and dependency package set on a bundle.

(Could be tested by triggering `api/bundles/check` - requires BundleModel in body though. That could get pulled via `api/bundles` endpoint.)

<img width="497" height="122" alt="image" src="https://github.com/user-attachments/assets/38627c91-08c8-4c16-ab50-0c62c37a5171" />


