### PR TITLE
Text search in entity list resolver

### DIFF
--- a/ayon_server/graphql/resolvers/entity_lists.py
+++ b/ayon_server/graphql/resolvers/entity_lists.py
@@ -19,6 +19,7 @@ from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
 from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.utils import SQLTool, json_loads
+from ayon_server.utils.strings import slugify
 
 SORT_OPTIONS = {
     "label": "label",
@@ -53,6 +54,7 @@ async def get_entity_lists(
     before: ARGBefore = None,
     ids: ARGIds = None,
     filter: Annotated[str | None, argdesc("Filter tasks using QueryFilter")] = None,
+    search: Annotated[str | None, argdesc("Fuzzy text search filter")] = None,
     sort_by: Annotated[str | None, sortdesc(SORT_OPTIONS)] = None,
 ) -> EntityListsConnection:
     project_name = root.project_name
@@ -98,6 +100,24 @@ async def get_entity_lists(
         fq = QueryFilter(**fdata)
         if fcond := build_filter(fq, columns=FILTER_OPTIONS):
             sql_conditions.append(fcond)
+
+    if search:
+        parts = search.split(",")
+        t1_conds = []
+        for part in parts:
+            terms = slugify(part, make_set=True, split_chars=" ")
+            t2_conds = []
+            for term in terms:
+                t2_conds.append(
+                    f"""
+                    (
+                        label ILIKE '%{term}%'
+                        OR entity_type ILIKE '%{term}%'
+                    )
+                    """
+                )
+            t1_conds.append(SQLTool.conditions(t2_conds, "AND", add_where=False))
+        sql_conditions.append(SQLTool.conditions(t1_conds, "OR", add_where=False))
 
     #
     # Pagination and sorting


### PR DESCRIPTION
This pull request adds a fuzzy text search capability to the `get_entity_lists` GraphQL resolver, allowing users to filter entity lists by searching across `label` and `entity_type` fields. The changes also include importing the `slugify` utility to process search terms.


<img width="824" height="354" alt="image" src="https://github.com/user-attachments/assets/5f8b3b90-e217-4159-a367-9a4e219c8b83" />
<img width="729" height="349" alt="image" src="https://github.com/user-attachments/assets/dac438e4-0eab-4d6c-afaa-8559e91db64d" />
