### PR TITLE
Bugfix: enhance task filtering to include inherited attributes

### DIFF
--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -579,22 +579,24 @@ async def get_folders(
 
         fdate = json.loads(task_filter)
         fq = QueryFilter(**fdate)
-        # Build a single filter that coalesces the attribute value across
-        # the task itself, its inherited (exported) attributes and the
-        # project attributes. A folder matches if any of its tasks has the
-        # requested attribute value in any of those sources.
-        task_filter_cond = build_filter(
+        tfilter = build_filter(
             fq,
             column_whitelist=column_whitelist,
             table_prefix="tasks",
-            column_map={
-                "attrib": (
-                    "COALESCE(tasks.attrib{key}, ex.attrib{key}, pr.attrib{key})"
-                ),
-            },
         )
 
-        if task_filter_cond:
+        if tfilter:
+            exfilter = build_filter(
+                fq,
+                column_whitelist=column_whitelist,
+                table_prefix="exported_attributes",
+            )
+            prfilter = build_filter(
+                fq,
+                column_whitelist=column_whitelist,
+                table_prefix="pr",
+            )
+
             sql_cte.append(
                 f"""
                 filtered_tasks AS (
@@ -602,9 +604,9 @@ async def get_folders(
                     FROM project_{project_name}.tasks
                     INNER JOIN public.projects AS pr
                         ON pr.name ILIKE '{project_name}'
-                    LEFT JOIN project_{project_name}.exported_attributes AS ex
-                        ON tasks.folder_id = ex.folder_id
-                    WHERE {task_filter_cond}
+                    LEFT JOIN project_{project_name}.exported_attributes
+                        ON tasks.folder_id = exported_attributes.folder_id
+                    WHERE {tfilter} or {exfilter} or {prfilter}
                 )
                 """
             )

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -743,9 +743,6 @@ async def get_folders(
     if stats_select_clause:
         field_stats = await generate_field_stats(query)
 
-        with open("/storage/server/projects/folders.txt", "w") as fp:
-            fp.write(query)
-
         return FoldersConnection(edges=[], field_stats=field_stats)
 
     return await resolve(

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -579,24 +579,22 @@ async def get_folders(
 
         fdate = json.loads(task_filter)
         fq = QueryFilter(**fdate)
-        tfilter = build_filter(
+        # Build a single filter that coalesces the attribute value across
+        # the task itself, its inherited (exported) attributes and the
+        # project attributes. A folder matches if any of its tasks has the
+        # requested attribute value in any of those sources.
+        task_filter_cond = build_filter(
             fq,
             column_whitelist=column_whitelist,
             table_prefix="tasks",
+            column_map={
+                "attrib": (
+                    "COALESCE(tasks.attrib{key}, ex.attrib{key}, pr.attrib{key})"
+                ),
+            },
         )
 
-        if tfilter:
-            exfilter = build_filter(
-                fq,
-                column_whitelist=column_whitelist,
-                table_prefix="exported_attributes",
-            )
-            prfilter = build_filter(
-                fq,
-                column_whitelist=column_whitelist,
-                table_prefix="pr",
-            )
-
+        if task_filter_cond:
             sql_cte.append(
                 f"""
                 filtered_tasks AS (
@@ -604,9 +602,9 @@ async def get_folders(
                     FROM project_{project_name}.tasks
                     INNER JOIN public.projects AS pr
                         ON pr.name ILIKE '{project_name}'
-                    LEFT JOIN project_{project_name}.exported_attributes
-                        ON tasks.folder_id = exported_attributes.folder_id
-                    WHERE {tfilter} or {exfilter} or {prfilter}
+                    LEFT JOIN project_{project_name}.exported_attributes AS ex
+                        ON tasks.folder_id = ex.folder_id
+                    WHERE {task_filter_cond}
                 )
                 """
             )

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -586,27 +586,12 @@ async def get_folders(
         )
 
         if tfilter:
-            exfilter = build_filter(
-                fq,
-                column_whitelist=column_whitelist,
-                table_prefix="exported_attributes",
-            )
-            prfilter = build_filter(
-                fq,
-                column_whitelist=column_whitelist,
-                table_prefix="pr",
-            )
-
             sql_cte.append(
                 f"""
                 filtered_tasks AS (
-                    SELECT DISTINCT tasks.folder_id
+                    SELECT DISTINCT folder_id
                     FROM project_{project_name}.tasks
-                    INNER JOIN public.projects AS pr
-                        ON pr.name ILIKE '{project_name}'
-                    LEFT JOIN project_{project_name}.exported_attributes
-                        ON tasks.folder_id = exported_attributes.folder_id
-                    WHERE {tfilter} or {exfilter} or {prfilter}
+                    WHERE {tfilter}
                 )
                 """
             )

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -586,12 +586,27 @@ async def get_folders(
         )
 
         if tfilter:
+            exfilter = build_filter(
+                fq,
+                column_whitelist=column_whitelist,
+                table_prefix="exported_attributes",
+            )
+            prfilter = build_filter(
+                fq,
+                column_whitelist=column_whitelist,
+                table_prefix="pr",
+            )
+
             sql_cte.append(
                 f"""
                 filtered_tasks AS (
-                    SELECT DISTINCT folder_id
+                    SELECT DISTINCT tasks.folder_id
                     FROM project_{project_name}.tasks
-                    WHERE {tfilter}
+                    INNER JOIN public.projects AS pr
+                        ON pr.name ILIKE '{project_name}'
+                    LEFT JOIN project_{project_name}.exported_attributes
+                        ON tasks.folder_id = exported_attributes.folder_id
+                    WHERE {tfilter} or {exfilter} or {prfilter}
                 )
                 """
             )

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -583,14 +583,21 @@ async def get_folders(
             fq,
             column_whitelist=column_whitelist,
             table_prefix="tasks",
+            column_map={
+                "attrib": "(coalesce(ex.attrib, '{}'::jsonb ) || tasks.attrib)"
+            },
         )
 
         if tfilter:
             sql_cte.append(
                 f"""
                 filtered_tasks AS (
-                    SELECT DISTINCT folder_id
+                    SELECT DISTINCT tasks.folder_id
                     FROM project_{project_name}.tasks
+                    INNER JOIN public.projects AS pr
+                        ON pr.name ILIKE '{project_name}'
+                    LEFT JOIN project_{project_name}.exported_attributes AS ex
+                        ON tasks.folder_id = ex.folder_id
                     WHERE {tfilter}
                 )
                 """
@@ -735,6 +742,9 @@ async def get_folders(
 
     if stats_select_clause:
         field_stats = await generate_field_stats(query)
+
+        with open("/storage/server/projects/folders.txt", "w") as fp:
+            fp.write(query)
 
         return FoldersConnection(edges=[], field_stats=field_stats)
 

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -186,6 +186,7 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
     cast_type = "text"
     safe_value: ValueType = None
     json_list_column: str | None = None
+    is_template = False
 
     column = path[0]
     if column in column_map:
@@ -212,8 +213,21 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
         if single_json_column:
             column = single_json_column
 
-        for k in path[1:]:
-            column += f"->'{k}'"
+        # If the column was mapped to a template containing a {key}
+        # placeholder, substitute it with the json path (e.g. ->'priority').
+        # This allows building expressions such as
+        # COALESCE(tasks.attrib->>'priority', ex.attrib->>'priority')
+        is_template = isinstance(column, str) and "{key}" in column
+        json_path = ""
+        for i, k in enumerate(path[1:]):
+            if i == len(path) - 2 and operator == "like":
+                json_path += f"->>'{k}'"
+            else:
+                json_path += f"->'{k}'"
+        if is_template:
+            column = column.format(key=json_path)
+        else:
+            column += json_path
 
         if operator in (
             "includesall",
@@ -388,7 +402,9 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
         return f"{column} = {safe_value}"
     elif operator == "like":
         # replace last -> with ->> to get text value
-        column = re.sub(r"->(?!.*->)", "->>", column)
+        # (already handled for template columns)
+        if not is_template:
+            column = re.sub(r"->(?!.*->)", "->>", column)
         return f"({column}) ILIKE {safe_value}"
     elif operator == "lt":
         return f"{column} < {safe_value}"

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -186,7 +186,6 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
     cast_type = "text"
     safe_value: ValueType = None
     json_list_column: str | None = None
-    is_template = False
 
     column = path[0]
     if column in column_map:
@@ -213,21 +212,8 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
         if single_json_column:
             column = single_json_column
 
-        # If the column was mapped to a template containing a {key}
-        # placeholder, substitute it with the json path (e.g. ->'priority').
-        # This allows building expressions such as
-        # COALESCE(tasks.attrib->>'priority', ex.attrib->>'priority')
-        is_template = isinstance(column, str) and "{key}" in column
-        json_path = ""
-        for i, k in enumerate(path[1:]):
-            if i == len(path) - 2 and operator == "like":
-                json_path += f"->>'{k}'"
-            else:
-                json_path += f"->'{k}'"
-        if is_template:
-            column = column.format(key=json_path)
-        else:
-            column += json_path
+        for k in path[1:]:
+            column += f"->'{k}'"
 
         if operator in (
             "includesall",
@@ -402,9 +388,7 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
         return f"{column} = {safe_value}"
     elif operator == "like":
         # replace last -> with ->> to get text value
-        # (already handled for template columns)
-        if not is_template:
-            column = re.sub(r"->(?!.*->)", "->>", column)
+        column = re.sub(r"->(?!.*->)", "->>", column)
         return f"({column}) ILIKE {safe_value}"
     elif operator == "lt":
         return f"{column} < {safe_value}"


### PR DESCRIPTION
## Description of changes

This handles weird issue in `Folder` counts in Summary row if task filtering is used (on `priority` = 'high') for example.

Original query builder looked for folders which had tasks with `priority` = 'high', but if 'high' was inherited from `folder`, that `folder` wasn't included and it wasn't calculated in `Summary` row.


### Technical details
Original:

<img width="808" height="441" alt="Screenshot 2026-07-10 131048" src="https://github.com/user-attachments/assets/7a0add37-17b9-4e4b-833b-cddda11078dc" />

(See `Folders: 0` in left bottom)

This PR:

<img width="805" height="420" alt="image" src="https://github.com/user-attachments/assets/7862730a-13e6-4ad5-a0cc-8843f0f69961" />


### Additional context

This needs to be tested thoroughly as it is touching query builder!
