### PR TITLE
Track calculated attributes in event stream

### DIFF
--- a/ayon_server/events/patch.py
+++ b/ayon_server/events/patch.py
@@ -194,7 +194,7 @@ def build_pl_entity_change_events(
                 "newValue": new_attributes,
             }
             if calculated_attributes:
-                evt["payload"]["calculatedAttributes"] = list[calculated_attributes]
+                evt["payload"]["calculatedAttributes"] = list(calculated_attributes)  # type: ignore[index]
 
         if new_attributes:
             attr_list = ", ".join(new_attributes.keys())

--- a/ayon_server/events/patch.py
+++ b/ayon_server/events/patch.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import Any
 
 from pydantic import BaseModel
@@ -66,6 +67,8 @@ def get_tags_description(entity_desc: str, list1: list[str], list2: list[str]) -
 def build_pl_entity_change_events(
     original_entity: ProjectLevelEntity,
     patch: BaseModel,
+    *,
+    calculated_attributes: Iterable[str] | None = None,
 ) -> list[EventData]:
     """Return a listof events triggered by a patch on a project level entity.
 
@@ -190,6 +193,8 @@ def build_pl_entity_change_events(
                 "oldValue": old_attributes,
                 "newValue": new_attributes,
             }
+            if calculated_attributes:
+                evt["payload"]["calculatedAttributes"] = list[calculated_attributes]
 
         if new_attributes:
             attr_list = ", ".join(new_attributes.keys())

--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -115,6 +115,7 @@ async def update_project_level_entity(
         "thumbnailId" in operation.data or "thumbnail_id" in operation.data
     )
     entity = await entity_class.load(project_name, operation.entity_id)
+
     calculated_attributes: set[str] = set()
 
     hooks = OperationHooks.hooks()
@@ -127,7 +128,7 @@ async def update_project_level_entity(
         for hook in hooks:
             res = await hook(operation, temp_entity, user)
             if res.calculated_attributes:
-                calculated_attributes.add(*res.calculated_attributes)
+                calculated_attributes.update(res.calculated_attributes)
 
     # Casting the payload to the model class is used to validate the data
     payload = entity_class.model.patch_model(**operation.data)

--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -10,7 +10,7 @@ from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.logging import logger
 
-from .hooks import OperationHooks
+from .hooks import HookResult, OperationHooks
 from .models import OperationModel
 from .validation import validate_task
 
@@ -127,7 +127,7 @@ async def update_project_level_entity(
 
         for hook in hooks:
             res = await hook(operation, temp_entity, user)
-            if res.calculated_attributes:
+            if isinstance(res, HookResult) and res.calculated_attributes:
                 calculated_attributes.update(res.calculated_attributes)
 
     # Casting the payload to the model class is used to validate the data

--- a/ayon_server/operations/project_level/entity_update.py
+++ b/ayon_server/operations/project_level/entity_update.py
@@ -115,6 +115,7 @@ async def update_project_level_entity(
         "thumbnailId" in operation.data or "thumbnail_id" in operation.data
     )
     entity = await entity_class.load(project_name, operation.entity_id)
+    calculated_attributes: set[str] = set()
 
     hooks = OperationHooks.hooks()
     if hooks:
@@ -124,7 +125,9 @@ async def update_project_level_entity(
         temp_entity.patch(temp_payload, user=user)
 
         for hook in hooks:
-            await hook(operation, temp_entity, user)
+            res = await hook(operation, temp_entity, user)
+            if res.calculated_attributes:
+                calculated_attributes.add(*res.calculated_attributes)
 
     # Casting the payload to the model class is used to validate the data
     payload = entity_class.model.patch_model(**operation.data)
@@ -147,7 +150,11 @@ async def update_project_level_entity(
     # Build events for every change
     # Do this before applying the patch, to the entity to detect the changes
 
-    events = build_pl_entity_change_events(entity, payload)
+    events = build_pl_entity_change_events(
+        entity,
+        payload,
+        calculated_attributes=calculated_attributes,
+    )
     if user:
         for event in events:
             event["user"] = user.name

--- a/ayon_server/operations/project_level/hooks.py
+++ b/ayon_server/operations/project_level/hooks.py
@@ -49,8 +49,6 @@ class OperationHooks:
 
     In both cases, hook should not modify the entity, but the operation data
     (operation.data) or raise exceptions to prevent the operation.
-
-    Handling Hook result is not yet implemented.
     """
 
     _hooks: dict[str, HookType] = {}

--- a/ayon_server/operations/project_level/hooks.py
+++ b/ayon_server/operations/project_level/hooks.py
@@ -13,6 +13,7 @@ from .models import OperationModel
 class HookResult(BaseModel):
     message: str | None = None
     triggers: list[str] | None = None
+    calculated_attributes: list[str] | None = None
 
 
 HookType = Callable[


### PR DESCRIPTION
This pull request introduces support for tracking and reporting "calculated attributes" that are determined by hooks during project-level entity updates. The main changes involve collecting these attributes from hook results and including them in the event payloads generated after an entity update.

These changes make it possible for downstream consumers to know which attributes were calculated during an entity update, improving traceability and extensibility of the event system.

<img width="923" height="765" alt="image" src="https://github.com/user-attachments/assets/d2154949-1438-4191-bc73-a403c9ca2837" />

