### PR TITLE
Include folder children in folder resolver

### DIFF
--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -66,7 +66,7 @@ async def get_folders(
     ids: ARGIds = None,
     include_folder_children: Annotated[
         bool,
-        argdesc("Include child folders when ids is used"),
+        argdesc("Include child folders when ids or parentIds is used"),
     ] = False,
     parent_id: Annotated[
         str | None,
@@ -396,19 +396,43 @@ async def get_folders(
         if not parent_ids:
             return FoldersConnection()
 
-        pids_set: set[str | None] = set(parent_ids)
-        lconds = []
-        if "root" in pids_set or None in pids_set:
-            lconds.append("folders.parent_id IS NULL")
+        if include_folder_children:
+            sql_cte.append(
+                f"""
+                top_folder_paths AS (
+                    SELECT id, path FROM project_{project_name}.hierarchy
+                    WHERE id IN {SQLTool.id_array(parent_ids)}
+                )
+                """
+            )
 
-        pids_set.discard("root")
-        pids_set.discard(None)
+            sql_cte.append(
+                f"""
+                child_folder_ids AS (
+                    SELECT id FROM project_{project_name}.hierarchy
+                    WHERE EXISTS (
+                        SELECT 1 FROM top_folder_paths
+                        WHERE project_{project_name}.hierarchy.path
+                        LIKE top_folder_paths.path || '/%'
+                    )
+                )
+                """
+            )
+            sql_conditions.append("folders.id IN (SELECT id FROM child_folder_ids)")
+        else:
+            pids_set: set[str | None] = set(parent_ids)
+            lconds = []
+            if "root" in pids_set or None in pids_set:
+                lconds.append("folders.parent_id IS NULL")
 
-        if pids_set:
-            pids_list = cast("list[str]", list(pids_set))
-            lconds.append(f"folders.parent_id IN {SQLTool.id_array(pids_list)}")
-        if lconds:
-            sql_conditions.append(f"({' OR '.join(lconds)})")
+            pids_set.discard("root")
+            pids_set.discard(None)
+
+            if pids_set:
+                pids_list = cast("list[str]", list(pids_set))
+                lconds.append(f"folders.parent_id IN {SQLTool.id_array(pids_list)}")
+            if lconds:
+                sql_conditions.append(f"({' OR '.join(lconds)})")
 
     if folder_types is not None:
         if not folder_types:

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -705,9 +705,9 @@ async def get_folders(
         {raw_data_end}
     """
     # Keep it here for debugging :)
-    from ayon_server.logging import logger
-
-    logger.debug(f"Folder query\n{query}")
+    # from ayon_server.logging import logger
+    #
+    # logger.debug(f"Folder query\n{query}")
 
     if stats_select_clause:
         field_stats = await generate_field_stats(query)

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -64,6 +64,10 @@ async def get_folders(
     last: ARGLast = None,
     before: ARGBefore = None,
     ids: ARGIds = None,
+    include_folder_children: Annotated[
+        bool,
+        argdesc("Include child folders when ids is used"),
+    ] = False,
     parent_id: Annotated[
         str | None,
         argdesc(
@@ -349,7 +353,36 @@ async def get_folders(
     if ids is not None:
         if not ids:
             return FoldersConnection()
-        sql_conditions.append(f"folders.id IN {SQLTool.id_array(ids)}")
+
+        if include_folder_children:
+            sql_cte.append(
+                f"""
+                top_folder_paths AS (
+                    SELECT id, path FROM project_{project_name}.hierarchy
+                    WHERE id IN {SQLTool.id_array(ids)}
+                )
+                """
+            )
+
+            sql_cte.append(
+                f"""
+                child_folder_ids AS (
+                    SELECT id FROM project_{project_name}.hierarchy
+                    WHERE EXISTS (
+                        SELECT 1 FROM top_folder_paths
+                        WHERE project_{project_name}.hierarchy.path
+                        LIKE top_folder_paths.path || '/%'
+                    )
+                    OR project_{project_name}.hierarchy.id
+                    IN (SELECT id FROM top_folder_paths)
+                )
+                """
+            )
+
+            sql_conditions.append("folders.id IN (SELECT id FROM child_folder_ids)")
+
+        else:
+            sql_conditions.append(f"folders.id IN {SQLTool.id_array(ids)}")
 
     if parent_id is not None:
         # Still used. do not remove!
@@ -362,6 +395,7 @@ async def get_folders(
     if parent_ids is not None:
         if not parent_ids:
             return FoldersConnection()
+
         pids_set: set[str | None] = set(parent_ids)
         lconds = []
         if "root" in pids_set or None in pids_set:
@@ -373,7 +407,6 @@ async def get_folders(
         if pids_set:
             pids_list = cast("list[str]", list(pids_set))
             lconds.append(f"folders.parent_id IN {SQLTool.id_array(pids_list)}")
-
         if lconds:
             sql_conditions.append(f"({' OR '.join(lconds)})")
 
@@ -672,9 +705,9 @@ async def get_folders(
         {raw_data_end}
     """
     # Keep it here for debugging :)
-    # from ayon_server.logging import logger
-    #
-    # logger.debug(f"Folder query\n{query}")
+    from ayon_server.logging import logger
+
+    logger.debug(f"Folder query\n{query}")
 
     if stats_select_clause:
         field_stats = await generate_field_stats(query)


### PR DESCRIPTION
This pull request enhances the folder retrieval functionality in the `get_folders` GraphQL resolver. The main improvement is the addition of an option to include child folders when querying by IDs the same way task resolver does. it.

<img width="1762" height="432" alt="image" src="https://github.com/user-attachments/assets/38bb405f-3fbf-40cf-ab9d-cb87f5455993" />

<img width="1266" height="473" alt="image" src="https://github.com/user-attachments/assets/44bad907-5080-4c0e-9a6d-d15f3d4bdae7" />
