### PR TITLE
Summary: Exposed entity types in CTE part of versions query

### DIFF
--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -186,6 +186,10 @@ async def get_versions(
         "versions.creation_order AS creation_order",
         "hierarchy.path AS _folder_path",
         "products.name AS _product_name",
+        "products.product_base_type AS product_base_type",
+        "products.product_type AS product_type",
+        "tasks.task_type AS task_type",
+        "folders.folder_type AS folder_type",
     ]
 
     if fields.any_endswith("latestComments"):
@@ -777,6 +781,8 @@ async def get_versions(
 
     if stats_select_clause:
         field_stats = await generate_field_stats(query)
+        with open("/storage/server/projects/version.txt", "w") as fp:
+            fp.write(query)
 
         return VersionsConnection(edges=[], field_stats=field_stats)
 


### PR DESCRIPTION
## Description of changes

Exposes type fields in `versions` graphQL query:
- `product_base_type`
- `product_type`
- `task_type`
- `folder_type`


### Additional context

BE part for https://github.com/ynput/ayon-backend/pull/1022
