### PR TITLE
Remove version list view

### DIFF
--- a/api/resolve/__init__.py
+++ b/api/resolve/__init__.py
@@ -161,8 +161,11 @@ def get_version_conditions(version_name: str | None) -> list[str]:
         return [
             """
             v.id in (
-                SELECT l.ids[array_upper(l.ids, 1)]
-                FROM version_list AS l
+                SELECT vv.id
+                FROM versions vv
+                WHERE vv.product_id = s.id
+                ORDER BY vv.version DESC
+                LIMIT 1
             )
         """
         ]

--- a/ayon_server/entities/version.py
+++ b/ayon_server/entities/version.py
@@ -86,17 +86,6 @@ class VersionEntity(ProjectLevelEntity):
                 self.task_id,
             )
 
-    @classmethod
-    async def refresh_views(cls, project_name: str) -> None:
-        """Refresh hierarchy materialized view on version save."""
-
-        await Postgres.execute(
-            f"""
-            REFRESH MATERIALIZED VIEW CONCURRENTLY
-            project_{project_name}.version_list
-            """
-        )
-
     async def ensure_create_access(self, user, **kwargs) -> None:
         if user.is_manager:
             return

--- a/ayon_server/graphql/dataloaders/__init__.py
+++ b/ayon_server/graphql/dataloaders/__init__.py
@@ -262,9 +262,10 @@ async def latest_version_loader(keys: list[KeyType]) -> list[dict[str, Any] | No
         ON hero_versions.id = v.id
 
         WHERE v.id IN (
-            SELECT l.ids[array_upper(l.ids, 1)]
-            FROM project_{project_name}.version_list as l
-            WHERE l.product_id IN {SQLTool.id_array([k[1] for k in keys])}
+            SELECT DISTINCT ON (vv.product_id) vv.id
+            FROM project_{project_name}.versions AS vv
+            WHERE vv.product_id IN {SQLTool.id_array([k[1] for k in keys])}
+            ORDER BY vv.product_id, vv.version DESC
         )
         """
 

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -456,9 +456,13 @@ async def get_products(
         )
         sql_joins.append(
             f"""
-            LEFT JOIN
-                project_{project_name}.version_list
-                ON products.id = version_list.product_id
+            LEFT JOIN LATERAL (
+                SELECT
+                    array_agg(v.id ORDER BY v.version) AS ids,
+                    array_agg(v.version ORDER BY v.version) AS versions
+                FROM project_{project_name}.versions AS v
+                WHERE v.product_id = products.id
+            ) AS version_list ON TRUE
             """
         )
 

--- a/maintenance/tasks/add_missing_project_indexes.py
+++ b/maintenance/tasks/add_missing_project_indexes.py
@@ -15,6 +15,7 @@ INDEXES = {
     "product_attrib_idx": "products USING gin(attrib);",
     "version_task_id_idx": "versions(task_id);",
     "version_status_idx": "versions(status);",
+    "version_parent_version_idx": "versions(product_id, version DESC);",
     "version_attrib_idx": "versions USING gin(attrib);",
     "representation_status_idx": "representations(status);",
     "representation_attrib_idx": "representations USING gin(attrib);",

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -327,7 +327,7 @@ CREATE TABLE versions(
     creation_order SERIAL NOT NULL
 );
 
-CREATE INDEX version_parent_idx ON versions(product_id);
+CREATE INDEX version_parent_idx ON versions(product_id, version DESC);
 CREATE INDEX version_thumbnail_idx ON versions(thumbnail_id);
 CREATE INDEX version_task_id_idx ON versions(task_id);
 CREATE INDEX version_status_idx ON versions(status);

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -327,7 +327,7 @@ CREATE TABLE versions(
     creation_order SERIAL NOT NULL
 );
 
-CREATE INDEX version_parent_idx ON versions(product_id, version DESC);
+CREATE INDEX version_parent_idx ON versions(product_id);
 CREATE INDEX version_thumbnail_idx ON versions(thumbnail_id);
 CREATE INDEX version_task_id_idx ON versions(task_id);
 CREATE INDEX version_status_idx ON versions(status);
@@ -337,6 +337,8 @@ CREATE UNIQUE INDEX version_unique_version_parent ON versions (product_id, versi
 
 -- Version list VIEW
 -- Materialized view used as a shorthand to get product versions
+-- TODO:This view is deprecated and will be removed in the future. As of 1.16.1, it is only present to maintain
+-- backwrads compatibility, but it is no longer updated upon version changes
 
 CREATE MATERIALIZED VIEW version_list
 AS


### PR DESCRIPTION
This pull request refactors how the latest version of a product is queried and managed throughout the codebase. The changes remove reliance on the `version_list` materialized view and instead use direct queries on the `versions` table, improving both query efficiency and maintainability. Additionally, an index is updated to optimize these new queries.

**Database and Query Refactoring:**

* Replaced queries that used the `version_list` materialized view with direct queries on the `versions` table, selecting the latest version by ordering on the `version` field and limiting to one. This affects version resolution logic in both API and GraphQL layers. [
* Updated the SQL join in product resolvers to use a lateral join that aggregates version IDs and numbers directly from the `versions` table, removing dependency on the `version_list` view.

**Codebase Cleanup:**

* Removed the `refresh_views` class method from the `Version` entity, as refreshing the materialized view is no longer necessary.


**Note**
This PR does not remove version_list view from the older projects. It will be kept in order to allow downgrading. The view itself should be removed later

This PR significantly speeds up version saving