### PR TITLE
Modified stats for inherited attribs to collect from all levels

### DIFF
--- a/ayon_server/graphql/resolvers/field_stats.py
+++ b/ayon_server/graphql/resolvers/field_stats.py
@@ -112,7 +112,10 @@ def _get_stats_for_column(
     return []
 
 
-def generate_specific_stats_columns(calculate_specific_statistics) -> str:
+def generate_specific_stats_columns(
+    calculate_specific_statistics: list[MetricTargetInput],
+    has_project_attributes: bool = False,
+) -> str:
     """Generate aggregations strictly requested by FE definitions."""
     stats_fields = set()
 
@@ -126,6 +129,20 @@ def generate_specific_stats_columns(calculate_specific_statistics) -> str:
             column_expr = f"({json_target}')"
         else:
             column_expr = raw_field
+
+        # collect values from all levels
+        if "inherited_attributes." in raw_field:
+            pure_name = raw_field.replace("inherited_attributes.", "")
+            pr_attr = (
+                f", project_attributes->>'{pure_name}' "
+                if has_project_attributes
+                else ""
+            )
+            column_expr = (
+                f"COALESCE(attrib->>'{pure_name}', "
+                f"inherited_attributes->>'{pure_name}'"
+                f" {pr_attr})"
+            )
 
         AGGR_TEMPLATES = {
             "min": f"MIN({column_expr}::numeric) AS {column_name}_min",

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -699,7 +699,7 @@ async def get_folders(
     stats_select_clause = None
     if calculate_specific_statistics:
         stats_select_clause = generate_specific_stats_columns(
-            calculate_specific_statistics
+            calculate_specific_statistics, True
         )
     elif calculate_statistics:
         stats_select_clause = generate_stats_columns(columns_metadata)


### PR DESCRIPTION
## Description of changes

This PR modifies calculation of stats for columns containing `inherited_attibutes` to collect values from `item.attrib`, `item.inherited_attributes` and `project_attributes` (if available). (In this order of precedence.)

This should handle wrong numbers for fields like `priority`.

### Technical details

<img width="117" height="371" alt="image" src="https://github.com/user-attachments/assets/10bb10b5-cd87-4fba-b0b3-566b4eba8ba9" /> (this PR)

vs

<img width="121" height="371" alt="image" src="https://github.com/user-attachments/assets/536a3c96-6c26-440a-a179-76037cb19d8a" /> (previous)

It is assumed that if we are asking for 'inherited' values, we want to actually get all levels. If there would be a need to differentiate between each level, new name (`effective.priority`) would need to be introduced in frontend (and BE updated accordingly).

(Now FE sends `inherited.priority` even if it means all levels (for example).

