### PR TITLE
Fix missing return on `BaseModel` in `json_default_handler`

### DIFF
--- a/ayon_server/utils/json.py
+++ b/ayon_server/utils/json.py
@@ -16,12 +16,12 @@ def isinstance_namedtuple(obj: Any) -> bool:
     )
 
 
-def json_default_handler(value: Any) -> Any:
+def json_default_handler(value: Any) -> list[Any] | dict[str, Any] | str:
     if isinstance_namedtuple(value):
         return list(value)
 
     if isinstance(value, BaseModel):
-        value.dict()
+        return value.dict()
 
     if isinstance(value, datetime.datetime):
         return value.isoformat()


### PR DESCRIPTION
## Description of changes

Fix missing return on `BaseModel` in `json_default_handler` + add return type hints to capture this earlier next time

### Technical details

Not sure what this would actually fix or affect.

### Additional context

Spotted this issue when trying to work on https://github.com/ynput/ayon-backend/pull/1059
