### PR TITLE
Add fallback anonymous guest avatar style

### DIFF
--- a/api/users/avatar.py
+++ b/api/users/avatar.py
@@ -82,6 +82,33 @@ def create_initials_svg(
     return svg_template.strip()
 
 
+def create_anonymous_svg(
+    name: str,
+    width: int = 100,
+    height: int = 100,
+    text_color: str = "white",
+) -> str:
+    bg_color = generate_color(f"{name}")
+
+    svg_template = f"""
+    <svg width="{width}" height="{height}" xmlns="http://www.w3.org/2000/svg">
+      <rect width="100%" height="100%" fill="{bg_color}"/>
+      <g
+        fill="none"
+        stroke="{text_color}"
+        stroke-width="6"
+        transform="scale(0.75) translate(0 -2)"
+        transform-origin="center"
+      >
+        <circle cx="50" cy="30" r="15" />
+        <path d="M 20 85 L 80 85 A 30 30, 0, 0, 0, 20 85 Z" />
+      </g>
+    </svg>
+    """
+
+    return svg_template.strip()
+
+
 async def load_avatar_file(user_name: str) -> bytes:
     """
     Load the avatar file for a given user.
@@ -134,6 +161,8 @@ async def obtain_avatar(user_name: str) -> bytes:
     )
 
     if not res:
+        if user_name.startswith("anonymous.guest."):
+            return create_anonymous_svg(user_name).encode()
         if user_name.startswith("guest."):
             # We cannot get full name for guests users,
             # as we do not know the current project.


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [ ] Referenced issue is linked

## Description of changes

Adds a fallback anonymous guest avatar in case the frontend doesn't have access to the user's full name.

### Technical details

Currently if anonymous guests (usernames starting with `anonymous.guest.`) enter AYON, there are lots of instances of the `UserImage` and `UserImagesStacked` components which should show their avatar. Because they don't have an avatar, but they **also don't have a proper username**, this means their avatar will currently show a weird combination of letters and numbers corresponding to their unique ID.

In some cases, we were able to easily address this on the frontend by checking if the user is an anonymous guest and **not passing the `src` prop to `UserImage`**. However, in lots of places a wrapper of `UserImage` is used which doesn't support the `src` prop. Some of these are quite hard to change for various reasons.

This PR adds a fallback avatar provided by the server which will show instead of the auto-generated initials for anonymous guests. Wherever the frontend is able to catch this and provide the correct initials, that'll still happen. But where it can't, we'll now show the fallback avatar:

<img width="509" height="383" alt="image" src="https://github.com/user-attachments/assets/485d4e5d-f92c-4ae5-81cc-3b78438f360d" />

This is by no means ideal but will let us get public links out of the door and ensure there are no weird avatars showing.

### Additional context

<!-- Add any other context or screenshots here. -->
