### PR TITLE
Optimize database migrations

### DIFF
--- a/schemas/migrations/00000002.sql
+++ b/schemas/migrations/00000002.sql
@@ -75,6 +75,7 @@ FOR rec IN
     JOIN pg_namespace ns ON c.relnamespace = ns.oid
     JOIN pg_attribute a ON a.attnum = ANY (con.conkey) AND a.attrelid = c.oid
     WHERE con.contype = 'f'
+      AND con.confupdtype != 'c'
       AND a.attname = 'user_name'
       AND ns.nspname LIKE 'project_%'
 LOOP

--- a/schemas/migrations/00000002.sql
+++ b/schemas/migrations/00000002.sql
@@ -66,24 +66,17 @@ DO $$
 DECLARE rec RECORD;
 BEGIN
 FOR rec IN
-    SELECT DISTINCT
-        tc.table_schema project_schema,
-        tc.table_name,
-        kcu.column_name,
-        tc.constraint_name,
-        pc.confupdtype
-    FROM
-        information_schema.table_constraints AS tc
-    JOIN information_schema.key_column_usage AS kcu
-        ON tc.constraint_name = kcu.constraint_name
-        AND kcu.column_name = 'user_name'
-    JOIN pg_constraint AS pc
-        ON tc.constraint_name = pc.conname
-        AND tc.table_schema = pc.connamespace::regnamespace::text
-        AND pc.confupdtype != 'c'
-    WHERE
-        tc.table_schema LIKE 'project_%'
-        AND tc.constraint_type = 'FOREIGN KEY'
+    SELECT ns.nspname AS project_schema,
+           c.relname AS table_name,
+           con.conname AS constraint_name,
+           a.attname AS column_name
+    FROM pg_constraint con
+    JOIN pg_class c ON con.conrelid = c.oid
+    JOIN pg_namespace ns ON c.relnamespace = ns.oid
+    JOIN pg_attribute a ON a.attnum = ANY (con.conkey) AND a.attrelid = c.oid
+    WHERE con.contype = 'f'
+      AND a.attname = 'user_name'
+      AND ns.nspname LIKE 'project_%'
 LOOP
     RAISE WARNING 'Fixing user_name foreign key on %.%', rec.project_schema, rec.table_name;
 

--- a/schemas/migrations/00000008.sql
+++ b/schemas/migrations/00000008.sql
@@ -7,10 +7,9 @@ DO $$
 DECLARE rec RECORD;
 BEGIN
 FOR rec IN
-  SELECT 
+  SELECT DISTINCT
     ns.nspname AS project_schema,
     cl.relname AS table_name,
-    att.attname AS column_name,
     con.conname AS constraint_name
   FROM pg_constraint con
   JOIN pg_class cl ON con.conrelid = cl.oid

--- a/schemas/migrations/00000008.sql
+++ b/schemas/migrations/00000008.sql
@@ -2,49 +2,33 @@
 -- that allows migrating projects between instances
 -- without breaking the foreign keys
 
+
 DO $$
 DECLARE rec RECORD;
 BEGIN
 FOR rec IN
-  SELECT DISTINCT
-    tc.table_schema project_schema,
-    tc.table_name,
-    kcu.column_name,
-    tc.constraint_name,
-    pc.confupdtype
-  FROM
-    information_schema.table_constraints AS tc
-  JOIN information_schema.key_column_usage AS kcu
-    ON tc.constraint_name = kcu.constraint_name
-    AND kcu.column_name IN (
-      'created_by', 
-      'updated_by',  
-      'owner',
-      'user_name',
-      'site_id'
-  )
-  JOIN pg_constraint AS pc
-    ON tc.constraint_name = pc.conname
-    AND tc.table_schema = pc.connamespace::regnamespace::text
-  WHERE
-    tc.table_schema LIKE 'project_%'
-    AND tc.table_name IN (
-      'workfiles', 
-      'entity_lists', 
-      'entity_list_items',
-      'project_site_settings',
-      'custom_roots'
-    )
-    AND tc.constraint_type = 'FOREIGN KEY'
-  LOOP
-    RAISE WARNING 'Removing users references from %.%', rec.project_schema, rec.table_name;
+  SELECT 
+    ns.nspname AS project_schema,
+    cl.relname AS table_name,
+    att.attname AS column_name,
+    con.conname AS constraint_name
+  FROM pg_constraint con
+  JOIN pg_class cl ON con.conrelid = cl.oid
+  JOIN pg_namespace ns ON cl.relnamespace = ns.oid
+  JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = ANY(con.conkey)
+  WHERE 
+    ns.nspname LIKE 'project_%'
+    AND cl.relname IN ('workfiles', 'entity_lists', 'entity_list_items', 'project_site_settings', 'custom_roots')
+    AND att.attname IN ('created_by', 'updated_by', 'owner', 'user_name', 'site_id')
+    AND con.contype = 'f'
+LOOP
+  RAISE WARNING 'Removing users references from %.%', rec.project_schema, rec.table_name;
 
