### PR TITLE
Increase gunicorn keepalive interval

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -7,6 +7,7 @@ SERVER_WORKERS=${AYON_SERVER_WORKERS:-1}
 SERVER_MAX_REQUESTS=${AYON_SERVER_MAX_REQUESTS:-0}
 SERVER_MAX_REQUESTS_JITTER=${AYON_SERVER_MAX_REQUESTS_JITTER:-0}
 SERVER_TIMEOUT=${AYON_SERVER_TIMEOUT:-120}
+SERVER_KEEPALIVE=${AYON_SERVER_KEEPALIVE:-75}
 SERVER_TYPE=${AYON_SERVER_TYPE:-gunicorn}
 
 [ -z "$AYON_RUN_SETUP" ] && AYON_RUN_SETUP=true
@@ -72,6 +73,7 @@ else
             --log-level ${SERVER_LOG_LEVEL} \
             --workers ${SERVER_WORKERS} \
             --timeout ${SERVER_TIMEOUT} \
+            --keep-alive ${SERVER_KEEPALIVE} \
             --max-requests ${SERVER_MAX_REQUESTS} \
             --max-requests-jitter ${SERVER_MAX_REQUESTS_JITTER} \
             -b :5000 \


### PR DESCRIPTION
This pull request updates the server startup script to introduce a configurable keep-alive timeout for the Gunicorn server. This allows the server to better manage persistent connections by specifying how long to wait for the next request before closing the connection.

**Server configuration improvements:**

* Added a new `AYON_SERVER_KEEPALIVE` environment variable to allow configuration of the Gunicorn `--keep-alive` timeout, with a default value of 75 seconds. (`start.sh`)
* Updated the Gunicorn command to include the `--keep-alive` option, using the value from `SERVER_KEEPALIVE`. (`start.sh`)