### PR TITLE
YnputCloud disconnect

### DIFF
--- a/api/ynputcloud/connect.py
+++ b/api/ynputcloud/connect.py
@@ -81,8 +81,11 @@ async def set_ynput_cloud_key(
 
 @router.delete("")
 async def delete_ynput_cloud_key(user: CurrentUser) -> EmptyResponse:
-    """Remove the Ynput cloud key from the database"""
+    """
+    Remove the Ynput cloud key from the
+    database and disconnect from the Ynput cloud
+    """
     if not user.is_admin:
-        raise ForbiddenException("Only admins can remove the Ynput cloud key")
-    await CloudUtils.remove_ynput_cloud_key()
+        raise ForbiddenException("Only admins can disconnect from the Ynput Cloud")
+    await CloudUtils.remove_ynput_cloud_key(disconnect_instance=True)
     return EmptyResponse()

--- a/ayon_server/helpers/cloud.py
+++ b/ayon_server/helpers/cloud.py
@@ -192,8 +192,24 @@ class CloudUtils:
         await Redis.set("global", "ynput_cloud_key", key)
 
     @classmethod
-    async def remove_ynput_cloud_key(cls) -> None:
+    async def remove_ynput_cloud_key(
+        cls,
+        *,
+        disconnect_instance: bool = False,
+    ) -> None:
         """Remove the Ynput Cloud key from cache"""
+
+        if disconnect_instance:
+            try:
+                headers = await cls.get_api_headers()
+                async with httpx.AsyncClient(timeout=ayonconfig.http_timeout) as client:
+                    await client.delete(
+                        f"{ayonconfig.ynput_cloud_api_url}/api/ayon/info",
+                        headers=headers,
+                    )
+            except Exception as e:
+                logger.warning(f"Failed to disconnect from Ynput Cloud: {e}")
+
         query = "DELETE FROM public.secrets WHERE name = 'ynput_cloud_key'"
         await Postgres.execute(query)
         await cls.clear_cloud_info_cache()


### PR DESCRIPTION
This pull request updates the process for removing the Ynput Cloud key to ensure that the instance is properly disconnected from the Ynput Cloud when an admin deletes the key. The main changes include updating the API endpoint to trigger a disconnect, modifying the helper method to support this behavior, and improving error handling and logging.


*  The `delete_ynput_cloud_key` endpoint now disconnects the instance from the Ynput Cloud in addition to removing the key. The admin-only restriction message has been clarified.
* `remove_ynput_cloud_key` method now accepts a `disconnect_instance` parameter. If set, it attempts to notify the Ynput Cloud API to disconnect the instance, with error handling and logging if the disconnect fails.