### PR TITLE
Hide support users

### DIFF
--- a/ayon_server/enum/resolvers/enum_users.py
+++ b/ayon_server/enum/resolvers/enum_users.py
@@ -63,6 +63,14 @@ class UsersEnumResolver(BaseEnumResolver):
             is_admin = udata.get("isAdmin", False)
             is_manager = udata.get("isManager", False)
 
+            if (
+                current_user
+                and (not current_user.data.get("isSupport", False))
+                and udata.get("isSupport", False)
+            ):
+                # we don't show support users to non-support users
+                return False
+
             if is_admin or is_manager:
                 # we always show admins and managers
                 return True

--- a/ayon_server/graphql/resolvers/users.py
+++ b/ayon_server/graphql/resolvers/users.py
@@ -57,7 +57,7 @@ async def get_users(
         list[str] | None, argdesc("List only users assigned to projects")
     ] = None,
     is_support: Annotated[
-        bool | None, argdesc("Filter users by isSupport flag in data")
+        bool | None, argdesc("Deprecated: Filter users by isSupport flag in data")
     ] = None,
     first: ARGFirst = None,
     after: ARGAfter = None,
@@ -97,17 +97,10 @@ async def get_users(
             f"LOWER(users.attrib->>'email') IN {SQLTool.array(emails)}"
         )
 
-    # Filter by isSupport
-    if is_support is not None:
-        if is_support:
-            # Only users with isSupport explicitly set to true
-            sql_conditions.append("users.data->>'isSupport' = 'true'")
-        else:
-            # Users where isSupport is false OR not set (NULL)
-            sql_conditions.append(
-                "(users.data->>'isSupport' = 'false' OR "
-                "users.data->>'isSupport' IS NULL)"
-            )
+    # Support users
+
+    if not user.data.get("isSupport", False):
+        sql_conditions.append("users.data->>'isSupport' IS DISTINCT FROM 'true'")
 
     # Filter by project
 


### PR DESCRIPTION
This pull request updates the user visibility logic to improve support user privacy and deprecates the `is_support` filter in the users GraphQL resolver. The main focus is to ensure that support users are only visible to other support users, and to simplify the filtering logic accordingly.