### PR TITLE
Fix nested SettingsModel defaults

### DIFF
--- a/api/addons/project_settings.py
+++ b/api/addons/project_settings.py
@@ -20,7 +20,10 @@ from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import logger
 from ayon_server.settings import BaseSettingsModel
 from ayon_server.settings.overrides import extract_overrides, list_overrides
-from ayon_server.settings.postprocess import postprocess_settings_schema
+from ayon_server.settings.postprocess import (
+    populate_schema_defaults,
+    postprocess_settings_schema,
+)
 from ayon_server.settings.set_addon_settings import set_addon_settings
 
 from .common import (
@@ -62,6 +65,7 @@ async def get_addon_project_settings_schema(
     }
 
     schema = copy.deepcopy(model.schema())
+    populate_schema_defaults(schema, model)
     await postprocess_settings_schema(schema, model, context=context)
     schema["title"] = addon.friendly_name
     return schema

--- a/api/addons/site_settings.py
+++ b/api/addons/site_settings.py
@@ -9,7 +9,10 @@ from ayon_server.api.responses import EmptyResponse
 from ayon_server.exceptions import BadRequestException, NotFoundException
 from ayon_server.lib.postgres import Postgres
 from ayon_server.logging import logger
-from ayon_server.settings.postprocess import postprocess_settings_schema
+from ayon_server.settings.postprocess import (
+    populate_schema_defaults,
+    postprocess_settings_schema,
+)
 
 from .router import router
 
@@ -32,6 +35,7 @@ async def get_addon_site_settings_schema(
         return {}
 
     schema = copy.deepcopy(model.schema())
+    populate_schema_defaults(schema, model)
     context = {
         "addon": addon,
         "user_name": user.name,

--- a/api/addons/studio_settings.py
+++ b/api/addons/studio_settings.py
@@ -16,7 +16,10 @@ from ayon_server.exceptions import (
 )
 from ayon_server.lib.postgres import Postgres
 from ayon_server.settings.overrides import extract_overrides, list_overrides
-from ayon_server.settings.postprocess import postprocess_settings_schema
+from ayon_server.settings.postprocess import (
+    populate_schema_defaults,
+    postprocess_settings_schema,
+)
 from ayon_server.settings.set_addon_settings import set_addon_settings
 
 from .common import ModifyOverridesRequestModel, pin_override, remove_override
@@ -47,6 +50,7 @@ async def get_addon_settings_schema(
     }
 
     schema = copy.deepcopy(model.schema())
+    populate_schema_defaults(schema, model)
     await postprocess_settings_schema(schema, model, context=context)
     schema["title"] = addon.friendly_name
     return schema

--- a/ayon_server/settings/postprocess.py
+++ b/ayon_server/settings/postprocess.py
@@ -11,6 +11,104 @@ from ayon_server.settings.common import BaseSettingsModel
 from ayon_server.types import SimpleValue, camelize
 
 
+def populate_schema_defaults(
+    schema: dict[str, Any],
+    model: type[BaseSettingsModel],
+) -> None:
+    definitions = {
+        **schema.get("$defs", {}),
+        **schema.get("definitions", {}),
+    }
+    missing = object()
+
+    def resolve(node: dict[str, Any]) -> dict[str, Any]:
+        if ref := node.get("$ref"):
+            definition_name = ref.rsplit("/", 1)[-1]
+            return definitions.get(definition_name, node)
+        return node
+
+    def serialize(value: Any) -> Any:
+        if isinstance(value, BaseSettingsModel):
+            return value.dict()
+        if isinstance(value, list):
+            return [serialize(item) for item in value]
+        if isinstance(value, dict):
+            return {key: serialize(item) for key, item in value.items()}
+        return value
+
+    def is_settings_model(value: Any) -> bool:
+        try:
+            return inspect.isclass(value) and issubclass(value, BaseSettingsModel)
+        except TypeError:
+            return False
+
+    def get_child_model(field: Any) -> type[BaseSettingsModel] | None:
+        candidates = [field.type_]
+        candidates.extend(sub_field.type_ for sub_field in field.sub_fields or [])
+        for candidate in candidates:
+            if is_settings_model(candidate):
+                return candidate
+        return None
+
+    def build_model_defaults(
+        current_model: type[BaseSettingsModel],
+        stack: set[type[BaseSettingsModel]] | None = None,
+    ) -> Any:
+        stack = stack or set()
+        if current_model in stack:
+            return missing
+
+        defaults = {}
+        next_stack = {*stack, current_model}
+        for field_name, field in current_model.__fields__.items():
+            default = get_field_default(field, next_stack)
+            if default is not missing:
+                defaults[field_name] = default
+        return defaults or missing
+
+    def get_field_default(
+        field: Any,
+        stack: set[type[BaseSettingsModel]] | None = None,
+    ) -> Any:
+        if field.default_factory is not None:
+            if is_settings_model(field.default_factory):
+                return build_model_defaults(field.default_factory, stack)
+            return serialize(field.default_factory())
+        if not field.required:
+            return serialize(field.default)
+        return missing
+
+    def populate(node: dict[str, Any], current_model: type[BaseSettingsModel]) -> None:
+        all_of = node.get("allOf")
+        if isinstance(all_of, list):
+            for sub_schema in all_of:
+                if isinstance(sub_schema, dict):
+                    populate(sub_schema, current_model)
+
+        resolved = resolve(node)
+        if resolved is not node:
+            node = resolved
+
+        for name, field in current_model.__fields__.items():
+            child_schema = node.get("properties", {}).get(name)
+            if child_schema is None:
+                continue
+
+            if "default" not in child_schema:
+                default = get_field_default(field)
+                if default is not missing:
+                    child_schema["default"] = default
+
+            child_model = get_child_model(field)
+            if child_model is not None:
+                nested_schema = child_schema
+                if isinstance(child_schema.get("items"), dict):
+                    nested_schema = child_schema["items"]
+                populate(nested_schema, child_model)
+
+    populate(schema, model)
+
+
 async def get_attrib_enum(
     name: str,
 ) -> tuple[list[SimpleValue], dict[SimpleValue, str]]:


### PR DESCRIPTION
## Description of changes

Fix nested SettingsModels like:

```python
class WriteKnobsModel(SettingsModel):
    custom: list[KnobModel] = SettingsField(
        title="Additional Knobs",
        default=[
            KnobModel(
                type="text",
                name="mov64_codec",
                text="ap4h",
            ),
            KnobModel(
                type="boolean",
                name="mov64_write_timecode",
                boolean=True,
            )
        ]
    )

class IntermediateOutputModel(BaseSettingsModel):
    write_knobs: WriteKnobsModel = SettingsField(
        default_factory=WriteKnobsModel,
        title="Write Knobs",
        description=(
            "Configure knobs on the output write node"
        )
    )
    
    
class MainModel(BaseSettingsModel):
    outputs: list[IntermediateOutputModel] = SettingsField(
        default_factory=list,
        title="Baking streams"
    )
```

The defaults to `custom` key should automatically be set when adding a new entry to `outputs` in the Settings in frontend.

### Technical details

I feel like this 'fix' is way too convoluted and there must be something wrong - but just putting this as draft because it does resolve the issue here. However we should likely need to look at some other 'correct fix'.

### Additional context

Solves case described here: https://github.com/ynput/ayon-nuke/pull/344#discussion_r3758358228

This is not a high priority at all.