### PR TITLE
Fix classmethod request coalescing

### DIFF
--- a/api/projects/projects.py
+++ b/api/projects/projects.py
@@ -27,7 +27,6 @@ from ayon_server.settings.anatomy.statuses import Status
 from ayon_server.settings.anatomy.tags import Tag
 from ayon_server.settings.anatomy.task_types import TaskType
 from ayon_server.types import PROJECT_CODE_REGEX, PROJECT_NAME_REGEX, Field, OPModel
-from ayon_server.utils.request_coalescer import RequestCoalescer
 
 from .router import router
 
@@ -89,9 +88,7 @@ async def get_project(
     """Retrieve a project by its name."""
 
     await user.ensure_project_access(project_name)
-    coalesce = RequestCoalescer()
-    project = await coalesce(ProjectEntity.load, project_name)
-
+    project = await ProjectEntity.load(project_name)
     enrich_project_config_with_product_base_types(project.config)
     return cast(ProjectModel, project.as_user(user))
 

--- a/ayon_server/entities/project.py
+++ b/ayon_server/entities/project.py
@@ -26,8 +26,7 @@ from ayon_server.helpers.inherited_attributes import rebuild_inherited_attribute
 from ayon_server.helpers.project_list import build_project_list
 from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
-from ayon_server.utils import SQLTool, dict_exclude, get_nickname
-from ayon_server.utils.request_coalescer import RequestCoalescer
+from ayon_server.utils import RequestCoalescer, SQLTool, dict_exclude, get_nickname
 
 if TYPE_CHECKING:
     from .project_skeleton import ProjectSkeletonEntity

--- a/ayon_server/entities/project.py
+++ b/ayon_server/entities/project.py
@@ -27,6 +27,7 @@ from ayon_server.helpers.project_list import build_project_list
 from ayon_server.lib.postgres import Postgres
 from ayon_server.lib.redis import Redis
 from ayon_server.utils import SQLTool, dict_exclude, get_nickname
+from ayon_server.utils.request_coalescer import RequestCoalescer
 
 if TYPE_CHECKING:
     from .project_skeleton import ProjectSkeletonEntity
@@ -67,7 +68,20 @@ class ProjectEntity(TopLevelEntity):
     async def load(
         cls,
         name: str,
-        transaction=None,  # deprecated
+        transaction: Any = None,  # deprecated
+        for_update: bool = False,
+    ) -> "ProjectEntity":
+        """Load a project from the database."""
+
+        if not for_update:
+            coalesce = RequestCoalescer()
+            return await coalesce(cls._load, name)
+        return await cls._load(name, for_update=for_update)
+
+    @classmethod
+    async def _load(
+        cls,
+        name: str,
         for_update: bool = False,
     ) -> "ProjectEntity":
         """Load a project from the database."""

--- a/ayon_server/utils/request_coalescer.py
+++ b/ayon_server/utils/request_coalescer.py
@@ -60,11 +60,13 @@ class RequestCoalescer(Generic[T]):
         async with self.lock:
             # Look for an existing task batch that has space for another waiter
             selected_key = None
+            selected_future: asyncio.Task[T] | None = None
             for key in self.current_futures:
                 if (
                     key == base_key or key.startswith(f"{base_key}:")
                 ) and self.current_waiters.get(key, 0) < self.max_waiters:
                     selected_key = key
+                    selected_future = self.current_futures[key]
                     break
 
             if selected_key is not None:
@@ -78,10 +80,12 @@ class RequestCoalescer(Generic[T]):
                 self.current_futures[selected_key] = asyncio.create_task(
                     func(*args, **kwargs)
                 )
+                selected_future = self.current_futures[selected_key]
                 self.current_waiters[selected_key] = 1
 
         try:
-            return await self.current_futures[selected_key]
+            assert selected_future is not None
+            return await selected_future
         finally:
             async with self.lock:
                 if selected_key in self.current_waiters:

--- a/ayon_server/utils/request_coalescer.py
+++ b/ayon_server/utils/request_coalescer.py
@@ -56,7 +56,7 @@ class RequestCoalescer(Generic[T]):
         *args: Any,
         **kwargs: Any,
     ) -> T:
