### PR TITLE
Entity lists: sort items by product name

### DIFF
--- a/ayon_server/graphql/resolvers/entity_list_items.py
+++ b/ayon_server/graphql/resolvers/entity_list_items.py
@@ -88,6 +88,16 @@ ITEM_SORT_OPTIONS = {
 }
 
 
+ENTITY_SORT_OPTIONS: dict[str, dict[str, str]] = {
+    "version": {
+        "productName": "_entity__product_name",
+    },
+    "product": {
+        "productName": "_entity_name",
+    },
+}
+
+
 @functools.cache
 def cols_for_entity(entity_type: str) -> list[str]:
     fields: list[FieldDefinitionDict]
@@ -480,6 +490,9 @@ async def get_entity_list_items(
 
         elif sort_by in ITEM_SORT_OPTIONS.values():
             order_by.append(sort_by)
+
+        elif entity_sort_by := ENTITY_SORT_OPTIONS.get(entity_type, {}).get(sort_by):
+            order_by.append(entity_sort_by)
 
         elif sort_by.startswith("attrib."):
             attr_name = sort_by[7:]


### PR DESCRIPTION
## PR Checklist

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

Allow sorting EntityList items by **product name**. There was no sort key for it, so the frontend's sort shortcut errored out with `Invalid entity sort key`.

### Technical details

- Add `ENTITY_SORT_OPTIONS`, a per-entity-type map of sort keys backed by columns that only exist for some entity types. A `productName` key resolves to:
- No new joins or query cost,  the product name column was already selected for display; it just had no sort key wired to it.

### Additional context

Fixes the error reported in ynput/ayon-frontend#2087. The frontend counterpart
(which sends `productName` as the sort key) depends on this merge/deploy this first.
