### PR TITLE
Cache assigned task folder paths

### DIFF
--- a/ayon_server/access/utils.py
+++ b/ayon_server/access/utils.py
@@ -109,7 +109,6 @@ async def parse_permset(
         elif perm.access_type == "assigned":
             cres = await get_assigned_task_folder_paths(project_name, user.name)
             for path in cres.get("paths") or []:
-                fpaths.add(path)
                 fpaths.update(
                     path_to_paths(
                         path,

--- a/ayon_server/access/utils.py
+++ b/ayon_server/access/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, TypedDict
 
 from ayon_server.exceptions import ForbiddenException
 from ayon_server.lib.postgres import Postgres
@@ -40,6 +40,10 @@ def path_to_paths(
     return result
 
 
+class AssignedTaskFolderPathsCache(TypedDict):
+    paths: list[str]
+
+
 @Redis.cached(
     "assigned-task-folder-paths",
     "{project_name}:{user_name}",
@@ -48,7 +52,7 @@ def path_to_paths(
 async def get_assigned_task_folder_paths(
     project_name: str,
     user_name: str,
-) -> list[str]:
+) -> AssignedTaskFolderPathsCache:
     """Get a list of folder paths for tasks assigned to the user"""
 
     logger.trace(
@@ -57,21 +61,18 @@ async def get_assigned_task_folder_paths(
     )
 
     query = f"""
-        SELECT
-            h.path
-        FROM
-            project_{project_name}.hierarchy as h
-        INNER JOIN
-            project_{project_name}.tasks as t
+        SELECT DISTINCT (h.path)
+        FROM project_{project_name}.hierarchy as h
+        INNER JOIN project_{project_name}.tasks as t
             ON h.id = t.folder_id
         WHERE
             $1 = ANY (t.assignees)
         """
-    fpaths = set()
-    async for record in Postgres.iterate(query, user_name):
-        for path in path_to_paths(record["path"]):
-            fpaths.add(path)
-    return list(fpaths)
+
+    paths: list[str] = [
+        record["path"] for record in await Postgres.fetch(query, user_name)
+    ]
+    return {"paths": paths}
 
 
 async def parse_permset(
@@ -106,7 +107,15 @@ async def parse_permset(
                 fpaths.add(path)
 
         elif perm.access_type == "assigned":
-            fpaths.update(await get_assigned_task_folder_paths(project_name, user.name))
+            cres = await get_assigned_task_folder_paths(project_name, user.name)
+            for path in cres.get("paths") or []:
+                fpaths.add(path)
+                fpaths.update(
+                    path_to_paths(
+                        path,
+                        include_parents=access_type == "read" and not no_parents,
+                    )
+                )
 
     folder_list = list(fpaths)
     return folder_list

--- a/ayon_server/access/utils.py
+++ b/ayon_server/access/utils.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, Literal
 
 from ayon_server.exceptions import ForbiddenException
 from ayon_server.lib.postgres import Postgres
+from ayon_server.lib.redis import Redis
+from ayon_server.logging import logger
 from ayon_server.utils import SQLTool
 
 if TYPE_CHECKING:
@@ -38,6 +40,40 @@ def path_to_paths(
     return result
 
 
+@Redis.cached(
+    "assigned-task-folder-paths",
+    "{project_name}:{user_name}",
+    ttl=120,
+)
+async def get_assigned_task_folder_paths(
+    project_name: str,
+    user_name: str,
+) -> list[str]:
+    """Get a list of folder paths for tasks assigned to the user"""
+
+    logger.trace(
+        f"Resolving assigned task folder paths for {user_name} "
+        f"in project {project_name}"
+    )
+
+    query = f"""
+        SELECT
+            h.path
+        FROM
+            project_{project_name}.hierarchy as h
+        INNER JOIN
+            project_{project_name}.tasks as t
+            ON h.id = t.folder_id
+        WHERE
+            $1 = ANY (t.assignees)
+        """
+    fpaths = set()
+    async for record in Postgres.iterate(query, user_name):
+        for path in path_to_paths(record["path"]):
+            fpaths.add(path)
+    return list(fpaths)
+
+
 async def parse_permset(
     user: "UserEntity",
     project_name: str,
@@ -48,12 +84,6 @@ async def parse_permset(
     """Convert a permission set to a list of paths"""
     if not permset.enabled:
         return None
-
-    # TODO: Enable caching when we figure out how to invalidate it
-    # ns = "folder-access-list"
-    # key = f"{project_name}:{user.name}:{access_type}"
-    # if (cached := await Redis.get_json(ns, key)) is not None:
-    #     return cached
 
     fpaths = set()
     for perm in permset.access_list:
@@ -76,29 +106,9 @@ async def parse_permset(
                 fpaths.add(path)
 
         elif perm.access_type == "assigned":
-            query = f"""
-                SELECT
-                    h.path
-                FROM
-                    project_{project_name}.hierarchy as h
-                INNER JOIN
-                    project_{project_name}.tasks as t
-                    ON h.id = t.folder_id
-                WHERE
-                    '{user.name}' = ANY (t.assignees)
-                """
-            async for record in Postgres.iterate(query):
-                for path in path_to_paths(
-                    record["path"],
-                    include_parents=access_type == "read" and not no_parents,
-                ):
-                    fpaths.add(path)
+            fpaths.update(await get_assigned_task_folder_paths(project_name, user.name))
+
     folder_list = list(fpaths)
-    # logger.trace(
-    #     f"Caching {user.name} {project_name} {access_type} "
-    #     f"access: {', '.join(folder_list)}"
-    # )
-    # await Redis.set_json(ns, key, folder_list)
     return folder_list
 
 
@@ -256,6 +266,11 @@ async def ensure_entity_access(
     raise ForbiddenException("Entity access denied")
 
 
+#
+# AccessChecker
+#
+
+
 class TrieNode:
     def __init__(self):
         self.children = {}
@@ -270,9 +285,13 @@ class AccessChecker:
     AccessChecker is used to determine if a user has access
     to specific paths within a project.
 
+
     This class builds a trie (prefix tree) structure to efficiently
     check if a given path is accessible based on the user's permissions.
     It also supports exact path matching and wildcard path matching.
+
+    It is useful when you need to check access for multiple paths in a project
+    during a single request, as it avoids repeated database queries.
 
     Usage:
         access_checker = AccessChecker()

--- a/ayon_server/access/utils.py
+++ b/ayon_server/access/utils.py
@@ -53,7 +53,7 @@ async def get_assigned_task_folder_paths(
     project_name: str,
     user_name: str,
 ) -> AssignedTaskFolderPathsCache:
-    """Get a list of folder paths for tasks assigned to the user"""
+    """Return cached folder paths for tasks assigned to the user."""
 
     logger.trace(
         f"Resolving assigned task folder paths for {user_name} "

--- a/ayon_server/activities/event_hook.py
+++ b/ayon_server/activities/event_hook.py
@@ -24,6 +24,7 @@ from ayon_server.activities.watchers.set_watchers import (
 from ayon_server.activities.watchers.watcher_list import build_watcher_list
 from ayon_server.helpers.get_entity_class import get_entity_class
 from ayon_server.lib.postgres import Postgres
+from ayon_server.lib.redis import Redis
 
 if TYPE_CHECKING:
     from ayon_server.events import EventModel, EventStream
@@ -133,6 +134,12 @@ class ActivityFeedEventHook:
                 body=f"Removed {name_tag} from {entity_tag}",
                 user_name=event.user,
                 data={"assignee": assignee},
+            )
+
+        for assignee in all_assignees:
+            await Redis.delete(
+                "assigned-task-folder-paths",
+                f"{event.project}:{assignee}",
             )
 
     @classmethod

--- a/ayon_server/helpers/thumbnails/common.py
+++ b/ayon_server/helpers/thumbnails/common.py
@@ -20,7 +20,7 @@ PlaceholderOption = Literal["empty", "none"]
 def get_fake_thumbnail() -> bytes:
     """Returns a fake thumbnail image as a byte stream.
 
-    The image is a 1x1 pixel PNG encoded in base64.
+    The image is a 1x1 pixel PNG.
     """
     base64_string = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="  # noqa
     return base64.b64decode(base64_string)

--- a/ayon_server/helpers/thumbnails/thumbnail_info_resolvers.py
+++ b/ayon_server/helpers/thumbnails/thumbnail_info_resolvers.py
@@ -4,7 +4,7 @@ from ayon_server.lib.redis import Redis
 
 from .common import ThumbnailInfo
 
-THUMBNAIL_INFO_TTL = 600  # 10 minutes
+THUMBNAIL_INFO_TTL = 3600
 
 
 @Redis.cached("thumbnail-info", "{project_name}:{entity_id}", ttl=THUMBNAIL_INFO_TTL)


### PR DESCRIPTION
This pull request introduces a Redis-backed caching mechanism for resolving assigned task folder paths, improving performance and reducing redundant database queries. The main change is the introduction of the `get_assigned_task_folder_paths` function, which is now used in permission resolution and properly invalidated when assignees change. Additional minor improvements include enhanced logging and code cleanup.

**Caching and Performance Improvements:**

* Added `get_assigned_task_folder_paths`, an async Redis-cached function, to efficiently fetch and cache all folder paths for tasks assigned to a user in a project
* Updated permission parsing logic to use the new cached function instead of direct database queries, reducing repeated lookups 
* Implemented cache invalidation for assigned task folder paths: when assignees for a task change, the corresponding Redis cache entries are deleted to ensure users see up-to-date access