### PR TITLE
Log GraphQL queries and slow requests

### DIFF
--- a/api/system/__init__.py
+++ b/api/system/__init__.py
@@ -93,9 +93,10 @@ async def set_restart_required(
 
 @router.get("/system/sleep", include_in_schema=False)
 async def debug_sleep(
-    user: CurrentUser,
-    duration: Annotated[int, Query(ge=0, description="Duration in seconds")] = 10,
-):
+    duration: Annotated[
+        int,
+        Query(ge=0, le=60, description="Duration in seconds"),
+    ] = 10,
     """
     Debug endpoint to simulate a long-running request.
     Only available for administrators.

--- a/api/system/__init__.py
+++ b/api/system/__init__.py
@@ -7,7 +7,10 @@ __all__ = [
     "dbimport",
 ]
 
-from fastapi import Response
+import asyncio
+from typing import Annotated
+
+from fastapi import Query, Response
 
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.api.system import clear_server_restart_required, require_server_restart
@@ -86,3 +89,21 @@ async def set_restart_required(
 
     if not user.is_admin:
         raise ForbiddenException("Only administrators can set server restart required")
+
+
+@router.get("/system/sleep", include_in_schema=False)
+async def debug_sleep(
+    user: CurrentUser,
+    duration: Annotated[int, Query(ge=0, description="Duration in seconds")] = 10,
+):
+    """
+    Debug endpoint to simulate a long-running request.
+    Only available for administrators.
+    """
+
+    if not user.is_admin:
+        raise ForbiddenException("Only administrators can use this endpoint")
+
+    logger.info(f"Simulating a long-running request for {duration} seconds")
+    await asyncio.sleep(duration)
+    return {"message": f"Slept for {duration} seconds"}

--- a/api/system/__init__.py
+++ b/api/system/__init__.py
@@ -93,10 +93,16 @@ async def set_restart_required(
 
 @router.get("/system/sleep", include_in_schema=False)
 async def debug_sleep(
+    user: CurrentUser,
     duration: Annotated[
         int,
-        Query(ge=0, le=60, description="Duration in seconds"),
+        Query(
+            ge=0,
+            le=60,
+            description="Duration in seconds",
+        ),
     ] = 10,
+) -> dict[str, str]:
     """
     Debug endpoint to simulate a long-running request.
     Only available for administrators.
@@ -105,6 +111,6 @@ async def debug_sleep(
     if not user.is_admin:
         raise ForbiddenException("Only administrators can use this endpoint")
 
-    logger.info(f"Simulating a long-running request for {duration} seconds")
+    logger.debug(f"Simulating a long-running request for {duration} seconds")
     await asyncio.sleep(duration)
     return {"message": f"Slept for {duration} seconds"}

--- a/ayon_server/api/logging.py
+++ b/ayon_server/api/logging.py
@@ -191,4 +191,5 @@ class LoggingMiddleware(BaseHTTPMiddleware):
                         # so it doesn't pollute the logs.
                         logger.trace(msg)
 
+        response.headers["X-Request-ID"] = request_id
         return response

--- a/ayon_server/api/logging.py
+++ b/ayon_server/api/logging.py
@@ -154,7 +154,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
             # Before processing the request, we don't have access to
             # the route information, so we need to check it here
             # (that's also why we don't track the beginning of the request)
-            should_trace = path.startswith("/api")  # or path.startswith("/graphql")
+            should_trace = path.startswith("/api") or path.startswith("/graphql")
 
             if should_trace and (route := request.scope.get("route")):
                 # We don't need to log successful requests to routes,
@@ -174,7 +174,21 @@ class LoggingMiddleware(BaseHTTPMiddleware):
 
                 process_time = round(time.perf_counter() - start_time, 3)
                 f_result = f"| {response.status_code} in {process_time}s"
+
+                log_path = path
+                if graphql_query := getattr(request.state, "graphql_query", None):
+                    log_path += f" ({graphql_query})"
+
+                msg = f"[{request.method}] {log_path} {f_result}"
+
                 with logger.contextualize(**extras):
-                    logger.trace(f"[{request.method}] {path} {f_result}")
+                    if process_time > 5 or response.status_code >= 500:
+                        # When a request takes longer than usual, raise the log level
+                        # so we can see it in the logs by default.
+                        logger.debug(msg)
+                    else:
+                        # Otherwise, we can log it as a trace,
+                        # so it doesn't pollute the logs.
+                        logger.trace(msg)
 
         return response

--- a/ayon_server/graphql/__init__.py
+++ b/ayon_server/graphql/__init__.py
@@ -3,8 +3,10 @@ import traceback
 from typing import Any
 
 import strawberry
+from fastapi import Request
 from graphql import GraphQLError
 from strawberry.dataloader import DataLoader
+from strawberry.extensions import SchemaExtension
 from strawberry.fastapi import GraphQLRouter
 from strawberry.types import ExecutionContext
 
@@ -51,10 +53,11 @@ from ayon_server.logging import logger
 from ayon_server.utils import json_dumps
 
 
-async def graphql_get_context(user: CurrentUser) -> dict[str, Any]:
+async def graphql_get_context(request: Request, user: CurrentUser) -> dict[str, Any]:
     """Get the current request context"""
     return {
         # Auth
+        "request": request,
         "user": user,
         # Record parsing
         "entity_list_from_record": entity_list_from_record,
@@ -222,8 +225,17 @@ class AyonSchema(strawberry.Schema):
             )
 
 
+class QueryNameExtension(SchemaExtension):
+    def on_operation(self):
+        execution_context = self.execution_context
+        request = execution_context.context.get("request")
+        if request and execution_context.operation_name:
+            request.state.graphql_query = execution_context.operation_name
+        yield
+
+
 router: GraphQLRouter[Any, Any] = GraphQLRouter(
-    schema=AyonSchema(query=Query),
+    schema=AyonSchema(query=Query, extensions=[QueryNameExtension]),
     graphql_ide=None,
     context_getter=graphql_get_context,
 )


### PR DESCRIPTION
This pull request introduces several improvements and debugging features to the API and logging infrastructure. The main highlights are the addition of a debug endpoint for simulating long-running requests, enhanced logging for slow or error-prone API and GraphQL requests, and improved context handling for GraphQL operations.

* Added a new `/system/sleep` debug endpoint to simulate long-running requests, accessible only to administrators. This can be used for testing and debugging purposes.
* Updated request logging to also trace GraphQL endpoints, not just `/api`, providing better visibility into GraphQL traffic.
* Enhanced request logging to include GraphQL operation names when available, and to log slow (>5s) or failed (status >= 500) requests at the debug level for easier identification in logs.
* Modified the GraphQL context to include the `request` object, enabling middleware and extensions to access request-specific data.


<img width="877" height="157" alt="image" src="https://github.com/user-attachments/assets/81920b94-7b23-4010-9234-fde6feefc379" />


<img width="818" height="232" alt="image" src="https://github.com/user-attachments/assets/3312cb35-43d8-4478-b7fc-f11584e33dd0" />
