### PR TITLE
Profile endpoints

### DIFF
--- a/api/profile/__init__.py
+++ b/api/profile/__init__.py
@@ -1,0 +1,6 @@
+__all__ = ["router"]
+
+from . import profile
+from .router import router
+
+_ = profile

--- a/api/profile/profile.py
+++ b/api/profile/profile.py
@@ -1,0 +1,93 @@
+from typing import Any
+
+from ayon_server.api.dependencies import (
+    AllowGuests,
+    CurrentUser,
+)
+from ayon_server.auth.session import Session
+from ayon_server.entities import UserEntity
+from ayon_server.exceptions import (
+    BadRequestException,
+)
+from ayon_server.lib.redis import Redis
+from ayon_server.logging import logger
+
+from .router import router
+
+#
+# [GET] /api/users/me
+#
+
+
+@router.get("", dependencies=[AllowGuests])
+async def get_current_user_profile(
+    user: CurrentUser,
+) -> UserEntity.model.main_model:  # type: ignore
+    """
+    Return the current user information (based on the Authorization header).
+    This is used for a profile page as well as as an initial check to ensure
+    the user is still logged in.
+    """
+
+    payload = user.payload
+    payload.ui_exposure_level = await user.get_ui_exposure_level()  # type: ignore
+    payload.data.pop("supportToken", None)  # type: ignore
+    return payload
+
+
+async def update_guest_attrib(
+    user: UserEntity, token: str, attrib_dict: dict[str, Any]
+) -> None:
+    if user.data.get("isProjectGuest"):
+        # Project guest users are not allowed to update their profile
+        raise BadRequestException("Project guest users cannot update their profile.")
+
+    for key, value in attrib_dict.items():
+        if key not in ["fullName", "avatarUrl", "email"]:
+            raise BadRequestException(
+                f"Cannot update attribute '{key}' for guest user."
+            )
+        setattr(user.attrib, key, value)
+
+    await Session.update(token, user)
+
+
+@router.patch("", dependencies=[AllowGuests])
+async def update_current_user_profile(
+    payload: UserEntity.model.patch_model,  # type: ignore
+    user: CurrentUser,
+) -> None:
+
+    attrib_dict = payload.attrib.dict(exclude_unset=True)
+
+    session = user.session
+    assert session is not None, "Session should be available for authenticated users"
+    token = session.token
+    assert token is not None, "Token should be available for authenticated users"
+
+    if user.is_guest:
+        await update_guest_attrib(user, token, attrib_dict)
+        return
+
+    target_user = await UserEntity.load(user.name)
+
+    avatar_changed = False
+    if (
+        "avatarUrl" in attrib_dict
+        and attrib_dict["avatarUrl"] != target_user.attrib.avatarUrl
+    ):
+        url = attrib_dict["avatarUrl"]
+        if (url) and not (url.startswith("http://") or url.startswith("https://")):
+            raise BadRequestException("Invalid avatar URL")
+        avatar_changed = True
+
+    for key, value in attrib_dict.items():
+        setattr(target_user.attrib, key, value)
+
+    await target_user.save()
+
+    if avatar_changed:
+        logger.debug(f"User {user.name} avatar changed, updating cache")
+        await Redis.delete("user.avatar", user.name)
+
+    return None

--- a/api/profile/router.py
+++ b/api/profile/router.py
@@ -1,0 +1,3 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/profile", tags=["Users"])

--- a/api/users/users.py
+++ b/api/users/users.py
@@ -33,7 +33,12 @@ from .router import router
 #
 
 
-@router.get("/me", response_model_exclude_none=True, dependencies=[AllowGuests])
+@router.get(
+    "/me",
+    response_model_exclude_none=True,
+    dependencies=[AllowGuests],
+    deprecated=True,
+)
 async def get_current_user(
     user: CurrentUser,
 ) -> UserEntity.model.main_model:  # type: ignore
@@ -41,6 +46,9 @@ async def get_current_user(
     Return the current user information (based on the Authorization header).
     This is used for a profile page as well as as an initial check to ensure
     the user is still logged in.
+
+    This endpoint is deprecated and will be removed in a future version.
+    Use [GET] /api/profile instead, which returns the same information.
     """
 
     payload = user.payload

--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -149,15 +149,20 @@ async def create_activity(
     )
 
     if user_name:
-        references.add(
-            ActivityReferenceModel(
-                entity_type="user",
-                entity_name=user_name,
-                reference_type="author",
-                entity_id=None,
+        if (not user) or (not user.is_guest):
+            references.add(
+                ActivityReferenceModel(
+                    entity_type="user",
+                    entity_name=user_name,
+                    reference_type="author",
+                    entity_id=None,
+                )
             )
-        )
         data["author"] = user_name
+        if user and user.is_guest and not user.data.get("isProjectGuest"):
+            # for anonymous guest, extract the full name and store it
+            # in data as well
+            data["authorFullName"] = user.attrib.fullName
 
     references.update(await extract_mentions(body, project_name))
     if activity_type not in ["watch", "attrib.change"]:

--- a/ayon_server/auth/tokenauth.py
+++ b/ayon_server/auth/tokenauth.py
@@ -123,6 +123,7 @@ async def create_guest_user_session(
     full_name: str | None = None,
     redirect_url: str | None = None,
     guest_access: list[dict[str, Any]] | None = None,
+    is_project_guest: bool = False,
 ) -> LoginResponseModel:
 
     if not user_name:
@@ -131,6 +132,8 @@ async def create_guest_user_session(
     user_data: dict[str, Any] = {"isGuest": True}
     if guest_access:
         user_data["guestAccess"] = guest_access
+    if is_project_guest:
+        user_data["isProjectGuest"] = True
 
     user = UserEntity(
         payload={
@@ -190,7 +193,8 @@ async def handle_token_auth_callback(
             msg = "Guest user token must contain project name"
             raise BadRequestException(msg)
         exists = await GuestUsers.exists(
-            payload.email, project_name=payload.project_name
+            payload.email,
+            project_name=payload.project_name,
         )
         if not exists:
             msg = (
@@ -213,4 +217,5 @@ async def handle_token_auth_callback(
         request=request,
         full_name=payload.full_name,
         redirect_url=payload.redirect_url,
+        is_project_guest=True,
     )

--- a/ayon_server/graphql/nodes/activity.py
+++ b/ayon_server/graphql/nodes/activity.py
@@ -138,7 +138,7 @@ class ActivityNode:
                 record = {
                     "name": author,
                     "attrib": {
-                        "fullName": author,
+                        "fullName": data.get("authorFullName", author),
                     },
                     "active": False,
                     "deleted": True,


### PR DESCRIPTION
This pull request introduces a new `/api/profile` endpoint for user profile management, deprecates the old `/api/users/me` endpoint, and adds improved handling for guest and project guest users. The changes are organized around API improvements, guest user handling, and internal refactoring.

The new "update_current_user_profile" additionally supports updating anonymous guest users session data, so they can update their own full names in order to be identified later.

<img width="1281" height="419" alt="image" src="https://github.com/user-attachments/assets/3e1fcf07-09ea-41ee-8d71-60bcb40d0474" />

<img width="695" height="568" alt="image" src="https://github.com/user-attachments/assets/1b3c7332-310d-466f-95ab-e8e975afb37f" />
