### PR TITLE
emit events on dependency package and installer uploads

### DIFF
--- a/api/desktop/deps.py
+++ b/api/desktop/deps.py
@@ -254,6 +254,15 @@ async def upload_dependency_package(
         raise AyonException("Filename in manifest does not match")
 
     await handle_upload(request, manifest.local_file_path)
+
+    await EventStream.dispatch(
+        "dependency_package.install",
+        description=f"Installed dependency_package: {filename}",
+        summary={"filename": filename},
+        user=user.name,
+        finished=True,
+    )
+
     await Redis.delete("desktop", "dependency-packages")
     return EmptyResponse(status_code=204)
 

--- a/api/desktop/deps.py
+++ b/api/desktop/deps.py
@@ -254,6 +254,7 @@ async def upload_dependency_package(
         raise AyonException("Filename in manifest does not match")
 
     await handle_upload(request, manifest.local_file_path)
+    await Redis.delete("desktop", "dependency-packages")
 
     await EventStream.dispatch(
         "dependency_package.install",
@@ -263,7 +264,6 @@ async def upload_dependency_package(
         finished=True,
     )
 
-    await Redis.delete("desktop", "dependency-packages")
     return EmptyResponse(status_code=204)
 
 

--- a/api/desktop/installers.py
+++ b/api/desktop/installers.py
@@ -233,7 +233,16 @@ async def upload_installer_file(user: CurrentUser, request: Request, filename: s
     if manifest.filename != filename:
         raise AyonException("Filename in manifest does not match")
 
-    return await handle_upload(request, manifest.local_file_path)
+    response = await handle_upload(request, manifest.local_file_path)
+
+    await EventStream.dispatch(
+        "installer.install",
+        description=f"Installed installer: {filename}",
+        summary={"filename": filename},
+        user=user.name,
+        finished=True,
+    )
+    return response
 
 
 @router.delete("/installers/{filename}", status_code=204)


### PR DESCRIPTION
## Description of changes

added `dependency_package.install` and `installer.install` events to the respective ``put` endpoints

### Technical details

for addons there is `addon.install_from_url` and `addon.install`.
This PR attempts to mirror the same events for dependecy_packages and installers

### Additional context

<img width="883" height="100" alt="image" src="https://github.com/user-attachments/assets/a51cd035-99bb-4499-9391-5fdb58f2f957" />


example `installer.install` event

```json
{
  "id": "00a1b43c91f211f18766b6578b830e54",
  "hash": "00a1b43c91f211f18766b6578b830e54",
  "topic": "installer.install",
  "sender": "ebE6MYNDH1NwundySqp2NN",
  "senderType": "api",
  "project": null,
  "user": "vincent",
  "dependsOn": null,
  "status": "finished",
  "retries": 0,
  "description": "Installed installer: AYON-1.5.4-macos.dmg",
  "summary": {
    "filename": "AYON-1.5.4-macos.dmg"
  },
  "payload": {},
  "createdAt": "2026-08-07T00:53:20.391040+01:00",
  "updatedAt": "2026-08-07T00:53:20.391040+01:00"
}
```

example `dependency_package.install`
```json
{
  "id": "08e04a0091f211f18766b6578b830e54",
  "hash": "08e04a0091f211f18766b6578b830e54",
  "topic": "dependency_package.install",
  "sender": "ebE6MYNDH1NwundySqp2NN",
  "senderType": "api",
  "project": null,
  "user": "vincent",
  "dependsOn": null,
  "status": "finished",
  "retries": 0,
  "description": "Installed dependency_package: ayon_2602190031_linux-rocky9.zip",
  "summary": {
    "filename": "ayon_2602190031_linux-rocky9.zip"
  },
  "payload": {},
  "createdAt": "2026-08-07T00:53:34.223094+01:00",
  "updatedAt": "2026-08-07T00:53:34.223094+01:00"
}
```
