### PR TITLE
Expose product/task/folder type in version column stats

### DIFF
--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -746,9 +746,11 @@ async def get_versions(
     elif calculate_statistics:
         stats_select_clause = generate_stats_columns(default_columns_metadata)
 
-    # Subtype fields live on joined tables, not versions.* — project them into
-    # raw_data so specific-stats distributions (e.g. productType) can GROUP BY them.
+    raw_data_start = ""
+    raw_data_end = ""
     if stats_select_clause:
+        # Subtype fields live on joined tables, not versions.* — project them into
+        # raw_data so specific-stats distributions (e.g. productType) can GROUP BY them.
         sql_columns.extend(
             [
                 "products.product_base_type AS product_base_type",
@@ -757,10 +759,6 @@ async def get_versions(
                 "tasks.task_type AS task_type",
             ]
         )
-
-    raw_data_start = ""
-    raw_data_end = ""
-    if stats_select_clause:
         cte_prefix = ",\n" if cte else "WITH"
         raw_data_start = f"{cte_prefix} raw_data AS ("
         raw_data_end = f"""

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -751,6 +751,7 @@ async def get_versions(
     if stats_select_clause:
         sql_columns.extend(
             [
+                "products.product_base_type AS product_base_type",
                 "products.product_type AS product_type",
                 "folders.folder_type AS folder_type",
                 "tasks.task_type AS task_type",

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -746,6 +746,17 @@ async def get_versions(
     elif calculate_statistics:
         stats_select_clause = generate_stats_columns(default_columns_metadata)
 
+    # Subtype fields live on joined tables, not versions.* — project them into
+    # raw_data so specific-stats distributions (e.g. productType) can GROUP BY them.
+    if stats_select_clause:
+        sql_columns.extend(
+            [
+                "products.product_type AS product_type",
+                "folders.folder_type AS folder_type",
+                "tasks.task_type AS task_type",
+            ]
+        )
+
     raw_data_start = ""
     raw_data_end = ""
     if stats_select_clause:


### PR DESCRIPTION
## PR Checklist

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

Lets version column-stats aggregate by product type, task type and folder type. These power per-value counts in the frontend slicer and group-by without hitting the expensive grouping endpoint.

### Technical details

<!-- Please state any technical details such as limitations -->

- Version stats distributions only aggregated native `versions.*` columns. `product_type`, `task_type` and `folder_type` live on the joined products/tasks/folders tables and were never projected into the stats `raw_data` CTE, so a distribution on them failed with `column "product_type" does not exist`.

### Additional context

<!-- Add any other context or screenshots here. -->

Paired with  PR: ynput/ayon-frontend#2179
