### PR TITLE
Added entity_list_folder_id  to list edit summary

### DIFF
--- a/ayon_server/entity_lists/models.py
+++ b/ayon_server/entity_lists/models.py
@@ -215,6 +215,7 @@ class EntityListPatchModel(OPModel):
 class EntityListSummary(OPModel):
     id: Annotated[str, FListID]
     entity_list_type: Annotated[str, FListType]
+    entity_list_folder_id: Annotated[str | None, FFolderID] = None
     entity_type: Annotated[ProjectLevelEntityType, FListEntityType]
     label: Annotated[str, FListLabel]
     count: Annotated[int, Field(title="Item count", ge=0)] = 0

--- a/ayon_server/entity_lists/save_entity_list.py
+++ b/ayon_server/entity_lists/save_entity_list.py
@@ -153,6 +153,7 @@ async def save_entity_list(
     summary = EntityListSummary(
         id=payload.id,
         entity_list_type=payload.entity_list_type,
+        entity_list_folder_id=payload.entity_list_folder_id,
         entity_type=payload.entity_type,
         label=payload.label,
         count=len(payload.items),


### PR DESCRIPTION
## Description of changes

Adds 'entity_list_folder_id' field to summary of `entity_list` update event.

<img width="253" height="81" alt="image" src="https://github.com/user-attachments/assets/e6db75e9-95a1-43a7-81e1-4b1f0e1644fb" />


## Testing notes
Add `entity_list` into folder, change its name, check event `summary`.