### PR TITLE
Changed allowed length of task type to 2 not 3

### DIFF
--- a/ayon_server/types.py
+++ b/ayon_server/types.py
@@ -71,7 +71,7 @@ LABEL_REGEX = r"^[^';]*$"
 NAME_REGEX = r"^[a-zA-Z0-9_]([a-zA-Z0-9_\.\-]*[a-zA-Z0-9_])?$"
 # statuses and type names (folder type, task type) can also contain spaces
 STATUS_REGEX = r"^[a-zA-Z0-9_][a-zA-Z0-9_ \-]{1,64}[a-zA-Z0-9_]$"
-TYPE_NAME_REGEX = r"^[a-zA-Z0-9_][a-zA-Z0-9_ \-]{1,64}[a-zA-Z0-9_]$"
+TYPE_NAME_REGEX = r"^[a-zA-Z0-9_][a-zA-Z0-9_ \-]{0,64}[a-zA-Z0-9_]$"
 
 # user names shouldn't start or end with underscores
 USER_NAME_REGEX = r"^[a-zA-Z0-9][a-zA-Z0-9_\.\-]*[a-zA-Z0-9]$"


### PR DESCRIPTION
## Description of changes

PR changes `TYPE_NAME_REGEX` which is used in `tasks` graphQL where it wasn't possible to search for tasks which had only 2 letters long `task_type`.

### Technical details

This brings up multiple issues. 

Question is if we should use this validation in search at all.

`TYPE_NAME_REGEX` is used only in graphQL, it probably should be used in `Anatomy` to validate names for newly created `task_types`. (As now it is possible create 2 letters long `task_type` which cannot be queried by graphQL back.)

But simply adding validator is not without risks as if there would be any existing `task_type` with single letter name, Anatomy won't be loaded. I could introduce fixing script which would add '_' suffix (for example) and update DB. (easy)
BUT as `task_type` is widely used in published path, updating those is completely different level of effort/possibility.

I don't think we can trigger validator only on new values and keep existing be. I don't think we can use validator only for fresh projects. I don't know how probable is that studio will have single letter task type. Don't think that 'a', 'B' would be too useful or widely used, but IDK.