### PR TITLE
Improved memory metrics

### DIFF
--- a/api/system/metrics.py
+++ b/api/system/metrics.py
@@ -107,8 +107,9 @@ async def get_tracemalloc_metrics(
 
     result += "# Tracemalloc metrics\n"
     for stat in top_stats[:10]:
-        result += f'tracemalloc_allocations{{file="{stat.traceback[0].filename}", line="{stat.traceback[0].lineno}"}} {stat.size_diff}\n'  # noqa: E501
-
+        tb0 = stat.traceback[0]
+        filename = tb0.filename.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+        result += f'ayon_tracemalloc_size_diff_bytes{{file="{filename}", line="{tb0.lineno}"}} {stat.size_diff}\n'
     return PlainTextResponse(result)
 
 

--- a/api/system/metrics.py
+++ b/api/system/metrics.py
@@ -99,10 +99,9 @@ async def get_tracemalloc_metrics(
             raise ForbiddenException("Access denied")
 
     global snapshot
-    if snapshot is None:
+    if snapshot is None or not tracemalloc.is_tracing():
         tracemalloc.start()
         snapshot = tracemalloc.take_snapshot()
-
     current_snapshot = tracemalloc.take_snapshot()
     top_stats = current_snapshot.compare_to(snapshot, "lineno")
 

--- a/api/system/metrics.py
+++ b/api/system/metrics.py
@@ -1,3 +1,5 @@
+import tracemalloc
+
 from fastapi import Query
 from fastapi.responses import PlainTextResponse
 
@@ -66,7 +68,69 @@ async def get_system_metrics(
             result += f'ayon_user_requests{{name="{name}"}} {num_requests}\n'
 
     # Get system metrics
-
     result += await system_metrics.render_prometheus()
 
     return PlainTextResponse(result)
+
+
+#
+# Tracemalloc metrics
+#
+
+snapshot: tracemalloc.Snapshot | None = None
+
+
+@router.get("/metrics/tracemalloc", dependencies=[NoTraces])
+async def get_tracemalloc_metrics(
+    user: CurrentUserOptional,
+    api_key: ApiKey,
+) -> PlainTextResponse:
+    """Get tracemalloc metrics in Prometheus format"""
+
+    result = ""
+
+    if user is not None and not user.is_admin:
+        user = None
+
+    if user is None:
+        if api_key is None:
+            raise ForbiddenException("Access denied")
+        if api_key != ayonconfig.metrics_api_key:
+            raise ForbiddenException("Access denied")
+
+    global snapshot
+    if snapshot is None:
+        tracemalloc.start()
+        snapshot = tracemalloc.take_snapshot()
+
+    current_snapshot = tracemalloc.take_snapshot()
+    top_stats = current_snapshot.compare_to(snapshot, "lineno")
+
+    result += "# Tracemalloc metrics\n"
+    for stat in top_stats[:10]:
+        result += f'tracemalloc_allocations{{file="{stat.traceback[0].filename}", line="{stat.traceback[0].lineno}"}} {stat.size_diff}\n'  # noqa: E501
+
+    return PlainTextResponse(result)
+
+
+@router.delete("/metrics/tracemalloc", dependencies=[NoTraces])
+async def stop_tracemalloc_metrics(
+    user: CurrentUserOptional,
+    api_key: ApiKey,
+) -> PlainTextResponse:
+    """Stop tracemalloc metrics collection"""
+
+    if user is not None and not user.is_admin:
+        user = None
+
+    if user is None:
+        if api_key is None:
+            raise ForbiddenException("Access denied")
+        if api_key != ayonconfig.metrics_api_key:
+            raise ForbiddenException("Access denied")
+
+    global snapshot
+    snapshot = None
+    tracemalloc.stop()
+
+    return PlainTextResponse("Tracemalloc metrics collection stopped")

--- a/ayon_server/metrics/system.py
+++ b/ayon_server/metrics/system.py
@@ -110,7 +110,7 @@ class SystemMetrics:
             Metric("uptime_seconds", time.time() - self.boot_time),
             Metric("runtime_seconds", time.time() - self.run_time),
             Metric("redis_size_total", redis_size),
-            Metric("asyncio_tasks_total", len(asyncio.all_tasks())),
+            Metric("asyncio_tasks", len(asyncio.all_tasks())),
         ]
 
     async def render_prometheus(self) -> str:

--- a/ayon_server/metrics/system.py
+++ b/ayon_server/metrics/system.py
@@ -97,14 +97,15 @@ class SystemMetrics:
         mem_usage = 100 * ((mem.total - mem.available) / mem.total)
 
         process = psutil.Process(os.getpid())
+        proc_mem = process.memory_info()
 
         redis_size = await Redis.get_total_size()
 
         return [
             Metric("cpu_usage", psutil.cpu_percent()),
             Metric("memory_usage", mem_usage),
-            Metric("process_memory_rss", process.memory_info().rss),
-            Metric("process_memory_vms", process.memory_info().vms),
+            Metric("process_memory_rss", proc_mem.rss),
+            Metric("process_memory_vms", proc_mem.vms),
             Metric("swap_usage", psutil.swap_memory().percent),
             Metric("uptime_seconds", time.time() - self.boot_time),
             Metric("runtime_seconds", time.time() - self.run_time),

--- a/ayon_server/metrics/system.py
+++ b/ayon_server/metrics/system.py
@@ -1,3 +1,5 @@
+import asyncio
+import os
 import time
 from typing import Any
 
@@ -94,15 +96,20 @@ class SystemMetrics:
         mem = psutil.virtual_memory()
         mem_usage = 100 * ((mem.total - mem.available) / mem.total)
 
+        process = psutil.Process(os.getpid())
+
         redis_size = await Redis.get_total_size()
 
         return [
             Metric("cpu_usage", psutil.cpu_percent()),
             Metric("memory_usage", mem_usage),
+            Metric("process_memory_rss", process.memory_info().rss),
+            Metric("process_memory_vms", process.memory_info().vms),
             Metric("swap_usage", psutil.swap_memory().percent),
             Metric("uptime_seconds", time.time() - self.boot_time),
             Metric("runtime_seconds", time.time() - self.run_time),
             Metric("redis_size_total", redis_size),
+            Metric("asyncio_tasks_total", len(asyncio.all_tasks())),
         ]
 
     async def render_prometheus(self) -> str:


### PR DESCRIPTION
This pull request adds new memory profiling and system metrics capabilities to the server, including tracemalloc-based memory allocation tracking and additional process-level metrics in Prometheus format. The changes enhance observability and diagnostics for administrators and API key holders.

**Tracemalloc metrics endpoints:**
* Added new `/metrics/tracemalloc` GET endpoint in `api/system/metrics.py` to expose memory allocation statistics using Python's `tracemalloc` module, with access restricted to admins or valid API keys.
* Added `/metrics/tracemalloc` DELETE endpoint to stop tracemalloc metrics collection and reset the snapshot.
* Imported `tracemalloc` in `api/system/metrics.py` to support the new endpoints.

**System metrics enhancements:**
* Added reporting of process memory usage (`process_memory_rss`, `process_memory_vms`) and the total number of asyncio tasks (`asyncio_tasks_total`) to the Prometheus metrics output in `ayon_server/metrics/system.py`.
* Imported `os` and `asyncio` in `ayon_server/metrics/system.py` to support new metrics.