-        base_key = _hash_args(func, args, kwargs)
+        base_key = _hash_args(func, *args, **kwargs)
         async with self.lock:
             # Look for an existing task batch that has space for another waiter
             selected_key = None

--- a/ayon_server/utils/request_coalescer.py
+++ b/ayon_server/utils/request_coalescer.py
@@ -11,7 +11,21 @@ def _hash_args(func: Callable[..., Any], *args: Any, **kwargs: Any) -> str:
 
     This is probably a terrible idea.
     """
-    func_id = str(id(func))
+    if hasattr(func, "__func__") and hasattr(func, "__self__"):
+        # Bound method (either instance or class method).
+        # stable identifier since Python recreates bound method objects on access.
+        self_class = (
+            func.__self__
+            if isinstance(func.__self__, type)
+            else func.__self__.__class__
+        )
+        func_name = f"{self_class.__module__}.{self_class.__qualname__}.{func.__func__.__name__}"  # noqa: E501
+        func_id = f"{func_name} (bound to {id(func.__self__)})"
+    elif hasattr(func, "__qualname__"):
+        func_id = f"{getattr(func, '__module__', '')}.{func.__qualname__}"
+    else:
+        func_id = f"{str(func)} (id: {id(func)})"
+
     arg_str = str(args)
     kwarg_str = str(sorted(kwargs.items()))
     combined_str = arg_str + kwarg_str + func_id
@@ -37,33 +51,34 @@ class RequestCoalescer(Generic[T]):
         return cls._instance
 
     async def __call__(
-        self, func: Callable[..., Coroutine[Any, Any, T]], *args: Any, **kwargs: Any
+        self,
+        func: Callable[..., Coroutine[Any, Any, T]],
+        *args: Any,
+        **kwargs: Any,
     ) -> T:
         base_key = _hash_args(func, args, kwargs)
         async with self.lock:
-            waiters = self.current_waiters.get(base_key, 0)
+            # Look for an existing task batch that has space for another waiter
+            selected_key = None
+            for key in self.current_futures:
+                if (
+                    key == base_key or key.startswith(f"{base_key}:")
+                ) and self.current_waiters.get(key, 0) < self.max_waiters:
+                    selected_key = key
+                    break
 
-            if base_key not in self.current_futures:
-                # First request: store under base_key
-                self.current_futures[base_key] = asyncio.create_task(
-                    func(*args, **kwargs)
-                )
-                self.current_waiters[base_key] = 1
-                selected_key = base_key
-
-            elif waiters >= self.max_waiters:
-                # Too many waiters: create a unique task
-                unique_key = f"{base_key}:{uuid4().hex}"
-                self.current_futures[unique_key] = asyncio.create_task(
-                    func(*args, **kwargs)
-                )
-                self.current_waiters[unique_key] = 1
-                selected_key = unique_key
-
+            if selected_key is not None:
+                self.current_waiters[selected_key] += 1
             else:
-                # Join existing task under base_key
-                self.current_waiters[base_key] += 1
-                selected_key = base_key
+                if base_key not in self.current_futures:
+                    selected_key = base_key
+                else:
+                    selected_key = f"{base_key}:{uuid4().hex}"
+
+                self.current_futures[selected_key] = asyncio.create_task(
+                    func(*args, **kwargs)
+                )
+                self.current_waiters[selected_key] = 1
 
         try:
             return await self.current_futures[selected_key]

--- a/tests/test_ayon_server_utils.py
+++ b/tests/test_ayon_server_utils.py
@@ -100,3 +100,114 @@ class TestRequestCoalescer:
                 self._reset_coalescer()
 
         asyncio.run(_run_test())
+
+    def test_coalesces_class_methods_and_bound_methods(self):
+        async def _run_test():
+            coalescer = self._reset_coalescer()
+            try:
+                calls = 0
+                started_event = asyncio.Event()
+                release_event = asyncio.Event()
+
+                class DummyClass:
+                    @classmethod
+                    async def class_method(cls, val):
+                        nonlocal calls
+                        calls += 1
+                        if calls == 1:
+                            started_event.set()
+                        await release_event.wait()
+                        return val
+
+                    async def instance_method(self, val):
+                        nonlocal calls
+                        calls += 1
+                        if calls == 1:
+                            started_event.set()
+                        await release_event.wait()
+                        return val
+
+                # Test classmethod coalescing
+                t1 = asyncio.create_task(
+                    coalescer(DummyClass.class_method, "class_val")
+                )
+                t2 = asyncio.create_task(
+                    coalescer(DummyClass.class_method, "class_val")
+                )
+
+                await asyncio.wait_for(started_event.wait(), timeout=1)
+                assert len(coalescer.current_futures) == 1
+                assert len(coalescer.current_waiters) == 1
+
+                release_event.set()
+                res1, res2 = await asyncio.gather(t1, t2)
+                assert res1 == "class_val"
+                assert res2 == "class_val"
+                assert calls == 1
+
+                # Reset events and coalescer
+                calls = 0
+                started_event.clear()
+                release_event.clear()
+                self._reset_coalescer()
+
+                # Test instancemethod coalescing
+                dummy_inst = DummyClass()
+                t1 = asyncio.create_task(
+                    coalescer(dummy_inst.instance_method, "instance_val")
+                )
+                t2 = asyncio.create_task(
+                    coalescer(dummy_inst.instance_method, "instance_val")
+                )
+
+                await asyncio.wait_for(started_event.wait(), timeout=1)
+                assert len(coalescer.current_futures) == 1
+                assert len(coalescer.current_waiters) == 1
+
+                release_event.set()
+                res1, res2 = await asyncio.gather(t1, t2)
+                assert res1 == "instance_val"
+                assert res2 == "instance_val"
+                assert calls == 1
+            finally:
+                self._reset_coalescer()
+
+        asyncio.run(_run_test())
+
+    def test_overflow_waiters_are_batched(self):
+        async def _run_test():
+            coalescer = self._reset_coalescer()
+            try:
+                coalescer.max_waiters = 2
+                started = 0
+                started_event = asyncio.Event()
+                release_event = asyncio.Event()
+
+                async def work(val) -> int:
+                    nonlocal started
+                    started += 1
+                    if started == 3:
+                        started_event.set()
+                    await release_event.wait()
+                    return val
+
+                # We will trigger 5 tasks.
+                # max_waiters is 2, so they should batch as:
+                # - Batch 1 (base_key): 2 waiters
+                # - Batch 2 (base_key:uuid1): 2 waiters
+                # - Batch 3 (base_key:uuid2): 1 waiter
+                # Total distinct tasks should be exactly 3.
+                tasks = [asyncio.create_task(coalescer(work, "val")) for _ in range(5)]
+
+                await asyncio.wait_for(started_event.wait(), timeout=1)
+                assert len(coalescer.current_futures) == 3
+                assert len(coalescer.current_waiters) == 3
+                assert started == 3
+
+                release_event.set()
+                results = await asyncio.gather(*tasks)
+                assert all(res == "val" for res in results)
+            finally:
+                self._reset_coalescer()
+
+        asyncio.run(_run_test())


### PR DESCRIPTION
This pull request improves the `RequestCoalescer` utility to better handle coalescing of asynchronous requests, especially for class methods and instance methods, and refactors project entity loading to leverage these improvements. It also adds comprehensive tests to ensure correct batching and coalescing behavior.

### Request coalescing improvements

* Enhanced the `_hash_args` function in `request_coalescer.py` to generate stable, unique identifiers for bound methods (class and instance methods), ensuring that coalescing works correctly for these cases.
* Refactored the batching logic in `RequestCoalescer.__call__` to allow multiple batches when the number of waiters exceeds `max_waiters`, ensuring that excess requests are grouped into new batches with unique keys.
* Updated `ProjectEntity.load` in `project.py` to use the improved `RequestCoalescer` for coalescing database loads, and split the actual load logic into a new `_load` method for clarity and flexibility.
* Removed direct usage of `RequestCoalescer` in `api/projects/projects.py` in favor of the new coalescing logic built into `ProjectEntity.load`.

### Testing

* Added tests to `test_ayon_server_utils.py` that verify coalescing works for class methods, instance methods, and that overflow waiters are properly batched into separate tasks when exceeding `max_waiters`.