-    EXECUTE format(
-      'ALTER TABLE %I.%I DROP CONSTRAINT %I;',
-      rec.project_schema,
-      rec.table_name,
-      rec.constraint_name
-    );
-  END LOOP;
+  EXECUTE format(
+    'ALTER TABLE %I.%I DROP CONSTRAINT %I;',
+    rec.project_schema,
+    rec.table_name,
+    rec.constraint_name
+  );
+END LOOP;
 END $$;
-

--- a/schemas/migrations/00000009.sql
+++ b/schemas/migrations/00000009.sql
@@ -25,7 +25,7 @@ FOR rec IN
         BEGIN
           EXECUTE 'SET LOCAL search_path TO ' || quote_ident(rec.project_schema);
 
-          CREATE TABLE entity_list_folders (
+          CREATE TABLE IF NOT EXISTS entity_list_folders (
               id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
               label VARCHAR NOT NULL,
               position INTEGER NOT NULL DEFAULT 0,
@@ -35,7 +35,7 @@ FOR rec IN
               data JSONB DEFAULT '{}'::JSONB
           );
 
-          CREATE UNIQUE INDEX uq_entity_list_folder_parent_label 
+          CREATE UNIQUE INDEX IF NOT EXISTS uq_entity_list_folder_parent_label 
             ON entity_list_folders(COALESCE(parent_id::varchar, ''), LOWER(label));
 
           ALTER TABLE entity_lists ADD COLUMN IF NOT EXISTS 
@@ -44,7 +44,7 @@ FOR rec IN
 
         EXCEPTION
           WHEN OTHERS THEN
-             RAISE WARNING 'Skipping schema % due to error: %', rec.nspname, SQLERRM;
+             RAISE WARNING 'Skipping schema % due to error: %', rec.project_schema, SQLERRM;
         END;
     END LOOP;
     RETURN;

--- a/schemas/migrations/00000009.sql
+++ b/schemas/migrations/00000009.sql
@@ -13,6 +13,9 @@ FOR rec IN
     FROM pg_namespace ns
     JOIN pg_class c 
       ON c.relnamespace = ns.oid
+    LEFT JOIN pg_class folders
+      ON folders.relnamespace = ns.oid
+      AND folders.relname = 'entity_list_folders'
     LEFT JOIN pg_attribute a 
       ON a.attrelid = c.oid 
       AND a.attnum > 0 
@@ -20,7 +23,7 @@ FOR rec IN
     WHERE 
       ns.nspname LIKE 'project_%'
       AND c.relname = 'entity_lists'
-      AND a.attname IS NULL
+      AND (folders.oid IS NULL OR a.attname IS NULL)
     LOOP
         BEGIN
           EXECUTE 'SET LOCAL search_path TO ' || quote_ident(rec.project_schema);
@@ -49,4 +52,3 @@ FOR rec IN
     END LOOP;
     RETURN;
 END $$;
-

--- a/schemas/migrations/00000009.sql
+++ b/schemas/migrations/00000009.sql
@@ -8,16 +8,22 @@
 DO $$
 DECLARE rec RECORD;
 BEGIN
-    FOR rec IN SELECT DISTINCT p.nspname FROM pg_namespace p
-    LEFT JOIN information_schema.columns c
-    ON p.nspname = c.table_schema
-    AND c.table_name = 'entity_list_folders'
-    WHERE p.nspname LIKE 'project_%'
-    AND c.table_name IS NULL
-    
+FOR rec IN 
+    SELECT ns.nspname AS project_schema
+    FROM pg_namespace ns
+    JOIN pg_class c 
+      ON c.relnamespace = ns.oid
+    LEFT JOIN pg_attribute a 
+      ON a.attrelid = c.oid 
+      AND a.attnum > 0 
+      AND a.attname = 'entity_list_folder_id'
+    WHERE 
+      ns.nspname LIKE 'project_%'
+      AND c.relname = 'entity_lists'
+      AND a.attname IS NULL
     LOOP
         BEGIN
-          EXECUTE 'SET LOCAL search_path TO ' || quote_ident(rec.nspname);
+          EXECUTE 'SET LOCAL search_path TO ' || quote_ident(rec.project_schema);
 
           CREATE TABLE entity_list_folders (
               id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/schemas/migrations/00000010.sql
+++ b/schemas/migrations/00000010.sql
@@ -10,10 +10,9 @@ DO $$
 DECLARE rec RECORD;
 BEGIN
 FOR rec IN
-  SELECT 
+  SELECT
     ns.nspname AS project_schema,
     cl.relname AS table_name,
-    att.attname AS column_name,
     con.conname AS constraint_name
   FROM pg_constraint con
   JOIN pg_class cl ON con.conrelid = cl.oid

--- a/schemas/migrations/00000010.sql
+++ b/schemas/migrations/00000010.sql
@@ -10,24 +10,21 @@ DO $$
 DECLARE rec RECORD;
 BEGIN
 FOR rec IN
-  SELECT DISTINCT
-    tc.table_schema project_schema,
-    tc.table_name,
-    kcu.column_name,
-    tc.constraint_name,
-    pc.confupdtype
-  FROM
-    information_schema.table_constraints AS tc
-  JOIN information_schema.key_column_usage AS kcu
-    ON tc.constraint_name = kcu.constraint_name
-    AND kcu.column_name = 'product_type'
-  JOIN pg_constraint AS pc
-    ON tc.constraint_name = pc.conname
-    AND tc.table_schema = pc.connamespace::regnamespace::text
-  WHERE
-    tc.table_schema LIKE 'project_%'
-    AND tc.table_name = 'products'
-    AND tc.constraint_type = 'FOREIGN KEY'
+  SELECT 
+    ns.nspname AS project_schema,
+    cl.relname AS table_name,
+    att.attname AS column_name,
+    con.conname AS constraint_name
+  FROM pg_constraint con
+  JOIN pg_class cl ON con.conrelid = cl.oid
+  JOIN pg_namespace ns ON cl.relnamespace = ns.oid
+  JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = ANY(con.conkey)
+  WHERE 
+    ns.nspname LIKE 'project_%'
+    AND cl.relname = 'products'
+    AND att.attname = 'product_type'
+    AND con.contype = 'f'
+
   LOOP
     RAISE WARNING 'Removing product type reference from %.%', rec.project_schema, rec.table_name;
     EXECUTE format(
@@ -46,16 +43,18 @@ END $$;
 DO $$
 DECLARE rec RECORD;
 BEGIN
-  FOR rec IN SELECT t.table_schema, t.table_name
-    FROM information_schema.tables t
-    LEFT JOIN information_schema.columns c
-    ON t.table_schema = c.table_schema
-    AND t.table_name = c.table_name
-    AND c.column_name = 'product_base_type'
-    WHERE t.table_schema LIKE 'project_%'
-    AND t.table_name = 'products'
-    GROUP BY t.table_schema, t.table_name
-    HAVING COUNT(c.column_name) = 0
+  FOR rec IN 
+    SELECT ns.nspname AS project_schema, cl.relname AS table_name
+    FROM pg_namespace ns
+    JOIN pg_class cl 
+      ON cl.relnamespace = ns.oid
+    LEFT JOIN pg_attribute att 
+      ON att.attrelid = cl.oid 
+      AND att.attname = 'product_base_type'
+    WHERE 
+      ns.nspname LIKE 'project_%'
+      AND cl.relname = 'products'
+      AND att.attname IS NULL
     LOOP
         BEGIN
           RAISE WARNING 'Adding product_base_type to %.%', rec.table_schema, rec.table_name;

--- a/schemas/migrations/00000010.sql
+++ b/schemas/migrations/00000010.sql
@@ -57,12 +57,12 @@ BEGIN
       AND att.attname IS NULL
     LOOP
         BEGIN
-          RAISE WARNING 'Adding product_base_type to %.%', rec.table_schema, rec.table_name;
-          EXECUTE 'SET LOCAL search_path TO ' || quote_ident(rec.table_schema);
+          RAISE WARNING 'Adding product_base_type to %.%', rec.project_schema, rec.table_name;
+          EXECUTE 'SET LOCAL search_path TO ' || quote_ident(rec.project_schema);
           EXECUTE 'ALTER TABLE ' || quote_ident(rec.table_name) || ' ADD COLUMN IF NOT EXISTS product_base_type VARCHAR;';
         EXCEPTION
           WHEN OTHERS THEN
-             RAISE WARNING 'Skipping schema % due to error: %', rec.table_schema, SQLERRM;
+             RAISE WARNING 'Skipping schema % due to error: %', rec.project_schema, SQLERRM;
         END;
     END LOOP;
     RETURN;


### PR DESCRIPTION
This pull request refactors several database migration scripts to use PostgreSQL system catalog tables (`pg_namespace`, `pg_class`, `pg_constraint`, and `pg_attribute`) instead of the `information_schema` views for introspecting and modifying schema objects. This change improves migration performance as information_schema usage is very costly.