### PR TITLE
Server addon auto update

### DIFF
--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -185,9 +185,9 @@ async def addon_update(library: AddonLibrary) -> None:
                 await Postgres.execute(
                     """
                     UPDATE public.bundles
-                    SET data = jsonb_set(data, '{addons}', $1)
+                    SET data = jsonb_set(data, '{addons}', $1::jsonb)
                     WHERE is_production = TRUE
-                    """,
+                    """
                     production_addons,
                 )
             else:

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -194,8 +194,8 @@ async def addon_update(library: AddonLibrary) -> None:
                 await Postgres.execute(
                     """
                     INSERT INTO public.bundles (name, is_production, data)
-                    VALUES ('InitialBundle', TRUE, $1)
-                    """,
+                    VALUES (concat('InitialBundle_', extract(epoch from now())::int), TRUE, $1)
+                    """
                     {
                         "addons": production_addons,
                         "installer_version": None,

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -139,9 +139,10 @@ async def addon_update(library: AddonLibrary) -> None:
             if production_addons.get(addon_name) == addon_version:
                 continue
 
+            from ayon_server.exceptions import NotFoundException
             try:
                 addon = library.addon(addon_name, addon_version)
-            except KeyError:
+            except NotFoundException:
                 logger.debug(
                     f"Required addon {addon_name} {addon_version} is not installed"
                 )

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -140,6 +140,7 @@ async def addon_update(library: AddonLibrary) -> None:
                 continue
 
             from ayon_server.exceptions import NotFoundException
+
             try:
                 addon = library.addon(addon_name, addon_version)
             except NotFoundException:
@@ -187,15 +188,19 @@ async def addon_update(library: AddonLibrary) -> None:
                     UPDATE public.bundles
                     SET data = jsonb_set(data, '{addons}', $1::jsonb)
                     WHERE is_production = TRUE
-                    """
+                    """,
                     production_addons,
                 )
             else:
                 await Postgres.execute(
                     """
                     INSERT INTO public.bundles (name, is_production, data)
-                    VALUES (concat('InitialBundle_', extract(epoch from now())::int), TRUE, $1)
-                    """
+                    VALUES (
+                        concat('InitialBundle_', extract(epoch from now())::int),
+                        TRUE,
+                        $1
+                    )
+                    """,
                     {
                         "addons": production_addons,
                         "installer_version": None,

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -128,7 +128,7 @@ async def addon_update(library: AddonLibrary) -> None:
         )
         bundle_update_needed = False
         if res:
-            production_addons = res["addons"]
+            production_addons = dict(res["addons"] or {})
             has_previous_bundle = True
         else:
             production_addons = {}

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 import os
 import traceback
@@ -159,7 +158,7 @@ async def addon_update(library: AddonLibrary) -> None:
 
                 logger.debug(
                     f"Migrating {addon_name} settings "
-                    f" from {production_addons[addon_name]} to {addon_version}"
+                    f"from {production_addons[addon_name]} to {addon_version}"
                 )
 
                 try:
@@ -183,6 +182,7 @@ async def addon_update(library: AddonLibrary) -> None:
 
         if bundle_update_needed:
             if has_previous_bundle:
+                logger.debug("Updating production bundle with required addons")
                 await Postgres.execute(
                     """
                     UPDATE public.bundles
@@ -192,6 +192,7 @@ async def addon_update(library: AddonLibrary) -> None:
                     production_addons,
                 )
             else:
+                logger.debug("Creating production bundle with required addons")
                 await Postgres.execute(
                     """
                     INSERT INTO public.bundles (name, is_production, data)
@@ -330,6 +331,7 @@ async def lifespan(app: "FastAPI"):
         init_frontend(app)
 
         await AddonLibrary.clear_addon_list_cache()
+        await clear_server_restart_required()
 
         if start_event is not None:
             await EventStream.update(
@@ -338,9 +340,8 @@ async def lifespan(app: "FastAPI"):
                 description="Server started",
             )
 
-        asyncio.create_task(clear_server_restart_required())
-        logger.info("Server is now ready to connect")
         logger.trace(f"{len(app.routes)} routes registered")
+        logger.info("Server is now ready to connect")
 
     yield
 

--- a/ayon_server/api/lifespan.py
+++ b/ayon_server/api/lifespan.py
@@ -16,6 +16,7 @@ from ayon_server.background.workers import background_workers
 from ayon_server.config import ayonconfig
 from ayon_server.events import EventStream
 from ayon_server.helpers.cloud import CloudUtils
+from ayon_server.helpers.migrate_addon_settings import migrate_addon_settings
 from ayon_server.initialize import ayon_init
 from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import log_traceback, logger
@@ -115,6 +116,94 @@ def init_addon_static(target_app: "FastAPI") -> None:
     target_app.include_router(addon_static_router)
 
 
+async def addon_update(library: AddonLibrary) -> None:
+    if not (required_addons := await CloudUtils.get_required_addons()):
+        return
+
+    async with Postgres.transaction():
+        res = await Postgres.fetchrow(
+            """
+            SELECT data->'addons' AS addons
+            FROM public.bundles WHERE is_production = TRUE
+            """
+        )
+        bundle_update_needed = False
+        if res:
+            production_addons = res["addons"]
+            has_previous_bundle = True
+        else:
+            production_addons = {}
+            has_previous_bundle = False
+
+        for addon_name, addon_version in required_addons:
+            if production_addons.get(addon_name) == addon_version:
+                continue
+
+            try:
+                addon = library.addon(addon_name, addon_version)
+            except KeyError:
+                logger.debug(
+                    f"Required addon {addon_name} {addon_version} is not installed"
+                )
+                continue
+
+            logger.debug(
+                f"Adding required addon {addon_name} {addon_version} "
+                "to production bundle"
+            )
+
+            if production_addons.get(addon_name):
+                # previous version of the addon is in production, migrate settings
+
+                logger.debug(
+                    f"Migrating {addon_name} settings "
+                    f" from {production_addons[addon_name]} to {addon_version}"
+                )
+
+                try:
+                    production_addon = library.addon(
+                        addon_name, production_addons[addon_name]
+                    )
+                    await migrate_addon_settings(
+                        source_addon=production_addon,
+                        target_addon=addon,
+                        source_variant="production",
+                        target_variant="production",
+                    )
+                except Exception as e:
+                    log_traceback(f"Error migrating {addon_name} settings")
+                    logger.error(f"Unable to migrate {addon_name} settings: {e}")
+                    continue
+
+            # add the required addon to production bundle
+            bundle_update_needed = True
+            production_addons[addon_name] = addon_version
+
+        if bundle_update_needed:
+            if has_previous_bundle:
+                await Postgres.execute(
+                    """
+                    UPDATE public.bundles
+                    SET data = jsonb_set(data, '{addons}', $1)
+                    WHERE is_production = TRUE
+                    """,
+                    production_addons,
+                )
+            else:
+                await Postgres.execute(
+                    """
+                    INSERT INTO public.bundles (name, is_production, data)
+                    VALUES ('InitialBundle', TRUE, $1)
+                    """,
+                    {
+                        "addons": production_addons,
+                        "installer_version": None,
+                        "dependency_packages": {},
+                    },
+                )
+            logger.debug("Production bundle updated with required addons")
+
+
 @asynccontextmanager
 async def lifespan(app: "FastAPI"):
     _ = app
@@ -145,6 +234,8 @@ async def lifespan(app: "FastAPI"):
             description="Server restart requested during addon initialization",
         )
         return
+
+    await addon_update(library)
 
     restart_requested = False
     bad_addons = {}

--- a/ayon_server/helpers/cloud.py
+++ b/ayon_server/helpers/cloud.py
@@ -286,7 +286,7 @@ class CloudUtils:
 
     @classmethod
     @Redis.cached("global", "required_addons", ttl=600)
-    async def get_required_addons(cls) -> list[dict[str, str]]:
+    async def get_required_addons(cls) -> list[tuple[str, str]]:
         if ayonconfig.offline_mode:
             return []
         try:

--- a/ayon_server/helpers/cloud.py
+++ b/ayon_server/helpers/cloud.py
@@ -289,16 +289,20 @@ class CloudUtils:
     async def get_required_addons(cls) -> list[dict[str, str]]:
         if ayonconfig.offline_mode:
             return []
+        try:
+            headers = await CloudUtils.get_api_headers()
+        except Exception:
+            return []
+
         url = f"{ayonconfig.ynput_cloud_api_url}/api/v1/me"
-        headers = await CloudUtils.get_api_headers()
         headers["X-Ayon-Version"] = __version__
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.get(url, headers=headers)
+                response = await client.get(url, headers=headers, timeout=3)
                 data = response.json()
                 return data.get("requiredAddons", [])
-        except Exception:
-            logger.debug("Failed to fetch required addons list")
+        except Exception as e:
+            logger.debug(f"Failed to fetch required addons list: {e}")
             return []
 
 

--- a/ayon_server/helpers/cloud.py
+++ b/ayon_server/helpers/cloud.py
@@ -285,7 +285,7 @@ class CloudUtils:
         return YnputCloudInfoModel(**data)
 
     @classmethod
-    @Redis.cached("global", "required_addons", ttl=600)
+    @Redis.cached("global", "required-addons", ttl=3600 * 48)
     async def get_required_addons(cls) -> list[tuple[str, str]]:
         if ayonconfig.offline_mode:
             return []

--- a/ayon_server/helpers/cloud.py
+++ b/ayon_server/helpers/cloud.py
@@ -284,6 +284,23 @@ class CloudUtils:
         await Redis.set_json("global", "cloudinfo", data)
         return YnputCloudInfoModel(**data)
 
+    @classmethod
+    @Redis.cached("global", "required_addons", ttl=600)
+    async def get_required_addons(cls) -> list[dict[str, str]]:
+        if ayonconfig.offline_mode:
+            return []
+        url = f"{ayonconfig.ynput_cloud_api_url}/api/v1/me"
+        headers = await CloudUtils.get_api_headers()
+        headers["X-Ayon-Version"] = __version__
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(url, headers=headers)
+                data = response.json()
+                return data.get("requiredAddons", [])
+        except Exception:
+            logger.debug("Failed to fetch required addons list")
+            return []
+
 
 #
 # Deprecated functions. Kept for compatibility with old code.

--- a/ayon_server/helpers/cloud.py
+++ b/ayon_server/helpers/cloud.py
@@ -290,7 +290,7 @@ class CloudUtils:
         if ayonconfig.offline_mode:
             return []
         try:
-            headers = await CloudUtils.get_api_headers()
+            headers = await cls.get_api_headers()
         except Exception:
             return []
 
@@ -299,6 +299,7 @@ class CloudUtils:
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.get(url, headers=headers, timeout=3)
+                response.raise_for_status()
                 data = response.json()
                 return data.get("requiredAddons", [])
         except Exception as e:

--- a/ayon_server/helpers/download_addon.py
+++ b/ayon_server/helpers/download_addon.py
@@ -59,7 +59,7 @@ async def download_addon(
         url_label += "..."
     logger.debug(f"Downloading addon from {url_label}")
     if no_queue:
-        await background_installer.process_event(event_id)
+        await background_installer.process_event(event_id, no_queue=True)
     else:
         await background_installer.enqueue(event_id)
     return event_id

--- a/ayon_server/installer/__init__.py
+++ b/ayon_server/installer/__init__.py
@@ -40,7 +40,7 @@ class BackgroundInstaller(BackgroundWorker):
         logger.debug("Background installer: enqueuing event", event_id=event_id)
         await self.event_queue.put(event_id)
 
-    async def process_event(self, event_id: str) -> None:
+    async def process_event(self, event_id: str, *, no_queue: bool = False) -> None:
         res = await Postgres().fetch(
             " SELECT topic, status, summary, retries FROM events WHERE id = $1 ",
             event_id,
@@ -83,7 +83,12 @@ class BackgroundInstaller(BackgroundWorker):
             event_id=event_id,
         )
 
-        asyncio.create_task(handle_need_restart(self))
+        if no_queue:
+            await require_server_restart(
+                None, "Restart the server to apply the addon changes."
+            )
+        else:
+            asyncio.create_task(handle_need_restart(self))
 
     async def run(self) -> None:
         # load past unprocessed events

--- a/ayon_server/installer/addons.py
+++ b/ayon_server/installer/addons.py
@@ -14,7 +14,6 @@ import semver
 import yaml
 from pydantic import BaseModel
 
-from ayon_server.api.system import require_server_restart
 from ayon_server.config import ayonconfig
 from ayon_server.events import EventStream
 from ayon_server.exceptions import AyonException
@@ -299,9 +298,6 @@ async def install_addon_from_url(event_id: str, url: str) -> AddonZipInfo:
         status="finished",
         sender="background-installer",
         sender_type="system",
-    )
-    await require_server_restart(
-        None, "New addon installed. Restart the server to apply the changes."
     )
 
     return zip_info

--- a/ayon_server/installer/addons.py
+++ b/ayon_server/installer/addons.py
@@ -14,6 +14,7 @@ import semver
 import yaml
 from pydantic import BaseModel
 
+from ayon_server.api.system import require_server_restart
 from ayon_server.config import ayonconfig
 from ayon_server.events import EventStream
 from ayon_server.exceptions import AyonException
@@ -298,6 +299,9 @@ async def install_addon_from_url(event_id: str, url: str) -> AddonZipInfo:
         status="finished",
         sender="background-installer",
         sender_type="system",
+    )
+    await require_server_restart(
+        None, "New addon installed. Restart the server to apply the changes."
     )
 
     return zip_info

--- a/maintenance/tasks/auto_update.py
+++ b/maintenance/tasks/auto_update.py
@@ -1,34 +1,13 @@
-import time
-
 import httpx
 
-from ayon_server.addons.library import AddonLibrary
 from ayon_server.config import ayonconfig
-from ayon_server.exceptions import AyonException, NotFoundException
+from ayon_server.exceptions import AyonException
 from ayon_server.helpers.cloud import CloudUtils
 from ayon_server.helpers.download_addon import download_addon
 from ayon_server.helpers.get_downloaded_addons import get_downloaded_addons
-from ayon_server.helpers.migrate_addon_settings import migrate_addon_settings
-from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import logger
 from ayon_server.version import __version__ as ayon_version
 from maintenance.maintenance_task import StudioMaintenanceTask
-
-
-async def get_required_addons() -> list[dict[str, str]]:
-    if ayonconfig.offline_mode:
-        return []
-    url = f"{ayonconfig.ynput_cloud_api_url}/api/v1/me"
-    headers = await CloudUtils.get_api_headers()
-    headers["X-Ayon-Version"] = ayon_version
-    try:
-        async with httpx.AsyncClient() as client:
-            response = await client.get(url, headers=headers)
-            data = response.json()
-            return data.get("requiredAddons", [])
-    except Exception:
-        logger.debug("Failed to fetch required addons list")
-        return []
 
 
 async def get_download_url(addon_name: str, addon_version: str) -> str:
@@ -40,27 +19,25 @@ async def get_download_url(addon_name: str, addon_version: str) -> str:
     async with httpx.AsyncClient(timeout=ayonconfig.http_timeout) as client:
         endpoint = f"addons/{addon_name}/{addon_version}"
         res = await client.get(
-            f"{ayonconfig.ynput_cloud_api_url}/api/v1/market/{endpoint}",
+            f"{ayonconfig.ynput_cloud_api_url}/api/v2/market/{endpoint}",
             headers=headers,
         )
         data = res.json()
         return data["url"]
 
 
-async def run_auto_update() -> None:
-    required_addons = await get_required_addons()
+async def download_addons() -> None:
+    required_addons = await CloudUtils.get_required_addons()
 
     if not required_addons:
         return
-
-    addon_library = AddonLibrary.getinstance()
-
-    bundle_addons_patch = {}
 
     downloaded_addons = get_downloaded_addons()
     for addon_name, addon_version in required_addons:
         # Do we have the required addon downloaded?
 
+        # Running as maintenance task. Ensure addon is downloaded,
+        # and trigger "restart requireded" after downloading.
         if (addon_name, addon_version) not in downloaded_addons:
             try:
                 url = await get_download_url(addon_name, addon_version)
@@ -76,79 +53,7 @@ async def run_auto_update() -> None:
                 url=url,
                 no_queue=True,
             )
-            # Just download the addon. After restart, we'll be able to continue
-            continue
-
-        # Addon is downloaded. Check if it's active
-
-        try:
-            addon = addon_library.addon(addon_name, addon_version)
-        except NotFoundException:
-            # Addon is downloaded, but not active. Server restart is needed
-            continue
-
-        # Addon is active. Check if it's in the production bundle
-
-        if await addon.is_production():
-            # Addon is active and in production we don't need to do anything
-            continue
-
-        logger.debug(
-            f"Required addon {addon_name} {addon_version} is not in production"
-        )
-
-        # Get the current production version of the addon
-
-        production_addon = await addon_library.get_production_addon(addon_name)
-        if production_addon is not None:
-            # There is a different version of the addon in production
-
-            logger.debug(
-                f"Migrating {addon_name} settings "
-                f" from {addon_version} to {production_addon.version}"
-            )
-            await migrate_addon_settings(
-                source_addon=production_addon,
-                target_addon=addon,
-                source_variant="production",
-                target_variant="production",
-            )
-
-        bundle_addons_patch[addon_name] = addon_version
-
-    if not bundle_addons_patch:
-        return
-
-    # Get the current production bundle
-
-    q = "SELECT name, data FROM public.bundles WHERE is_production = TRUE"
-    production_bundle = await Postgres.fetchrow(q)
-    if production_bundle:
-        data = production_bundle["data"]
-        data["addons"].update(bundle_addons_patch)
-
-        q = "UPDATE public.bundles SET data = $1 WHERE name = $2"
-        await Postgres.execute(q, data, production_bundle["name"])
-
-        for addon_name, addon_version in bundle_addons_patch.items():
-            logger.info(f"Updated production bundle with {addon_name} {addon_version}")
-
-    else:
-        ts = int(time.time())
-        bundle_name = f"default_bundle_{ts}"
-        bundle_data = {
-            "addons": bundle_addons_patch,
-            "dependency_packages": {},
-            "installer_version": None,
-        }
-        q = """
-            INSERT INTO public.bundles (name, data, is_production)
-            VALUES ($1, $2, TRUE)
-        """
-        await Postgres.execute(q, bundle_name, bundle_data)
-
-        for addon_name, addon_version in bundle_addons_patch.items():
-            logger.info(f"Created production bundle with {addon_name} {addon_version}")
+            logger.debug(f"Downloaded required addon {addon_name} {addon_version}")
 
 
 class AutoUpdate(StudioMaintenanceTask):
@@ -161,4 +66,4 @@ class AutoUpdate(StudioMaintenanceTask):
             # not connected to cloud. do nothing
             return
 
-        await run_auto_update()
+        await download_addons()

--- a/maintenance/tasks/auto_update.py
+++ b/maintenance/tasks/auto_update.py
@@ -5,6 +5,7 @@ from ayon_server.exceptions import AyonException
 from ayon_server.helpers.cloud import CloudUtils
 from ayon_server.helpers.download_addon import download_addon
 from ayon_server.helpers.get_downloaded_addons import get_downloaded_addons
+from ayon_server.lib.redis import Redis
 from ayon_server.logging import logger
 from ayon_server.version import __version__ as ayon_version
 from maintenance.maintenance_task import StudioMaintenanceTask
@@ -27,6 +28,7 @@ async def get_download_url(addon_name: str, addon_version: str) -> str:
 
 
 async def download_addons() -> None:
+    await Redis.delete("global", "required-addons")
     required_addons = await CloudUtils.get_required_addons()
 
     if not required_addons:

--- a/maintenance/tasks/auto_update.py
+++ b/maintenance/tasks/auto_update.py
@@ -37,7 +37,7 @@ async def download_addons() -> None:
         # Do we have the required addon downloaded?
 
         # Running as maintenance task. Ensure addon is downloaded,
-        # and trigger "restart requireded" after downloading.
+        # and trigger "restart required" after downloading.
         if (addon_name, addon_version) not in downloaded_addons:
             try:
                 url = await get_download_url(addon_name, addon_version)


### PR DESCRIPTION
This pull request refactors the process for handling required server addons, centralizing the logic for updating the production bundle and migrating addon settings into the server's startup lifecycle. It also simplifies the maintenance auto-update task to only ensure required addons are downloaded, removing logic for activating or migrating addons in that context.


* Moved the logic for updating the production bundle with required addons and migrating addon settings from the maintenance task (`auto_update.py`) into a new `addon_update` function, now called during server startup in the `lifespan` function. This ensures that production bundle updates and migrations happen reliably at startup.
* Added the `CloudUtils.get_required_addons` method to centralize and cache fetching the required addons list from the cloud, replacing previous ad-hoc implementations.
* Refactored the maintenance auto-update task to only download missing required addons, removing logic that previously handled activating addons, updating the production bundle, and migrating settings. This reduces complexity and potential side effects during maintenance runs.
* Updated the download URL endpoint from `/api/v1/market/` to `/api/v2/market/` in the maintenance task, ensuring compatibility with the latest API.

These changes improve reliability by ensuring production bundle updates and migrations occur during server startup, and make the maintenance auto-update task safer and easier to maintain.