### PR TITLE
GraphQL: use direct sql for products and versions resolvers

### DIFF
--- a/ayon_server/graphql/nodes/product.py
+++ b/ayon_server/graphql/nodes/product.py
@@ -74,7 +74,7 @@ class ProductNode(BaseNode):
         description="Simple (id /version) list of versions in the product",
     )
 
-    _folder: FolderNode | None = None
+    _folder: strawberry.Private[FolderNode | None] = None
 
     @strawberry.field(description="Parent folder of the product")
     async def folder(self, info: Info) -> FolderNode:

--- a/ayon_server/graphql/nodes/task.py
+++ b/ayon_server/graphql/nodes/task.py
@@ -82,7 +82,7 @@ class TaskNode(BaseNode):
         description=get_workfiles.__doc__,
     )
 
-    _folder: FolderNode | None = None
+    _folder: strawberry.Private[FolderNode | None] = None
 
     @strawberry.field
     def type(self) -> str:

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -147,7 +147,6 @@ async def version_from_record(
                     folder = None
                 else:
                     folder = await cfun(project_name, folder_data, context=context)
-                    print("created folder from folder_data")
             except KeyError:
                 pass
 

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -51,6 +51,8 @@ class VersionNode(BaseNode):
 
     _folder_path: strawberry.Private[str | None] = None
 
+    _product: strawberry.Private[ProductNode | None] = None
+
     # GraphQL specifics
 
     representations: RepresentationsConnection = strawberry.field(
@@ -60,12 +62,26 @@ class VersionNode(BaseNode):
 
     @strawberry.field(description="Parent product of the version")
     async def product(self, info: Info) -> ProductNode:
+        if self._product:
+            return self._product
+
         record = await info.context["product_loader"].load(
             (self.project_name, self.product_id)
         )
-        return await info.context["product_from_record"](
+        product = await info.context["product_from_record"](
             self.project_name, record, info.context
         )
+
+        if product:
+            folder_record = await info.context["folder_loader"].load(
+                (self.project_name, product.folder_id)
+            )
+            folder = await info.context["folder_from_record"](
+                self.project_name, folder_record, info.context
+            )
+            product._folder = folder
+
+        return product
 
     @strawberry.field(description="Task")
     async def task(self, info: Info) -> TaskNode | None:
@@ -99,6 +115,43 @@ async def version_from_record(
     project_name: str, record: dict[str, Any], context: dict[str, Any]
 ) -> VersionNode:
     """Construct a version node from a DB row."""
+
+    product = None
+    folder = None
+    if context:
+        product_data = {}
+        folder_data = {}
+        for key, value in record.items():
+            if key.startswith("_product_"):
+                key = key.removeprefix("_product_")
+                product_data[key] = value
+
+            if key.startswith("_folder_"):
+                key = key.removeprefix("_folder_")
+                folder_data[key] = value
+
+        if product_data.get("id"):
+            try:
+                cfun = context["product_from_record"]
+                if product_data is None:
+                    product = None
+                else:
+                    product = await cfun(project_name, product_data, context=context)
+            except KeyError:
+                pass
+
+        if product and folder_data.get("id"):
+            try:
+                cfun = context["folder_from_record"]
+                if folder_data is None:
+                    folder = None
+                else:
+                    folder = await cfun(project_name, folder_data, context=context)
+                    print("created folder from folder_data")
+            except KeyError:
+                pass
+
+        product._folder = folder
 
     current_user = context["user"]
     author = record["author"]
@@ -164,6 +217,7 @@ async def version_from_record(
         is_latest=record.get("is_latest", False),
         is_latest_done=record.get("is_latest_done", False),
         latest_comments=[EntityComment(**comment) for comment in latest_comments],
+        _product=product,
         _folder_path=folder_path,
         _attrib=record["attrib"] or {},
         _user=current_user,

--- a/ayon_server/graphql/nodes/version.py
+++ b/ayon_server/graphql/nodes/version.py
@@ -147,10 +147,9 @@ async def version_from_record(
                     folder = None
                 else:
                     folder = await cfun(project_name, folder_data, context=context)
+                    product._folder = folder
             except KeyError:
                 pass
-
-        product._folder = folder
 
     current_user = context["user"]
     author = record["author"]

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -11,6 +11,7 @@ from ayon_server.exceptions import ForbiddenException
 from ayon_server.graphql.types import Info, PageInfo
 from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import logger
+from ayon_server.utils import SQLTool
 
 from .pagination import encode_cursor
 
@@ -158,6 +159,35 @@ async def create_folder_access_list(root, info) -> list[str] | None:
     # if root.__class__.__name__ != "ProjectNode":
     #     return None
     return await folder_access_list(user, project_name)
+
+
+def create_child_folder_ctes(
+    project_name: str,
+    folder_ids: list[str],
+) -> list[str]:
+    """Create CTE queries for resolving child folder IDs based on parent paths."""
+    return [
+        f"""
+        top_folder_paths AS (
+            SELECT path FROM project_{project_name}.hierarchy
+            WHERE id IN {SQLTool.id_array(folder_ids)}
+        )
+        """,
+        f"""
+        child_folder_ids AS (
+            SELECT id FROM project_{project_name}.hierarchy
+            WHERE EXISTS (
+                SELECT 1
+                FROM top_folder_paths
+                WHERE project_{project_name}.hierarchy.path
+                LIKE top_folder_paths.path || '/%'
+            )
+            OR project_{project_name}.hierarchy.path = ANY (
+                SELECT path FROM top_folder_paths
+            )
+        )
+        """,
+    ]
 
 
 #

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -193,6 +193,7 @@ def create_child_folder_ctes(
 def get_folder_fields_block(
     project_name: str,
     folder_id_column: str,
+    is_inner: bool = True,
 ) -> tuple[list[str], list[str]]:
     """Return SQL columns and joins for resolving full folder fields."""
     columns = [
@@ -212,13 +213,14 @@ def get_folder_fields_block(
         "projects.attrib as _folder_project_attributes",
         "folder_ex.attrib as _folder_inherited_attributes",
     ]
+    exported_join = "INNER" if is_inner else "LEFT"
     joins = [
         f"""
         INNER JOIN project_{project_name}.folders
         ON folders.id = {folder_id_column}
         """,
         f"""
-        LEFT JOIN project_{project_name}.exported_attributes AS folder_ex
+        {exported_join} JOIN project_{project_name}.exported_attributes AS folder_ex
         ON folders.parent_id = folder_ex.folder_id
         """,
         f"""

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -190,6 +190,29 @@ def create_child_folder_ctes(
     ]
 
 
+def get_product_fields_block(
+    product_alias: str = "products",
+) -> tuple[list[str], list[str]]:
+    """Return SQL columns and joins for resolving full product fields."""
+    columns = [
+        f"{product_alias}.id AS _product_id",
+        f"{product_alias}.name AS _product_name",
+        f"{product_alias}.folder_id AS _product_folder_id",
+        f"{product_alias}.product_type AS _product_product_type",
+        f"{product_alias}.product_base_type AS _product_product_base_type",
+        f"{product_alias}.status AS _product_status",
+        f"{product_alias}.tags AS _product_tags",
+        f"{product_alias}.data AS _product_data",
+        f"{product_alias}.active AS _product_active",
+        f"{product_alias}.created_at AS _product_created_at",
+        f"{product_alias}.updated_at AS _product_updated_at",
+        f"{product_alias}.created_by AS _product_created_by",
+        f"{product_alias}.updated_by AS _product_updated_by",
+        f"{product_alias}.attrib AS _product_attrib",
+    ]
+    return columns, []
+
+
 def get_folder_fields_block(
     project_name: str,
     folder_id_column: str,

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -210,7 +210,7 @@ def get_folder_fields_block(
         "folders.created_at AS _folder_created_at",
         "folders.updated_at AS _folder_updated_at",
         "projects.attrib as _folder_project_attributes",
-        "pf_ex.attrib as _folder_inherited_attributes",
+        "folder_ex.attrib as _folder_inherited_attributes",
     ]
     joins = [
         f"""

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -238,7 +238,7 @@ def get_folder_fields_block(
         "folder_ex.attrib as _folder_inherited_attributes",
     ]
     exported_join = "INNER" if is_inner else "LEFT"
-    joins = []
+    joins: list[str] = []
 
     def has_join(alias_or_table: str) -> bool:
         all_joins = sql_joins + joins

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -190,6 +190,45 @@ def create_child_folder_ctes(
     ]
 
 
+def get_folder_fields_block(
+    project_name: str,
+    folder_id_column: str,
+) -> tuple[list[str], list[str]]:
+    """Return SQL columns and joins for resolving full folder fields."""
+    columns = [
+        "folders.id AS _folder_id",
+        "folders.name AS _folder_name",
+        "folders.label AS _folder_label",
+        "folders.folder_type AS _folder_folder_type",
+        "folders.thumbnail_id AS _folder_thumbnail_id",
+        "folders.parent_id AS _folder_parent_id",
+        "folders.attrib AS _folder_attrib",
+        "folders.data AS _folder_data",
+        "folders.active AS _folder_active",
+        "folders.status AS _folder_status",
+        "folders.tags AS _folder_tags",
+        "folders.created_at AS _folder_created_at",
+        "folders.updated_at AS _folder_updated_at",
+        "projects.attrib as _folder_project_attributes",
+        "pf_ex.attrib as _folder_inherited_attributes",
+    ]
+    joins = [
+        f"""
+        INNER JOIN project_{project_name}.folders
+        ON folders.id = {folder_id_column}
+        """,
+        f"""
+        LEFT JOIN project_{project_name}.exported_attributes AS pf_ex
+        ON folders.parent_id = pf_ex.folder_id
+        """,
+        f"""
+        INNER JOIN public.projects AS projects
+        ON projects.name ILIKE '{project_name}'
+        """,
+    ]
+    return columns, joins
+
+
 #
 # Actual resolver
 #

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -218,8 +218,8 @@ def get_folder_fields_block(
         ON folders.id = {folder_id_column}
         """,
         f"""
-        LEFT JOIN project_{project_name}.exported_attributes AS pf_ex
-        ON folders.parent_id = pf_ex.folder_id
+        LEFT JOIN project_{project_name}.exported_attributes AS folder_ex
+        ON folders.parent_id = folder_ex.folder_id
         """,
         f"""
         INNER JOIN public.projects AS projects

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -256,7 +256,7 @@ def get_folder_fields_block(
         joins.append(
             f"""
             {exported_join} JOIN project_{project_name}.exported_attributes AS folder_ex
-                ON folders.parent_id = folder_ex.folder_id
+                ON folders.id = folder_ex.folder_id
             """
         )
 

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -216,6 +216,7 @@ def get_product_fields_block(
 def get_folder_fields_block(
     project_name: str,
     folder_id_column: str,
+    sql_joins: list[str],
     is_inner: bool = True,
 ) -> tuple[list[str], list[str]]:
     """Return SQL columns and joins for resolving full folder fields."""
@@ -237,20 +238,35 @@ def get_folder_fields_block(
         "folder_ex.attrib as _folder_inherited_attributes",
     ]
     exported_join = "INNER" if is_inner else "LEFT"
-    joins = [
-        f"""
-        INNER JOIN project_{project_name}.folders
-        ON folders.id = {folder_id_column}
-        """,
-        f"""
-        {exported_join} JOIN project_{project_name}.exported_attributes AS folder_ex
-        ON folders.parent_id = folder_ex.folder_id
-        """,
-        f"""
-        INNER JOIN public.projects AS projects
-        ON projects.name ILIKE '{project_name}'
-        """,
-    ]
+    joins = []
+
+    def has_join(alias_or_table: str) -> bool:
+        all_joins = sql_joins + joins
+        return any(alias_or_table in j for j in all_joins)
+
+    if not has_join(".folders"):
+        joins.append(
+            f"""
+            INNER JOIN project_{project_name}.folders AS folders
+                ON folders.id = {folder_id_column}
+            """
+        )
+
+    if not has_join("folder_ex"):
+        joins.append(
+            f"""
+            {exported_join} JOIN project_{project_name}.exported_attributes AS folder_ex
+                ON folders.parent_id = folder_ex.folder_id
+            """
+        )
+
+    if not has_join("public.projects"):
+        joins.append(
+            f"""
+            INNER JOIN public.projects AS projects
+                ON projects.name ILIKE '{project_name}'
+            """
+        )
     return columns, joins
 
 

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -1,7 +1,6 @@
 import json
 from typing import Annotated
 
-from ayon_server.access.utils import folder_access_list
 from ayon_server.entities import ProjectEntity
 from ayon_server.exceptions import BadRequestException, NotFoundException
 from ayon_server.graphql.connections import ProductsConnection
@@ -17,6 +16,8 @@ from ayon_server.graphql.resolvers.common import (
     ColumnMetadata,
     FieldInfo,
     argdesc,
+    create_child_folder_ctes,
+    create_folder_access_list,
     get_has_links_conds,
     resolve,
     sortdesc,
@@ -143,36 +144,22 @@ async def get_products(
         if not ids:
             return ProductsConnection(edges=[])
 
-    #
-    # SQL
-    #
+    use_folder_query = False
 
     sql_columns = [
         "products.*",
-        "folders.id AS _folder_id",
-        "folders.name AS _folder_name",
-        "folders.label AS _folder_label",
-        "folders.folder_type AS _folder_folder_type",
-        "folders.parent_id AS _folder_parent_id",
-        "folders.thumbnail_id AS _folder_thumbnail_id",
-        "folders.attrib AS _folder_attrib",
-        "folders.data AS _folder_data",
-        "folders.active AS _folder_active",
-        "folders.status AS _folder_status",
-        "folders.tags AS _folder_tags",
-        "folders.created_at AS _folder_created_at",
-        "folders.updated_at AS _folder_updated_at",
         "hierarchy.path AS _folder_path",
+        "f_ex.attrib as inherited_attributes",
     ]
 
     sql_joins = [
         f"""
-        INNER JOIN project_{project_name}.folders
-        ON folders.id = products.folder_id
+        INNER JOIN project_{project_name}.hierarchy AS hierarchy
+        ON products.folder_id = hierarchy.id
         """,
         f"""
-        INNER JOIN project_{project_name}.hierarchy AS hierarchy
-        ON folders.id = hierarchy.id
+        INNER JOIN project_{project_name}.exported_attributes AS f_ex
+        ON products.folder_id = f_ex.folder_id
         """,
     ]
 
@@ -187,39 +174,15 @@ async def get_products(
     if folder_ids is not None:
         if not folder_ids:
             return ProductsConnection()
-        if not include_folder_children:
+        if include_folder_children:
+            use_folder_query = True
+            sql_cte.extend(create_child_folder_ctes(project_name, folder_ids))
             sql_conditions.append(
-                f"products.folder_id IN {SQLTool.id_array(folder_ids)}"
+                "products.folder_id IN (SELECT id FROM child_folder_ids)"
             )
         else:
-            sql_cte.append(
-                f"""
-                top_folder_paths AS (
-                    SELECT path FROM project_{project_name}.hierarchy
-                    WHERE id IN {SQLTool.id_array(folder_ids)}
-                )
-                """
-            )
-            sql_cte.append(
-                f"""
-                child_folder_ids AS (
-                    SELECT id FROM project_{project_name}.hierarchy
-                    WHERE EXISTS (
-                        SELECT 1 FROM top_folder_paths
-                        WHERE project_{project_name}.hierarchy.path
-                        LIKE top_folder_paths.path || '/%'
-                    )
-                    OR project_{project_name}.hierarchy.path = ANY(
-                        SELECT path FROM top_folder_paths
-                    )
-                )
-                """
-            )
-            sql_joins.append(
-                """
-                INNER JOIN child_folder_ids AS cfi
-                ON cfi.id = products.folder_id
-                """
+            sql_conditions.append(
+                f"products.folder_id IN {SQLTool.id_array(folder_ids)}"
             )
 
     elif root.__class__.__name__ == "FolderNode":
@@ -282,56 +245,13 @@ async def get_products(
     # Access control
     #
 
-    access_list = None
-    if root.__class__.__name__ == "ProjectNode":
-        # Selecting products directly from the project node,
-        # so we need to check access rights
-        user = info.context["user"]
-        if user.is_guest:
-            # Guests need to provide explicit IDs
-            # that is handled above and provides a sufficient
-            # level of security.
-
-            # We may use additional checks for version lists in the future
-            pass
-        else:
-            access_list = await folder_access_list(user, project_name)
-            if access_list is not None:
-                sql_conditions.append(
-                    f"hierarchy.path like ANY ('{{ {','.join(access_list)} }}')"
-                )
-
-    #
-    # Do we need parent folder attributes?
-    # And most importantly - do we need to know which are inherited?
-    #
-
-    if any(field.endswith("folder.attrib") for field in fields):
-        sql_columns.extend(
-            [
-                "pr.attrib as _folder_project_attributes",
-                "ex.attrib as _folder_inherited_attributes",
-            ]
-        )
-        sql_joins.extend(
-            [
-                f"""
-                LEFT JOIN project_{project_name}.exported_attributes AS ex
-                ON folders.parent_id = ex.folder_id
-                """,
-                f"""
-                INNER JOIN public.projects AS pr
-                ON pr.name ILIKE '{project_name}'
-                """,
-            ]
-        )
-    else:
-        sql_columns.extend(
-            [
-                "'{}'::JSONB as _folder_project_attributes",
-                "'{}'::JSONB as _folder_inherited_attributes",
-            ]
-        )
+    user = info.context["user"]
+    if not user.is_manager:
+        access_list = await create_folder_access_list(root, info)
+        if access_list is not None:
+            sql_conditions.append(
+                f"hierarchy.path like ANY ('{{ {','.join(access_list)} }}')"
+            )
 
     if ff_field := fields.find_field("featuredVersion"):
         req_order = ff_field.arguments.get("order") or [
@@ -467,6 +387,7 @@ async def get_products(
     #
 
     if search:
+        use_folder_query = True
         terms = slugify(search, make_set=True, split_chars=" ")
         for term in terms:
             sub_conditions = []
@@ -477,6 +398,44 @@ async def get_products(
 
             condition = " OR ".join(sub_conditions)
             sql_conditions.append(f"({condition})")
+
+    if use_folder_query or "folder" in fields:
+        sql_columns.extend(
+            [
+                "folders.id AS _folder_id",
+                "folders.name AS _folder_name",
+                "folders.label AS _folder_label",
+                "folders.folder_type AS _folder_folder_type",
+                "folders.thumbnail_id AS _folder_thumbnail_id",
+                "folders.parent_id AS _folder_parent_id",
+                "folders.attrib AS _folder_attrib",
+                "folders.data AS _folder_data",
+                "folders.active AS _folder_active",
+                "folders.status AS _folder_status",
+                "folders.tags AS _folder_tags",
+                "folders.created_at AS _folder_created_at",
+                "folders.updated_at AS _folder_updated_at",
+                "projects.attrib as _folder_project_attributes",
+                "pf_ex.attrib as _folder_inherited_attributes",
+            ]
+        )
+
+        sql_joins.extend(
+            [
+                f"""
+                INNER JOIN project_{project_name}.folders
+                ON folders.id = products.folder_id
+                """,
+                f"""
+                LEFT JOIN project_{project_name}.exported_attributes AS pf_ex
+                ON folders.parent_id = pf_ex.folder_id
+                """,
+                f"""
+                INNER JOIN public.projects AS projects
+                ON projects.name ILIKE '{project_name}'
+                """,
+            ]
+        )
 
     #
     # Filter (actual product filter)

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -164,7 +164,7 @@ async def get_products(
         """,
         f"""
         INNER JOIN project_{project_name}.exported_attributes AS folder_ex
-        ON folders.id = folder_ex.folder_id
+        ON products.folder_id = folder_ex.folder_id
         """,
     ]
 

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -408,7 +408,11 @@ async def get_products(
             condition = " OR ".join(sub_conditions)
             sql_conditions.append(f"({condition})")
 
-    if use_folder_query or "folder" in fields:
+    if (
+        use_folder_query
+        or "folder" in fields
+        or sort_by in ["folderName", "folderType"]
+    ):
         folder_columns, folder_joins = get_folder_fields_block(
             project_name, "products.folder_id", sql_joins=sql_joins
         )

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -255,7 +255,7 @@ async def get_products(
         access_list = await create_folder_access_list(root, info)
         if access_list is not None:
             sql_conditions.append(
-                f"hierarchy.path like ANY ('{{ {','.join(access_list)} }}')"
+                f"folder_ex.path like ANY ('{{ {','.join(access_list)} }}')"
             )
 
     if ff_field := fields.find_field("featuredVersion"):

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -18,6 +18,7 @@ from ayon_server.graphql.resolvers.common import (
     argdesc,
     create_child_folder_ctes,
     create_folder_access_list,
+    get_folder_fields_block,
     get_has_links_conds,
     resolve,
     sortdesc,
@@ -400,42 +401,11 @@ async def get_products(
             sql_conditions.append(f"({condition})")
 
     if use_folder_query or "folder" in fields:
-        sql_columns.extend(
-            [
-                "folders.id AS _folder_id",
-                "folders.name AS _folder_name",
-                "folders.label AS _folder_label",
-                "folders.folder_type AS _folder_folder_type",
-                "folders.thumbnail_id AS _folder_thumbnail_id",
-                "folders.parent_id AS _folder_parent_id",
-                "folders.attrib AS _folder_attrib",
-                "folders.data AS _folder_data",
-                "folders.active AS _folder_active",
-                "folders.status AS _folder_status",
-                "folders.tags AS _folder_tags",
-                "folders.created_at AS _folder_created_at",
-                "folders.updated_at AS _folder_updated_at",
-                "projects.attrib as _folder_project_attributes",
-                "pf_ex.attrib as _folder_inherited_attributes",
-            ]
+        folder_columns, folder_joins = get_folder_fields_block(
+            project_name, "products.folder_id"
         )
-
-        sql_joins.extend(
-            [
-                f"""
-                INNER JOIN project_{project_name}.folders
-                ON folders.id = products.folder_id
-                """,
-                f"""
-                LEFT JOIN project_{project_name}.exported_attributes AS pf_ex
-                ON folders.parent_id = pf_ex.folder_id
-                """,
-                f"""
-                INNER JOIN public.projects AS projects
-                ON projects.name ILIKE '{project_name}'
-                """,
-            ]
-        )
+        sql_columns.extend(folder_columns)
+        sql_joins.extend(folder_joins)
 
     #
     # Filter (actual product filter)

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -408,17 +408,6 @@ async def get_products(
             condition = " OR ".join(sub_conditions)
             sql_conditions.append(f"({condition})")
 
-    if (
-        use_folder_query
-        or "folder" in fields
-        or sort_by in ["folderName", "folderType"]
-    ):
-        folder_columns, folder_joins = get_folder_fields_block(
-            project_name, "products.folder_id", sql_joins=sql_joins
-        )
-        sql_columns.extend(folder_columns)
-        sql_joins.extend(folder_joins)
-
     #
     # Filter (actual product filter)
     #
@@ -474,6 +463,7 @@ async def get_products(
             column_map={"attrib": "folder_ex.attrib"},
         ):
             sql_conditions.append(fcond)
+            use_folder_query = True
 
     #
     # Filtering products by versions and tasks
@@ -578,6 +568,17 @@ async def get_products(
                 ON products.id = filtered_versions.product_id
                 """
             )
+
+    if (
+        use_folder_query
+        or "folder" in fields
+        or sort_by in ["folderName", "folderType"]
+    ):
+        folder_columns, folder_joins = get_folder_fields_block(
+            project_name, "products.folder_id", sql_joins=sql_joins
+        )
+        sql_columns.extend(folder_columns)
+        sql_joins.extend(folder_joins)
 
     #
     # Pagination

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -154,7 +154,7 @@ async def get_products(
     sql_columns = [
         "products.*",
         "hierarchy.path AS _folder_path",
-        "f_ex.attrib as inherited_attributes",
+        "folder_ex.attrib as inherited_attributes",
     ]
 
     sql_joins = [
@@ -691,6 +691,9 @@ async def get_products(
         field_stats = await generate_field_stats(query)
 
         return ProductsConnection(edges=[], field_stats=field_stats)
+
+    with open("/storage/server/projects/products.txt", "w") as f:
+        f.write(query)
 
     return await resolve(
         ProductsConnection,

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -406,7 +406,7 @@ async def get_products(
 
     if use_folder_query or "folder" in fields:
         folder_columns, folder_joins = get_folder_fields_block(
-            project_name, "products.folder_id"
+            project_name, "products.folder_id", sql_joins=sql_joins
         )
         sql_columns.extend(folder_columns)
         sql_joins.extend(folder_joins)
@@ -691,9 +691,6 @@ async def get_products(
         field_stats = await generate_field_stats(query)
 
         return ProductsConnection(edges=[], field_stats=field_stats)
-
-    with open("/storage/server/projects/products.txt", "w") as f:
-        f.write(query)
 
     return await resolve(
         ProductsConnection,

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -492,7 +492,7 @@ async def get_tasks(
     # Do we need the parent folder data?
     if use_folder_query or "folder" in fields or sort_by == "folderName":
         folder_columns, folder_joins = get_folder_fields_block(
-            project_name, "tasks.folder_id", is_inner=False
+            project_name, "tasks.folder_id", is_inner=False, sql_joins=sql_joins
         )
         sql_columns.extend(folder_columns)
         sql_joins.extend(folder_joins)

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -492,7 +492,7 @@ async def get_tasks(
     # Do we need the parent folder data?
     if use_folder_query or "folder" in fields or sort_by == "folderName":
         folder_columns, folder_joins = get_folder_fields_block(
-            project_name, "tasks.folder_id"
+            project_name, "tasks.folder_id", is_inner=False
         )
         sql_columns.extend(folder_columns)
         sql_joins.extend(folder_joins)

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -20,6 +20,7 @@ from ayon_server.graphql.resolvers.common import (
     ColumnMetadata,
     FieldInfo,
     argdesc,
+    create_child_folder_ctes,
     create_folder_access_list,
     get_has_links_conds,
     resolve,
@@ -291,31 +292,7 @@ async def get_tasks(
 
         if include_folder_children:
             use_folder_query = True
-            sql_cte.append(
-                f"""
-                top_folder_paths AS (
-                    SELECT path FROM project_{project_name}.hierarchy
-                    WHERE id IN {SQLTool.id_array(folder_ids)}
-                )
-                """
-            )
-
-            sql_cte.append(
-                f"""
-                child_folder_ids AS (
-                    SELECT id FROM project_{project_name}.hierarchy
-                    WHERE EXISTS (
-                        SELECT 1
-                        FROM top_folder_paths
-                        WHERE project_{project_name}.hierarchy.path
-                        LIKE top_folder_paths.path || '/%'
-                    )
-                    OR project_{project_name}.hierarchy.path = ANY (
-                        SELECT path FROM top_folder_paths
-                    )
-                )
-                """
-            )
+            sql_cte.extend(create_child_folder_ctes(project_name, folder_ids))
             sql_conditions.append(
                 "tasks.folder_id IN (SELECT id FROM child_folder_ids)"
             )

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -490,7 +490,7 @@ async def get_tasks(
     #
 
     # Do we need the parent folder data?
-    if use_folder_query or "folder" in fields:
+    if use_folder_query or "folder" in fields or sort_by == "folderName":
         folder_columns, folder_joins = get_folder_fields_block(
             project_name, "tasks.folder_id"
         )

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -22,6 +22,7 @@ from ayon_server.graphql.resolvers.common import (
     argdesc,
     create_child_folder_ctes,
     create_folder_access_list,
+    get_folder_fields_block,
     get_has_links_conds,
     resolve,
     sortdesc,
@@ -489,45 +490,11 @@ async def get_tasks(
 
     # Do we need the parent folder data?
     if use_folder_query or "folder" in fields:
-        sql_columns.extend(
-            [
-                "folders.id AS _folder_id",
-                "folders.name AS _folder_name",
-                "folders.label AS _folder_label",
-                "folders.folder_type AS _folder_folder_type",
-                "folders.thumbnail_id AS _folder_thumbnail_id",
-                "folders.parent_id AS _folder_parent_id",
-                "folders.attrib AS _folder_attrib",
-                "folders.data AS _folder_data",
-                "folders.active AS _folder_active",
-                "folders.status AS _folder_status",
-                "folders.tags AS _folder_tags",
-                "folders.created_at AS _folder_created_at",
-                "folders.updated_at AS _folder_updated_at",
-                "projects.attrib as _folder_project_attributes",
-                "pf_ex.attrib as _folder_inherited_attributes",
-            ]
+        folder_columns, folder_joins = get_folder_fields_block(
+            project_name, "tasks.folder_id"
         )
-
-        # Use inner join, tasks without folder cannot exist
-
-        sql_joins.extend(
-            [
-                f"""
-                INNER JOIN project_{project_name}.folders
-                ON folders.id = tasks.folder_id
-                """,
-                # but not here. parent's parent can be NULL
-                f"""
-                LEFT JOIN project_{project_name}.exported_attributes AS pf_ex
-                ON folders.parent_id = pf_ex.folder_id
-                """,
-                f"""
-                INNER JOIN public.projects AS projects
-                ON projects.name ILIKE '{project_name}'
-                """,
-            ]
-        )
+        sql_columns.extend(folder_columns)
+        sql_joins.extend(folder_joins)
 
     #
     # Pagination

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -184,6 +184,14 @@ async def get_versions(
         ON products.id = versions.product_id
         """,
         f"""
+        INNER JOIN project_{project_name}.exported_attributes AS folder_ex
+        ON folder_ex.folder_id = products.folder_id
+        """,
+        f"""
+        INNER JOIN project_{project_name}.folders AS folders
+        ON folders.id = products.folder_id
+        """,
+        f"""
         LEFT JOIN project_{project_name}.tasks AS tasks
         ON tasks.id = versions.task_id
         """,
@@ -196,13 +204,13 @@ async def get_versions(
         "products.name AS _product_name",
     ]
 
-    if "product" in fields:
+    if any("product" in str(field) for field in fields):
         product_columns, product_joins = get_product_fields_block()
         sql_columns.extend(product_columns)
         sql_joins.extend(product_joins)
 
         folder_columns, folder_joins = get_folder_fields_block(
-            project_name, "products.folder_id"
+            project_name, "products.folder_id", sql_joins=sql_joins
         )
         sql_columns.extend(folder_columns)
         sql_joins.extend(folder_joins)

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -364,68 +364,113 @@ async def get_versions(
 
     sql_cte.extend(
         [
+            # f"""
+            # latest_versions AS (
+            #     SELECT DISTINCT ON (product_id) id, version, product_id
+            #     FROM project_{project_name}.versions
+            #     WHERE version >= 0
+            #     ORDER BY product_id, creation_order DESC
+            # )
+            # """,
             f"""
-            latest_versions AS (
-                SELECT DISTINCT ON (product_id) id, version, product_id
-                FROM project_{project_name}.versions
-                WHERE version >= 0
-                ORDER BY product_id, creation_order DESC
-            )
-            """,
-            f"""
-            done_statuses AS (
+            done_statuses AS MATERIALIZED (
                 SELECT name from project_{project_name}.statuses
                 WHERE data->>'state' = 'done'
             )
             """,
+            # f"""
+            # latest_done_versions AS (
+            #     SELECT DISTINCT ON (v.product_id) v.id, v.version, v.product_id
+            #     FROM project_{project_name}.versions v
+            #     JOIN done_statuses ds
+            #     ON v.status = ds.name
+            #     WHERE v.version >= 0
+            #     ORDER BY v.product_id, v.creation_order DESC
+            # )
+            # """,
+            # f"""
+            # hero_versions AS (
+            #     SELECT version.id id, hero_version.id AS hero_version_id
+            #     FROM project_{project_name}.versions AS version
+            #     JOIN project_{project_name}.versions AS hero_version
+            #     ON hero_version.product_id = version.product_id
+            #     AND hero_version.version < 0
+            #     AND ABS(hero_version.version) = version.version
+            # )
+            # """,
+        ]
+    )
+
+    sql_joins.extend(
+        [
             f"""
-            latest_done_versions AS (
-                SELECT DISTINCT ON (v.product_id) v.id, v.version, v.product_id
-                FROM project_{project_name}.versions v
-                JOIN done_statuses ds
-                ON v.status = ds.name
-                WHERE v.version >= 0
-                ORDER BY v.product_id, v.creation_order DESC
-            )
+            LEFT JOIN LATERAL (
+                SELECT id
+                FROM project_{project_name}.versions lv_inner
+                WHERE lv_inner.product_id = versions.product_id
+                AND lv_inner.version >= 0
+                ORDER BY lv_inner.creation_order DESC
+                LIMIT 1
+            ) lv ON true
             """,
             f"""
-            hero_versions AS (
-                SELECT version.id id, hero_version.id AS hero_version_id
+            LEFT JOIN LATERAL (
+                SELECT v.id
+                FROM project_{project_name}.versions v
+                WHERE v.product_id = versions.product_id
+                AND v.version >= 0
+                AND v.status IN (SELECT name FROM done_statuses)
+                ORDER BY v.creation_order DESC
+                LIMIT 1
+            ) ldv ON true
+            """,
+            f"""
+            LEFT JOIN LATERAL (
+                SELECT version.id
                 FROM project_{project_name}.versions AS version
                 JOIN project_{project_name}.versions AS hero_version
-                ON hero_version.product_id = version.product_id
+                ON hero_version.product_id = versions.product_id
                 AND hero_version.version < 0
                 AND ABS(hero_version.version) = version.version
-            )
+                LIMIT 1
+            ) hv ON true
             """,
+        ]
+    )
+
+    sql_columns.extend(
+        [
+            "hv.id AS hero_version_id",
+            "lv IS NOT NULL AS is_latest",
+            "ldv IS NOT NULL AS is_latest_done",
         ]
     )
 
     # Map versions to their hero versions
 
-    sql_joins.append(
-        """
-        LEFT JOIN hero_versions
-        ON hero_versions.id = versions.id
-        """
-    )
-    sql_columns.append("hero_versions.hero_version_id AS hero_version_id")
-
-    sql_joins.append(
-        """
-        LEFT JOIN latest_versions AS lv
-        ON lv.id = versions.id
-        """
-    )
-    sql_columns.append("lv IS NOT NULL AS is_latest")
-
-    sql_joins.append(
-        """
-        LEFT JOIN latest_done_versions AS ldv
-        ON ldv.id = versions.id
-        """
-    )
-    sql_columns.append("ldv IS NOT NULL AS is_latest_done")
+    # sql_joins.append(
+    #     """
+    #     LEFT JOIN hero_versions
+    #     ON hero_versions.id = versions.id
+    #     """
+    # )
+    # sql_columns.append("hero_versions.hero_version_id AS hero_version_id")
+    #
+    # sql_joins.append(
+    #     """
+    #     LEFT JOIN latest_versions AS lv
+    #     ON lv.id = versions.id
+    #     """
+    # )
+    # sql_columns.append("lv IS NOT NULL AS is_latest")
+    #
+    # sql_joins.append(
+    #     """
+    #     LEFT JOIN latest_done_versions AS ldv
+    #     ON ldv.id = versions.id
+    #     """
+    # )
+    # sql_columns.append("ldv IS NOT NULL AS is_latest_done")
 
     #
     # Filtering by latest / hero versions
@@ -455,77 +500,22 @@ async def get_versions(
         if not featured_only:
             return VersionsConnection()
 
-        # for every product, select only one version based on the order
-        # of flags in featured_only.
-
-        where_clauses = []
-        order_clause = "CASE "
-        for idx, flag in enumerate(featured_only):
+        coalesce_args = []
+        for flag in featured_only:
             if flag not in ("hero", "latestDone", "latest"):
                 raise BadRequestException(
                     "Invalid featuredOnly value: "
                     f"'{flag}'. Must be one of 'hero', 'latestDone', 'latest'."
                 )
             if flag == "hero":
-                where_clauses.append("hv.id IS NOT NULL")
-                order_clause += f"WHEN hv.id IS NOT NULL THEN {idx} "
+                coalesce_args.append("hv.id")
             elif flag == "latestDone":
-                where_clauses.append("ldv.id IS NOT NULL")
-                order_clause += f"WHEN ldv.id IS NOT NULL THEN {idx} "
+                coalesce_args.append("ldv.id")
             elif flag == "latest":
-                where_clauses.append("lv.id IS NOT NULL")
-                order_clause += f"WHEN lv.id IS NOT NULL THEN {idx} "
+                coalesce_args.append("lv.id")
 
-        order_clause += f"ELSE {len(featured_only)} END"
-
-        if featured_only_entity_type == "product":
-            sql_cte.append(
-                f"""
-                featured_versions AS (
-                    SELECT DISTINCT ON (versions.product_id) versions.id
-                    FROM project_{project_name}.versions AS versions
-                    LEFT JOIN latest_versions AS lv
-                    ON lv.id = versions.id
-                    LEFT JOIN latest_done_versions AS ldv
-                    ON ldv.id = versions.id
-                    LEFT JOIN hero_versions AS hv
-                    ON hv.id = versions.id
-                    WHERE {" OR ".join(where_clauses)}
-                    ORDER BY versions.product_id, {order_clause}
-                )
-                """
-            )
-        elif featured_only_entity_type == "folder":
-            sql_cte.append(
-                f"""
-                featured_versions AS (
-                    SELECT DISTINCT ON (products.folder_id) versions.id
-                    FROM project_{project_name}.versions AS versions
-                    JOIN project_{project_name}.products AS products
-                    ON products.id = versions.product_id
-                    LEFT JOIN latest_versions AS lv
-                    ON lv.id = versions.id
-                    LEFT JOIN latest_done_versions AS ldv
-                    ON ldv.id = versions.id
-                    LEFT JOIN hero_versions AS hv
-                    ON hv.id = versions.id
-                    WHERE {" OR ".join(where_clauses)}
-                    ORDER BY products.folder_id, {order_clause}
-                )
-                """
-            )
-        else:
-            raise BadRequestException(
-                "Invalid featuredByEntity value: "
-                f"'{featured_only_entity_type}'. Must be one of 'product', 'folder'."
-            )
-
-        sql_joins.append(
-            """
-            INNER JOIN featured_versions AS fv
-            ON fv.id = versions.id
-            """
-        )
+        # versions.id must equal whichever candidate wins by flag priority order
+        sql_conditions.append(f"versions.id = COALESCE({', '.join(coalesce_args)})")
 
     #
     # Filtering by links
@@ -835,11 +825,10 @@ async def get_versions(
         {raw_data_end}
     """
 
-    # print()
-    # print("Versions query:")
-    # print(query)
-    # print()
-    #
+    print()
+    print("Versions query:")
+    print(query)
+    print()
 
     if stats_select_clause:
         field_stats = await generate_field_stats(query)

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -196,7 +196,7 @@ async def get_versions(
     ]
 
     folder_columns, folder_joins = get_folder_fields_block(
-        project_name, "tasks.folder_id"
+        project_name, "products.folder_id"
     )
     sql_columns.extend(folder_columns)
     sql_joins.extend(folder_joins)

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -359,46 +359,16 @@ async def get_versions(
             )
 
     #
-    # Always-on CTEs (to get latest and hero versions)
+    # Latest / latest done / hero versions logic
     #
 
-    sql_cte.extend(
-        [
-            # f"""
-            # latest_versions AS (
-            #     SELECT DISTINCT ON (product_id) id, version, product_id
-            #     FROM project_{project_name}.versions
-            #     WHERE version >= 0
-            #     ORDER BY product_id, creation_order DESC
-            # )
-            # """,
-            f"""
-            done_statuses AS MATERIALIZED (
-                SELECT name from project_{project_name}.statuses
-                WHERE data->>'state' = 'done'
-            )
-            """,
-            # f"""
-            # latest_done_versions AS (
-            #     SELECT DISTINCT ON (v.product_id) v.id, v.version, v.product_id
-            #     FROM project_{project_name}.versions v
-            #     JOIN done_statuses ds
-            #     ON v.status = ds.name
-            #     WHERE v.version >= 0
-            #     ORDER BY v.product_id, v.creation_order DESC
-            # )
-            # """,
-            # f"""
-            # hero_versions AS (
-            #     SELECT version.id id, hero_version.id AS hero_version_id
-            #     FROM project_{project_name}.versions AS version
-            #     JOIN project_{project_name}.versions AS hero_version
-            #     ON hero_version.product_id = version.product_id
-            #     AND hero_version.version < 0
-            #     AND ABS(hero_version.version) = version.version
-            # )
-            # """,
-        ]
+    sql_cte.append(
+        f"""
+        done_statuses AS MATERIALIZED (
+            SELECT name from project_{project_name}.statuses
+            WHERE data->>'state' = 'done'
+        )
+        """
     )
 
     sql_joins.extend(
@@ -445,32 +415,6 @@ async def get_versions(
             "ldv IS NOT NULL AS is_latest_done",
         ]
     )
-
-    # Map versions to their hero versions
-
-    # sql_joins.append(
-    #     """
-    #     LEFT JOIN hero_versions
-    #     ON hero_versions.id = versions.id
-    #     """
-    # )
-    # sql_columns.append("hero_versions.hero_version_id AS hero_version_id")
-    #
-    # sql_joins.append(
-    #     """
-    #     LEFT JOIN latest_versions AS lv
-    #     ON lv.id = versions.id
-    #     """
-    # )
-    # sql_columns.append("lv IS NOT NULL AS is_latest")
-    #
-    # sql_joins.append(
-    #     """
-    #     LEFT JOIN latest_done_versions AS ldv
-    #     ON ldv.id = versions.id
-    #     """
-    # )
-    # sql_columns.append("ldv IS NOT NULL AS is_latest_done")
 
     #
     # Filtering by latest / hero versions

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -16,6 +16,7 @@ from ayon_server.graphql.resolvers.common import (
     ColumnMetadata,
     FieldInfo,
     argdesc,
+    create_child_folder_ctes,
     create_folder_access_list,
     get_has_links_conds,
     resolve,
@@ -317,30 +318,7 @@ async def get_versions(
             return VersionsConnection()
 
         if include_folder_children:
-            sql_cte.append(
-                f"""
-                top_folder_paths AS (
-                    SELECT path FROM project_{project_name}.hierarchy
-                    WHERE id IN {SQLTool.id_array(folder_ids)}
-                )
-                """
-            )
-
-            sql_cte.append(
-                f"""
-                child_folder_ids AS (
-                    SELECT id FROM project_{project_name}.hierarchy
-                    WHERE EXISTS (
-                        SELECT 1 FROM top_folder_paths
-                        WHERE project_{project_name}.hierarchy.path
-                        LIKE top_folder_paths.path || '/%'
-                    )
-                    OR project_{project_name}.hierarchy.path = ANY(
-                        SELECT path FROM top_folder_paths
-                    )
-                )
-                """
-            )
+            sql_cte.extend(create_child_folder_ctes(project_name, folder_ids))
 
             sql_joins.append(
                 """

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -114,6 +114,10 @@ async def get_versions(
         bool | None,
         argdesc("Filter versions that have reviewables"),
     ] = None,
+    has_hero: Annotated[
+        bool | None,
+        argdesc("Filter versions that have a hero version"),
+    ] = None,
     featured_only: Annotated[
         list[str] | None,
         argdesc(
@@ -411,14 +415,12 @@ async def get_versions(
                 f"""
                 LEFT JOIN LATERAL (
                     SELECT
-                        versions_inner.id AS id,
+                        versions.id AS id,
                         hero_versions.id AS hero_version_id
-                    FROM project_{project_name}.versions AS versions_inner
-                    JOIN project_{project_name}.versions AS hero_versions
-                    ON hero_versions.product_id = versions.product_id
+                    FROM project_{project_name}.versions AS hero_versions
+                    WHERE hero_versions.product_id = versions.product_id
                     AND hero_versions.version < 0
-                    AND ABS(hero_versions.version) = versions_inner.version
-                    WHERE versions_inner.product_id = versions.product_id   -- add this
+                    AND ABS(hero_versions.version) = versions.version
                     LIMIT 1
                 ) hv ON true
                 """,
@@ -452,6 +454,9 @@ async def get_versions(
         # The frontend uses new featuredVersion filter instead
 
         sql_conditions.append("(versions.version < 0 OR lv IS NOT NULL)")
+
+    elif has_hero:
+        sql_conditions.append("hv.id IS NOT NULL")
 
     #
     # Filtering by featured versions
@@ -608,7 +613,7 @@ async def get_versions(
                 "product_base_type": product_base_type_expr,
                 "task_type": "tasks.task_type",
                 "folder_type": "folders.folder_type",
-                "hero_version_id": "hero_versions.hero_version_id",
+                "hero_version_id": "hv.hero_version_id",
             },
         ):
             sql_conditions.append(fcond)

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -362,59 +362,71 @@ async def get_versions(
     # Latest / latest done / hero versions logic
     #
 
-    sql_cte.append(
-        f"""
-        done_statuses AS MATERIALIZED (
-            SELECT name from project_{project_name}.statuses
-            WHERE data->>'state' = 'done'
+    if (
+        fields.any_endswith("isLatest")
+        or fields.any_endswith("isLatestDone")
+        or fields.any_endswith("heroVersionId")
+        or latest_only
+        or hero_only
+        or hero_or_latest_only
+        or featured_only
+    ):
+        sql_cte.append(
+            f"""
+            done_statuses AS MATERIALIZED (
+                SELECT name from project_{project_name}.statuses
+                WHERE data->>'state' = 'done'
+            )
+            """
         )
-        """
-    )
 
-    sql_joins.extend(
-        [
-            f"""
-            LEFT JOIN LATERAL (
-                SELECT id
-                FROM project_{project_name}.versions lv_inner
-                WHERE lv_inner.product_id = versions.product_id
-                AND lv_inner.version >= 0
-                ORDER BY lv_inner.creation_order DESC
-                LIMIT 1
-            ) lv ON true
-            """,
-            f"""
-            LEFT JOIN LATERAL (
-                SELECT v.id
-                FROM project_{project_name}.versions v
-                WHERE v.product_id = versions.product_id
-                AND v.version >= 0
-                AND v.status IN (SELECT name FROM done_statuses)
-                ORDER BY v.creation_order DESC
-                LIMIT 1
-            ) ldv ON true
-            """,
-            f"""
-            LEFT JOIN LATERAL (
-                SELECT version.id
-                FROM project_{project_name}.versions AS version
-                JOIN project_{project_name}.versions AS hero_version
-                ON hero_version.product_id = versions.product_id
-                AND hero_version.version < 0
-                AND ABS(hero_version.version) = version.version
-                LIMIT 1
-            ) hv ON true
-            """,
-        ]
-    )
+        sql_joins.extend(
+            [
+                f"""
+                LEFT JOIN LATERAL (
+                    SELECT id
+                    FROM project_{project_name}.versions lv_inner
+                    WHERE lv_inner.product_id = versions.product_id
+                    AND lv_inner.version >= 0
+                    ORDER BY lv_inner.creation_order DESC
+                    LIMIT 1
+                ) lv ON true
+                """,
+                f"""
+                LEFT JOIN LATERAL (
+                    SELECT v.id
+                    FROM project_{project_name}.versions v
+                    WHERE v.product_id = versions.product_id
+                    AND v.version >= 0
+                    AND v.status IN (SELECT name FROM done_statuses)
+                    ORDER BY v.creation_order DESC
+                    LIMIT 1
+                ) ldv ON true
+                """,
+                f"""
+                LEFT JOIN LATERAL (
+                    SELECT
+                        versions_inner.id AS id,
+                        hero_versions.id AS hero_version_id
+                    FROM project_{project_name}.versions AS versions_inner
+                    JOIN project_{project_name}.versions AS hero_versions
+                    ON hero_versions.product_id = versions.product_id
+                    AND hero_versions.version < 0
+                    AND ABS(hero_versions.version) = versions_inner.version
+                    WHERE versions_inner.product_id = versions.product_id   -- add this
+                    LIMIT 1
+                ) hv ON true
+                """,
+            ]
+        )
 
-    sql_columns.extend(
-        [
-            "hv.id AS hero_version_id",
-            "lv IS NOT NULL AS is_latest",
-            "ldv IS NOT NULL AS is_latest_done",
-        ]
-    )
+        sql_columns.extend(
+            [
+                "hv.hero_version_id AS hero_version_id",
+                "lv IS NOT NULL AS is_latest",
+                "ldv IS NOT NULL AS is_latest_done",
+            ]
+        )
 
     #
     # Filtering by latest / hero versions
@@ -426,7 +438,7 @@ async def get_versions(
 
     elif hero_only:
         # This returns actual (negative) hero versions only
-        # Not versions that point to hero via hero_versions CTE
+        # Not versions that point to hero via hero_versions
         sql_conditions.append("versions.version < 0")
 
     elif hero_or_latest_only:
@@ -446,17 +458,17 @@ async def get_versions(
 
         coalesce_args = []
         for flag in featured_only:
-            if flag not in ("hero", "latestDone", "latest"):
-                raise BadRequestException(
-                    "Invalid featuredOnly value: "
-                    f"'{flag}'. Must be one of 'hero', 'latestDone', 'latest'."
-                )
             if flag == "hero":
                 coalesce_args.append("hv.id")
             elif flag == "latestDone":
                 coalesce_args.append("ldv.id")
             elif flag == "latest":
                 coalesce_args.append("lv.id")
+            else:
+                raise BadRequestException(
+                    "Invalid featuredOnly value: "
+                    f"'{flag}'. Must be one of 'hero', 'latestDone', 'latest'."
+                )
 
         # versions.id must equal whichever candidate wins by flag priority order
         sql_conditions.append(f"versions.id = COALESCE({', '.join(coalesce_args)})")

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -123,6 +123,10 @@ async def get_versions(
             "heroOnly, latestOnly and heroOrLatestOnly"
         ),
     ] = None,
+    featured_only_entity_type: Annotated[
+        str,
+        argdesc("Deprecated and noop"),
+    ] = "product",
     latest_per_folder: Annotated[
         bool,
         argdesc(

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -18,6 +18,7 @@ from ayon_server.graphql.resolvers.common import (
     argdesc,
     create_child_folder_ctes,
     create_folder_access_list,
+    get_folder_fields_block,
     get_has_links_conds,
     resolve,
     sortdesc,
@@ -182,14 +183,6 @@ async def get_versions(
         ON products.id = versions.product_id
         """,
         f"""
-        INNER JOIN project_{project_name}.exported_attributes AS folder_ex
-        ON folder_ex.folder_id = products.folder_id
-        """,
-        f"""
-        INNER JOIN project_{project_name}.folders AS folders
-        ON folders.id = products.folder_id
-        """,
-        f"""
         LEFT JOIN project_{project_name}.tasks AS tasks
         ON tasks.id = versions.task_id
         """,
@@ -201,6 +194,12 @@ async def get_versions(
         "folder_ex.path AS _folder_path",
         "products.name AS _product_name",
     ]
+
+    folder_columns, folder_joins = get_folder_fields_block(
+        project_name, "tasks.folder_id"
+    )
+    sql_columns.extend(folder_columns)
+    sql_joins.extend(folder_joins)
 
     if fields.any_endswith("latestComments"):
         sql_cte.append(

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -808,10 +808,10 @@ async def get_versions(
         {raw_data_end}
     """
 
-    print()
-    print("Versions query:")
-    print(query)
-    print()
+    # print()
+    # print("Versions query:")
+    # print(query)
+    # print()
 
     if stats_select_clause:
         field_stats = await generate_field_stats(query)

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -20,6 +20,7 @@ from ayon_server.graphql.resolvers.common import (
     create_folder_access_list,
     get_folder_fields_block,
     get_has_links_conds,
+    get_product_fields_block,
     resolve,
     sortdesc,
 )
@@ -195,11 +196,16 @@ async def get_versions(
         "products.name AS _product_name",
     ]
 
-    folder_columns, folder_joins = get_folder_fields_block(
-        project_name, "products.folder_id"
-    )
-    sql_columns.extend(folder_columns)
-    sql_joins.extend(folder_joins)
+    if "product" in fields:
+        product_columns, product_joins = get_product_fields_block()
+        sql_columns.extend(product_columns)
+        sql_joins.extend(product_joins)
+
+        folder_columns, folder_joins = get_folder_fields_block(
+            project_name, "products.folder_id"
+        )
+        sql_columns.extend(folder_columns)
+        sql_joins.extend(folder_joins)
 
     if fields.any_endswith("latestComments"):
         sql_cte.append(

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -123,15 +123,6 @@ async def get_versions(
             "heroOnly, latestOnly and heroOrLatestOnly"
         ),
     ] = None,
-    featured_only_entity_type: Annotated[
-        str,
-        argdesc(
-            """
-            Specify entity type to group featured versions
-            (either product or folder).
-            """
-        ),
-    ] = "product",
     has_links: ARGHasLinks = None,
     search: Annotated[
         str | None,

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -181,6 +181,8 @@ async def get_versions(
     user = info.context["user"]
     fields = FieldInfo(info, ["versions.edges.node", "version"])
 
+    use_folder_query = False
+
     #
     # SQL
     #
@@ -212,17 +214,6 @@ async def get_versions(
         "folder_ex.path AS _folder_path",
         "products.name AS _product_name",
     ]
-
-    if any("product" in str(field) for field in fields):
-        product_columns, product_joins = get_product_fields_block()
-        sql_columns.extend(product_columns)
-        sql_joins.extend(product_joins)
-
-        folder_columns, folder_joins = get_folder_fields_block(
-            project_name, "products.folder_id", sql_joins=sql_joins
-        )
-        sql_columns.extend(folder_columns)
-        sql_joins.extend(folder_joins)
 
     if fields.any_endswith("latestComments"):
         sql_cte.append(
@@ -701,6 +692,7 @@ async def get_versions(
             column_map={"attrib": "folder_ex.attrib"},
         ):
             sql_conditions.append(fcond)
+            use_folder_query = True
 
     #
     # Latest version per folder (from the set matching all filters above)
@@ -727,6 +719,17 @@ async def get_versions(
         # Every condition above is already baked into latest_matching_versions,
         # so the outer query only needs to look rows up by id (primary key).
         sql_conditions = []
+
+    if any("product" in str(field) for field in fields) or use_folder_query:
+        product_columns, product_joins = get_product_fields_block()
+        sql_columns.extend(product_columns)
+        sql_joins.extend(product_joins)
+
+        folder_columns, folder_joins = get_folder_fields_block(
+            project_name, "products.folder_id", sql_joins=sql_joins
+        )
+        sql_columns.extend(folder_columns)
+        sql_joins.extend(folder_joins)
 
     #
     # Pagination

--- a/maintenance/tasks/add_missing_project_indexes.py
+++ b/maintenance/tasks/add_missing_project_indexes.py
@@ -17,6 +17,7 @@ INDEXES = {
     "version_status_idx": "versions(status);",
     "version_parent_version_idx": "versions(product_id, version DESC);",
     "version_attrib_idx": "versions USING gin(attrib);",
+    "version_product_corder_idx": "versions(product_id, creation_order DESC) WHERE version >= 0;",  # noqa: E501
     "version_product_status_corder_idx": "versions(product_id, status, creation_order DESC) WHERE version >= 0;",  # noqa: E501
     "representation_status_idx": "representations(status);",
     "representation_attrib_idx": "representations USING gin(attrib);",

--- a/maintenance/tasks/add_missing_project_indexes.py
+++ b/maintenance/tasks/add_missing_project_indexes.py
@@ -17,6 +17,7 @@ INDEXES = {
     "version_status_idx": "versions(status);",
     "version_parent_version_idx": "versions(product_id, version DESC);",
     "version_attrib_idx": "versions USING gin(attrib);",
+    "version_product_status_corder_idx": "versions(product_id, status, creation_order DESC) WHERE version >= 0;",  # noqa: E501
     "representation_status_idx": "representations(status);",
     "representation_attrib_idx": "representations USING gin(attrib);",
     "activity_origin_desc_idx": "activity_references (entity_type, entity_id, created_at DESC) WHERE reference_type = 'origin';",  # noqa: E501

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -332,6 +332,7 @@ CREATE INDEX version_thumbnail_idx ON versions(thumbnail_id);
 CREATE INDEX version_task_id_idx ON versions(task_id);
 CREATE INDEX version_status_idx ON versions(status);
 CREATE INDEX version_attrib_idx ON versions USING gin(attrib);
+CREATE INDEX version_product_status_corder_idx ON versions(product_id, status, creation_order DESC) WHERE version >= 0;
 CREATE UNIQUE INDEX version_creation_order_idx ON versions(creation_order);
 CREATE UNIQUE INDEX version_unique_version_parent ON versions (product_id, version) WHERE (active IS TRUE);
 

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -332,6 +332,7 @@ CREATE INDEX version_thumbnail_idx ON versions(thumbnail_id);
 CREATE INDEX version_task_id_idx ON versions(task_id);
 CREATE INDEX version_status_idx ON versions(status);
 CREATE INDEX version_attrib_idx ON versions USING gin(attrib);
+CREATE INDEX version_product_corder_idx ON versions(product_id, creation_order DESC) WHERE version >= 0;
 CREATE INDEX version_product_status_corder_idx ON versions(product_id, status, creation_order DESC) WHERE version >= 0;
 CREATE UNIQUE INDEX version_creation_order_idx ON versions(creation_order);
 CREATE UNIQUE INDEX version_unique_version_parent ON versions (product_id, version) WHERE (active IS TRUE);


### PR DESCRIPTION
## Description of changes

This PR should increase performance of `products` and `versions` graphQL resolvers in regards of folder data information.

Contains couple of new helper methods to clean up code.

WIP for discussion.