### PR TITLE
Set explicit version thumbnail from reviewable

### DIFF
--- a/ayon_server/helpers/thumbnails/__init__.py
+++ b/ayon_server/helpers/thumbnails/__init__.py
@@ -29,6 +29,7 @@ from .thumbnail_info_resolvers import (
     resolve_folder_thumbnail_info,
     resolve_task_thumbnail_info,
     resolve_version_thumbnail_info,
+    resolve_workfile_thumbnail_info,
 )
 
 
@@ -50,8 +51,6 @@ async def resolve_thumbnail(
     elif entity_type == "version":
         resolver = resolve_version_thumbnail_info
     elif entity_type == "workfile":
-        from .thumbnail_info_resolvers import resolve_workfile_thumbnail_info
-
         resolver = resolve_workfile_thumbnail_info
     else:
         raise ValueError(f"Unsupported entity type '{entity_type}' for thumbnail")

--- a/ayon_server/helpers/thumbnails/store_thumbnail.py
+++ b/ayon_server/helpers/thumbnails/store_thumbnail.py
@@ -47,6 +47,9 @@ async def store_thumbnail(
         )
         mime = guessed_mime
 
+    else:
+        mime = guessed_mime
+
     if mime not in ["image/png", "image/jpeg"]:
         raise UnsupportedMediaException(f"Unsupported thumbnail mime type {mime}")
 

--- a/ayon_server/helpers/thumbnails/thumbnail_from_reviewable.py
+++ b/ayon_server/helpers/thumbnails/thumbnail_from_reviewable.py
@@ -1,0 +1,34 @@
+from ayon_server.entities.user import UserEntity
+from ayon_server.entities.version import VersionEntity
+from ayon_server.helpers.preview import obtain_file_preview
+from ayon_server.helpers.thumbnails import store_thumbnail
+from ayon_server.logging import log_traceback, logger
+from ayon_server.utils.hashing import create_uuid
+
+
+async def assign_version_thumbnail_from_reviewable(
+    project_name: str,
+    file_id: str,
+    *,
+    version: str | VersionEntity,
+    user: str | UserEntity | None = None,
+) -> None:
+
+    if isinstance(version, str):
+        version = await VersionEntity.load(project_name, version)
+
+    logger.debug(f"Assigning {version} thumbnail from reviewable {file_id}")
+    try:
+        pvw_bytes = await obtain_file_preview(project_name, file_id, thumbnail=True)
+        user_name = user.name if isinstance(user, UserEntity) else user
+
+        thumbnail_id = create_uuid()
+        await store_thumbnail(
+            project_name,
+            thumbnail_id,
+            pvw_bytes,
+            entity=version,
+            user_name=user_name,
+        )
+    except Exception:
+        log_traceback(f"Failed to assign thumbnail for version {version.id}")

--- a/ayon_server/helpers/thumbnails/thumbnail_from_reviewable.py
+++ b/ayon_server/helpers/thumbnails/thumbnail_from_reviewable.py
@@ -2,7 +2,7 @@ from ayon_server.entities.user import UserEntity
 from ayon_server.entities.version import VersionEntity
 from ayon_server.helpers.preview import obtain_file_preview
 from ayon_server.helpers.thumbnails import store_thumbnail
-from ayon_server.logging import log_traceback, logger
+from ayon_server.logging import logger
 from ayon_server.utils.hashing import create_uuid
 
 
@@ -17,18 +17,19 @@ async def assign_version_thumbnail_from_reviewable(
     if isinstance(version, str):
         version = await VersionEntity.load(project_name, version)
 
-    logger.debug(f"Assigning {version} thumbnail from reviewable {file_id}")
-    try:
-        pvw_bytes = await obtain_file_preview(project_name, file_id, thumbnail=True)
-        user_name = user.name if isinstance(user, UserEntity) else user
+    assert isinstance(version, VersionEntity), (
+        "version must be a VersionEntity instance"
+    )
 
-        thumbnail_id = create_uuid()
-        await store_thumbnail(
-            project_name,
-            thumbnail_id,
-            pvw_bytes,
-            entity=version,
-            user_name=user_name,
-        )
-    except Exception:
-        log_traceback(f"Failed to assign thumbnail for version {version.id}")
+    logger.debug(f"Assigning {version} thumbnail from reviewable {file_id}")
+    pvw_bytes = await obtain_file_preview(project_name, file_id, thumbnail=True)
+    user_name = user.name if isinstance(user, UserEntity) else user
+
+    thumbnail_id = create_uuid()
+    await store_thumbnail(
+        project_name,
+        thumbnail_id,
+        pvw_bytes,
+        entity=version,
+        user_name=user_name,
+    )

--- a/ayon_server/reviewables/create_reviewable.py
+++ b/ayon_server/reviewables/create_reviewable.py
@@ -5,11 +5,6 @@ from ayon_server.events import EventStream
 from ayon_server.exceptions import BadRequestException
 from ayon_server.files import Storages, create_project_file_record
 from ayon_server.helpers.ffprobe import availability_from_media_info
-from ayon_server.helpers.hierarchy_cache import rebuild_hierarchy_cache
-from ayon_server.helpers.preview import get_file_preview
-from ayon_server.helpers.thumbnails.invalidate_thumbnail import (
-    invalidate_thumbnail_by_entity,
-)
 from ayon_server.helpers.thumbnails.thumbnail_from_reviewable import (
     assign_version_thumbnail_from_reviewable,
 )
@@ -145,17 +140,6 @@ async def create_reviewable(
             user=user_name,
             version=version,
         )
-
-    try:
-        await get_file_preview(project_name, file_id)
-    except Exception as e:
-        logger.warning(f"Failed to generate preview for reviewable {file_id}: {e}")
-
-    # Reset the thumbnail hash for the version,
-    # so the client will know to fetch a new thumbnail
-
-    await invalidate_thumbnail_by_entity(project_name, "version", version.id)
-    await rebuild_hierarchy_cache(project_name)
 
     return ReviewableModel(
         file_id=file_id,

--- a/ayon_server/reviewables/create_reviewable.py
+++ b/ayon_server/reviewables/create_reviewable.py
@@ -8,7 +8,7 @@ from ayon_server.helpers.ffprobe import availability_from_media_info
 from ayon_server.helpers.thumbnails.thumbnail_from_reviewable import (
     assign_version_thumbnail_from_reviewable,
 )
-from ayon_server.logging import logger
+from ayon_server.logging import log_traceback, logger
 from ayon_server.reviewables.models import ReviewableAuthor, ReviewableModel
 
 
@@ -132,12 +132,18 @@ async def create_reviewable(
     # If a version doesn't have a thumbnail, assign the reviewable as a thumbnail.
 
     if not version.thumbnail_id:
-        await assign_version_thumbnail_from_reviewable(
-            project_name,
-            file_id,
-            user=user_name,
-            version=version,
-        )
+        try:
+            await assign_version_thumbnail_from_reviewable(
+                project_name,
+                file_id,
+                user=user_name,
+                version=version,
+            )
+        except Exception:
+            log_traceback(
+                f"Unable to assign reviewable {file_id} "
+                "as thumbnail for version {version.id}"
+            )
 
     return ReviewableModel(
         file_id=file_id,

--- a/ayon_server/reviewables/create_reviewable.py
+++ b/ayon_server/reviewables/create_reviewable.py
@@ -10,6 +10,9 @@ from ayon_server.helpers.preview import get_file_preview
 from ayon_server.helpers.thumbnails.invalidate_thumbnail import (
     invalidate_thumbnail_by_entity,
 )
+from ayon_server.helpers.thumbnails.thumbnail_from_reviewable import (
+    assign_version_thumbnail_from_reviewable,
+)
 from ayon_server.logging import logger
 from ayon_server.reviewables.models import ReviewableAuthor, ReviewableModel
 
@@ -134,6 +137,15 @@ async def create_reviewable(
     # Ensure the file preview is generated and cached,
     # so it is not generated when the client requests it for the first time,
     # which would cause a delay for the user.
+
+    if not version.thumbnail_id:
+        await assign_version_thumbnail_from_reviewable(
+            project_name,
+            file_id,
+            user=user_name,
+            version=version,
+        )
+
     try:
         await get_file_preview(project_name, file_id)
     except Exception as e:

--- a/ayon_server/reviewables/create_reviewable.py
+++ b/ayon_server/reviewables/create_reviewable.py
@@ -129,9 +129,7 @@ async def create_reviewable(
     else:
         author = ReviewableAuthor(name="system", full_name=None)
 
-    # Ensure the file preview is generated and cached,
-    # so it is not generated when the client requests it for the first time,
-    # which would cause a delay for the user.
+    # If a version doesn't have a thumbnail, assign the reviewable as a thumbnail.
 
     if not version.thumbnail_id:
         await assign_version_thumbnail_from_reviewable(

--- a/cli/generate_version_thumbnails/__init__.py
+++ b/cli/generate_version_thumbnails/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["generate_version_thumbnails"]
+
+from .generate_version_thumbnails import generate_version_thumbnails

--- a/cli/generate_version_thumbnails/generate_version_thumbnails.py
+++ b/cli/generate_version_thumbnails/generate_version_thumbnails.py
@@ -1,0 +1,76 @@
+import time
+
+from ayon_server.cli import app
+from ayon_server.helpers.project_list import get_project_list
+from ayon_server.helpers.thumbnails.thumbnail_from_reviewable import (
+    assign_version_thumbnail_from_reviewable,
+)
+from ayon_server.initialize import ayon_init
+from ayon_server.lib.postgres import Postgres
+from ayon_server.logging import logger
+
+
+async def process_project_thumbnails(project_name: str) -> None:
+    query = f"""
+        WITH reviewables AS (
+            SELECT DISTINCT ON (a.entity_id)
+            a.entity_id AS version_id,
+            f.id AS reviewable_id
+            FROM project_{project_name}.files f
+            JOIN project_{project_name}.activity_feed a
+            ON a.activity_id = f.activity_id
+            AND a.entity_type = 'version'
+            AND a.activity_type = 'reviewable'
+            AND a.reference_type = 'origin'
+            ORDER BY a.entity_id, a.created_at DESC
+        )
+        SELECT
+            h.path,
+            v.id AS version_id,
+            v.thumbnail_id,
+            r.reviewable_id
+        FROM project_{project_name}.versions v
+
+        JOIN project_{project_name}.products p
+        ON p.id = v.product_id
+
+        JOIN project_{project_name}.hierarchy h
+        ON h.id = p.folder_id
+
+        LEFT JOIN reviewables r
+        ON r.version_id = v.id
+
+        WHERE v.thumbnail_id IS NULL
+        AND r.reviewable_id IS NOT NULL
+        ORDER BY v.created_at DESC
+        LIMIT 1000
+    """
+
+    rows = await Postgres.fetch(query)
+    for row in rows:
+        version_id = row["version_id"]
+        reviewable_id = row["reviewable_id"]
+
+        await assign_version_thumbnail_from_reviewable(
+            project_name,
+            reviewable_id,
+            version=version_id,
+        )
+
+
+@app.command()
+async def generate_version_thumbnails(project_name: str | None = None) -> None:
+    """Create thumbnails for versions with reviewables, without thumbnail set"""
+
+    await ayon_init()
+    projects = await get_project_list()
+
+    start_time = time.monotonic()
+    if project_name is None:
+        for project in projects:
+            await process_project_thumbnails(project.name)
+    else:
+        await process_project_thumbnails(project_name)
+    elapsed_time = time.monotonic() - start_time
+
+    logger.info(f"Took {elapsed_time:.2f} seconds to process thumbnails")

--- a/cli/generate_version_thumbnails/generate_version_thumbnails.py
+++ b/cli/generate_version_thumbnails/generate_version_thumbnails.py
@@ -25,17 +25,9 @@ async def process_project_thumbnails(project_name: str) -> None:
             ORDER BY a.entity_id, a.created_at DESC
         )
         SELECT
-            h.path,
             v.id AS version_id,
-            v.thumbnail_id,
             r.reviewable_id
         FROM project_{project_name}.versions v
-
-        JOIN project_{project_name}.products p
-        ON p.id = v.product_id
-
-        JOIN project_{project_name}.hierarchy h
-        ON h.id = p.folder_id
 
         LEFT JOIN reviewables r
         ON r.version_id = v.id
@@ -43,11 +35,9 @@ async def process_project_thumbnails(project_name: str) -> None:
         WHERE v.thumbnail_id IS NULL
         AND r.reviewable_id IS NOT NULL
         ORDER BY v.created_at DESC
-        LIMIT 1000
     """
 
-    rows = await Postgres.fetch(query)
-    for row in rows:
+    async for row in Postgres.iterate(query):
         version_id = row["version_id"]
         reviewable_id = row["reviewable_id"]
 

--- a/cli/generate_version_thumbnails/generate_version_thumbnails.py
+++ b/cli/generate_version_thumbnails/generate_version_thumbnails.py
@@ -10,7 +10,9 @@ from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import logger
 
 
-async def process_project_thumbnails(project_name: str) -> None:
+async def process_project_thumbnails(
+    project_name: str, limit: int | None = None
+) -> None:
     query = f"""
         WITH reviewables AS (
             SELECT DISTINCT ON (a.entity_id)
@@ -37,19 +39,31 @@ async def process_project_thumbnails(project_name: str) -> None:
         ORDER BY v.created_at DESC
     """
 
+    if limit is not None:
+        query += f" LIMIT {limit}"
+
     async for row in Postgres.iterate(query):
         version_id = row["version_id"]
         reviewable_id = row["reviewable_id"]
 
-        await assign_version_thumbnail_from_reviewable(
-            project_name,
-            reviewable_id,
-            version=version_id,
-        )
+        try:
+            await assign_version_thumbnail_from_reviewable(
+                project_name,
+                reviewable_id,
+                version=version_id,
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to assign thumbnail for version {version_id} "
+                f"in project {project_name}: {e}"
+            )
 
 
 @app.command()
-async def generate_version_thumbnails(project_name: str | None = None) -> None:
+async def generate_version_thumbnails(
+    project_name: str | None = None,
+    limit: int | None = None,
+) -> None:
     """Create thumbnails for versions with reviewables, without thumbnail set"""
 
     await ayon_init()
@@ -58,7 +72,7 @@ async def generate_version_thumbnails(project_name: str | None = None) -> None:
     start_time = time.monotonic()
     if project_name is None:
         for project in projects:
-            await process_project_thumbnails(project.name)
+            await process_project_thumbnails(project.name, limit)
     else:
         project_name = await normalize_project_name(project_name)
         await process_project_thumbnails(project_name)

--- a/cli/generate_version_thumbnails/generate_version_thumbnails.py
+++ b/cli/generate_version_thumbnails/generate_version_thumbnails.py
@@ -1,7 +1,7 @@
 import time
 
 from ayon_server.cli import app
-from ayon_server.helpers.project_list import get_project_list
+from ayon_server.helpers.project_list import get_project_list, normalize_project_name
 from ayon_server.helpers.thumbnails.thumbnail_from_reviewable import (
     assign_version_thumbnail_from_reviewable,
 )
@@ -60,6 +60,7 @@ async def generate_version_thumbnails(project_name: str | None = None) -> None:
         for project in projects:
             await process_project_thumbnails(project.name)
     else:
+        project_name = await normalize_project_name(project_name)
         await process_project_thumbnails(project_name)
     elapsed_time = time.monotonic() - start_time
 


### PR DESCRIPTION
This pull request introduces a new mechanism for automatically assigning thumbnails to version entities from associated reviewable files, both during reviewable creation and via a new CLI utility for batch processing. It also includes some minor code cleanups and refactoring to support this functionality.

**New thumbnail assignment workflow:**

* Added `assign_version_thumbnail_from_reviewable` in `thumbnail_from_reviewable.py`, which extracts a preview from a reviewable file and assigns it as the thumbnail for a version. This is now used during reviewable creation if the version lacks a thumbnail. 

**CLI utility for batch thumbnail generation:**

* Introduced a new CLI command `generate_version_thumbnails` for populating missing version thumbnails from reviewables across projects, including efficient SQL queries and logging. 