### PR TITLE
EntityLists: Delete list items in merge mode

### DIFF
--- a/api/entity_lists/entity_list_items.py
+++ b/api/entity_lists/entity_list_items.py
@@ -124,19 +124,22 @@ async def _multi_merge(
 
     for i, item in enumerate(payload):
         if item.id in existing_ids:
-            pos = i if item.position is None else item.position
-            patched_fields = item.dict(exclude_unset=True).keys()
-            await entity_list.update(
-                item.id,
-                entity_id=item.entity_id,
-                position=pos,
-                label=item.label if "label" in patched_fields else None,
-                attrib=item.attrib if "attrib" in patched_fields else None,
-                data=item.data if "data" in patched_fields else None,
-                tags=item.tags if "tags" in patched_fields else None,
-                normalize_positions=False,
-                merge_fields=True,
-            )
+            if item.entity_id is None:
+                await entity_list.remove(item.id)
+            else:
+                pos = i if item.position is None else item.position
+                patched_fields = item.dict(exclude_unset=True).keys()
+                await entity_list.update(
+                    item.id,
+                    entity_id=item.entity_id,
+                    position=pos,
+                    label=item.label if "label" in patched_fields else None,
+                    attrib=item.attrib if "attrib" in patched_fields else None,
+                    data=item.data if "data" in patched_fields else None,
+                    tags=item.tags if "tags" in patched_fields else None,
+                    normalize_positions=False,
+                    merge_fields=True,
+                )
 
         else:
             if not item.entity_id:

--- a/api/entity_lists/entity_list_items.py
+++ b/api/entity_lists/entity_list_items.py
@@ -126,6 +126,7 @@ async def _multi_merge(
         if item.id in existing_ids:
             if item.entity_id is None:
                 await entity_list.remove(item.id)
+                existing_ids.pop(item.id, None)
             else:
                 pos = i if item.position is None else item.position
                 patched_fields = item.dict(exclude_unset=True).keys()

--- a/api/entity_lists/entity_list_items.py
+++ b/api/entity_lists/entity_list_items.py
@@ -126,7 +126,7 @@ async def _multi_merge(
         if item.id in existing_ids:
             if item.entity_id is None:
                 await entity_list.remove(item.id)
-                existing_ids.pop(item.id, None)
+                existing_ids.remove(item.id)
             else:
                 pos = i if item.position is None else item.position
                 patched_fields = item.dict(exclude_unset=True).keys()
@@ -160,6 +160,9 @@ async def _multi_merge(
                 tags=item.tags,
                 normalize_positions=False,
             )
+
+            if item.id:
+                existing_ids.add(item.id)
 
     entity_list.items.sort(key=lambda item: item.position)
     entity_list.normalize_positions()

--- a/api/entity_lists/entity_list_items.py
+++ b/api/entity_lists/entity_list_items.py
@@ -124,23 +124,24 @@ async def _multi_merge(
 
     for i, item in enumerate(payload):
         if item.id in existing_ids:
-            if item.entity_id is None:
-                await entity_list.remove(item.id)
+            patched_fields = item.dict(exclude_unset=True).keys()
+            if "entity_id" in patched_fields and item.entity_id is None:
+                await entity_list.remove(item.id, normalize_positions=False)
                 existing_ids.remove(item.id)
-            else:
-                pos = i if item.position is None else item.position
-                patched_fields = item.dict(exclude_unset=True).keys()
-                await entity_list.update(
-                    item.id,
-                    entity_id=item.entity_id,
-                    position=pos,
-                    label=item.label if "label" in patched_fields else None,
-                    attrib=item.attrib if "attrib" in patched_fields else None,
-                    data=item.data if "data" in patched_fields else None,
-                    tags=item.tags if "tags" in patched_fields else None,
-                    normalize_positions=False,
-                    merge_fields=True,
-                )
+                continue
+
+            pos = i if item.position is None else item.position
+            await entity_list.update(
+                item.id,
+                entity_id=item.entity_id,
+                position=pos,
+                label=item.label if "label" in patched_fields else None,
+                attrib=item.attrib if "attrib" in patched_fields else None,
+                data=item.data if "data" in patched_fields else None,
+                tags=item.tags if "tags" in patched_fields else None,
+                normalize_positions=False,
+                merge_fields=True,
+            )
 
         else:
             if not item.entity_id:

--- a/ayon_server/entity_lists/entity_list.py
+++ b/ayon_server/entity_lists/entity_list.py
@@ -331,12 +331,13 @@ class EntityList:
             # Tags are always replaced, not merged
             item.tags = tags
 
-    async def remove(self, item_id: str) -> None:
+    async def remove(self, item_id: str, *, normalize_positions: bool = True) -> None:
         """Remove an item from the list"""
         for i, item in enumerate(self._payload.items):
             if item.id == item_id:
                 del self._payload.items[i]
-                self.normalize_positions()
+                if normalize_positions:
+                    self.normalize_positions()
                 return
         raise NotFoundException(f"Item ID {item_id} not found in {self._payload.label}")
 


### PR DESCRIPTION
## Description of changes

Allows deletion of `entity_list_item` in `merge` mode if `entity_id` is `None`. 

