### PR TITLE
Activity feed: track tags and type changes

### DIFF
--- a/ayon_server/activities/event_hook.py
+++ b/ayon_server/activities/event_hook.py
@@ -50,6 +50,12 @@ class ActivityFeedEventHook:
             "entity.version.attrib_changed": cls.handle_attrib_changed,
             "entity.product.status_changed": cls.handle_status_changed,
             "entity.product.attrib_changed": cls.handle_attrib_changed,
+            "entity.folder.tags_changed": cls.handle_tags_changed,
+            "entity.task.tags_changed": cls.handle_tags_changed,
+            "entity.version.tags_changed": cls.handle_tags_changed,
+            "entity.product.tags_changed": cls.handle_tags_changed,
+            "entity.folder.type_changed": cls.handle_type_changed,
+            "entity.task.type_changed": cls.handle_type_changed,
             "entity.task.assignees_changed": cls.handle_assignees_changed,
             "entity.version.created": cls.handle_version_created,
         }
@@ -117,6 +123,69 @@ class ActivityFeedEventHook:
                     "newValue": new_value,
                 },
             )
+
+    @classmethod
+    async def handle_tags_changed(cls, event: "EventModel"):
+        entity_type = event.topic.split(".")[1]
+        entity_class = get_entity_class(entity_type)
+        assert event.project is not None, "Project is required for activities"
+
+        # old/new values are only in the payload when audit trail is enabled
+        old_value = event.payload.get("oldValue")
+        new_value = event.payload.get("newValue")
+        if old_value is None and new_value is None:
+            return
+        if old_value == new_value:
+            return
+
+        entity = await entity_class.load(event.project, event.summary["entityId"])
+
+        origin_link = f"[{entity.name}]({entity_type}:{entity.id})"
+        body = f"{origin_link} tags changed from {old_value} to {new_value}"
+
+        await create_activity(
+            entity,
+            activity_type="tags.change",
+            body=body,
+            user_name=event.user,
+            data={
+                "oldValue": old_value,
+                "newValue": new_value,
+            },
+        )
+
+    @classmethod
+    async def handle_type_changed(cls, event: "EventModel"):
+        entity_type = event.topic.split(".")[1]
+        entity_class = get_entity_class(entity_type)
+        assert event.project is not None, "Project is required for activities"
+
+        # old/new values are only in the payload when audit trail is enabled
+        old_value = event.payload.get("oldValue")
+        new_value = event.payload.get("newValue")
+        if old_value is None and new_value is None:
+            return
+        if old_value == new_value:
+            return
+
+        entity = await entity_class.load(event.project, event.summary["entityId"])
+
+        origin_link = f"[{entity.name}]({entity_type}:{entity.id})"
+        body = (
+            f"{origin_link} {entity_type} type changed from {old_value} to {new_value}"
+        )
+
+        await create_activity(
+            entity,
+            activity_type="type.change",
+            body=body,
+            user_name=event.user,
+            data={
+                "key": f"{entity_type}Type",
+                "oldValue": old_value,
+                "newValue": new_value,
+            },
+        )
 
     @classmethod
     async def handle_assignees_changed(cls, event: "EventModel"):

--- a/ayon_server/activities/event_hook.py
+++ b/ayon_server/activities/event_hook.py
@@ -140,8 +140,11 @@ class ActivityFeedEventHook:
 
         entity = await entity_class.load(event.project, event.summary["entityId"])
 
+        old_label = ", ".join(old_value) if old_value else "(none)"
+        new_label = ", ".join(new_value) if new_value else "(none)"
+
         origin_link = f"[{entity.name}]({entity_type}:{entity.id})"
-        body = f"{origin_link} tags changed from {old_value} to {new_value}"
+        body = f"{origin_link} tags changed from {old_label} to {new_label}"
 
         await create_activity(
             entity,
@@ -170,14 +173,17 @@ class ActivityFeedEventHook:
 
         entity = await entity_class.load(event.project, event.summary["entityId"])
 
+        old_label = old_value or "(none)"
+        new_label = new_value or "(none)"
+
         origin_link = f"[{entity.name}]({entity_type}:{entity.id})"
         body = (
-            f"{origin_link} {entity_type} type changed from {old_value} to {new_value}"
+            f"{origin_link} {entity_type} type changed from {old_label} to {new_label}"
         )
 
         await create_activity(
             entity,
-            activity_type="type.change",
+            activity_type="subtype.change",
             body=body,
             user_name=event.user,
             data={

--- a/ayon_server/activities/models.py
+++ b/ayon_server/activities/models.py
@@ -14,6 +14,8 @@ ActivityType = Literal[
     "version.publish",
     "version.review",
     "attrib.change",
+    "tags.change",
+    "type.change",
 ]
 
 ActivityReferenceType = Literal[

--- a/ayon_server/activities/models.py
+++ b/ayon_server/activities/models.py
@@ -15,7 +15,7 @@ ActivityType = Literal[
     "version.review",
     "attrib.change",
     "tags.change",
-    "type.change",
+    "subtype.change",
 ]
 
 ActivityReferenceType = Literal[

--- a/ayon_server/events/patch.py
+++ b/ayon_server/events/patch.py
@@ -207,6 +207,9 @@ def build_pl_entity_change_events(
             result.append(evt)
 
     for column_name, topic_name in ADDITIONAL_COLUMNS.items():
+        if column_name == "tags":
+            continue  # tags_changed is already emitted by the explicit block above
+
         if not hasattr(original_entity, column_name):
             continue
 


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

Adds activity feed entries when entity tags or folder/task type change, so these edits show up in the feed like status changes do.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

- New `tags.change` and `type.change` activity types in `ayon_server/activities/models.py`
- `handle_tags_changed` and `handle_type_changed` handlers subscribed to `entity.*.tags_changed` / `type_changed` in `ayon_server/activities/event_hook.py`

### Additional context

<!-- Add any other context or screenshots here. -->

ynput/ayon-frontend#2197
