### PR TITLE
Fix sorting by Folder Name in tasks resolver

### DIFF
--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -58,7 +58,7 @@ SORT_OPTIONS = {
     "updatedAt": "tasks.updated_at",
     "createdBy": "tasks.created_by",
     "updatedBy": "tasks.updated_by",
-    "folder": "folders.name",
+    "folderName": "folders.name",
 }
 
 

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -512,7 +512,7 @@ async def get_tasks(
     #
 
     # Do we need the parent folder data?
-    if use_folder_query or "folder" in fields or sort_by == "folder":
+    if use_folder_query or "folder" in fields or sort_by == "folderName":
         sql_columns.extend(
             [
                 "folders.id AS _folder_id",

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -58,6 +58,7 @@ SORT_OPTIONS = {
     "updatedAt": "tasks.updated_at",
     "createdBy": "tasks.created_by",
     "updatedBy": "tasks.updated_by",
+    "folder": "folders.name",
 }
 
 
@@ -511,7 +512,7 @@ async def get_tasks(
     #
 
     # Do we need the parent folder data?
-    if use_folder_query or "folder" in fields:
+    if use_folder_query or "folder" in fields or sort_by == "folder":
         sql_columns.extend(
             [
                 "folders.id AS _folder_id",


### PR DESCRIPTION
## Description of changes

PR solves issue when particular folder is used in `Slicer` in `Overview` tab and then subfolders (and tasks) are sorted by `Folder Name`.


### Technical details

<img width="608" height="325" alt="image" src="https://github.com/user-attachments/assets/f4ba4bdd-b083-4f37-b9af-bf02dd237784" />
