### PR TITLE
Migrate attrib type

### DIFF
--- a/ayon_server/__main__.py
+++ b/ayon_server/__main__.py
@@ -2,7 +2,7 @@ import importlib
 import os
 import sys
 
-from ayon_server.logging import logger
+from ayon_server.logging import log_traceback, logger
 from ayon_server.version import __version__
 
 CLI_PLUGINS_DIRS = [
@@ -29,6 +29,7 @@ def main() -> None:
                 _ = importlib.import_module(module_name)
             except ImportError:
                 logger.error(f"Unable to initialize {module_name}")
+                log_traceback()
                 continue
     app()
 

--- a/cli/file_cleanup/file_cleanup.py
+++ b/cli/file_cleanup/file_cleanup.py
@@ -1,7 +1,6 @@
 import sqlite3
 
 from ayon_server.cli import app
-from ayon_server.files import Storages
 from ayon_server.helpers.project_list import get_project_list
 from ayon_server.initialize import ayon_init
 from ayon_server.lib.postgres import Postgres
@@ -10,6 +9,8 @@ from nxtools import logging
 
 async def cleanup_project_files(project_name: str, *, dry_run: bool) -> None:
     logging.info(f"Cleaning up files for project: {project_name}")
+    from ayon_server.files import Storages
+
     storage = await Storages.project(project_name)
 
     # Create an SQLite database in memory

--- a/cli/migrate_attrib_type/__init__.py
+++ b/cli/migrate_attrib_type/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["migrate_attrib_type"]
+
+from .migrate_attrib_type import migrate_attrib_type

--- a/cli/migrate_attrib_type/migrate_attrib_type.py
+++ b/cli/migrate_attrib_type/migrate_attrib_type.py
@@ -79,7 +79,7 @@ async def _do_migration(
             n.new_value
         )
         FROM new_values n
-        WHERE e.id = n.id
+        WHERE e.__IDENTIFIER__ = n.__IDENTIFIER__
         AND e.attrib ? $1
     """
 
@@ -103,9 +103,11 @@ async def migrate_attrib_type(
         for table_name in (
             "folders",
             "tasks",
+            "products",
             "versions",
             "representations",
             "workfiles",
+            "entity_lists",
         ):
             await _do_migration(
                 attrib_name=attrib_name,
@@ -119,6 +121,7 @@ async def migrate_attrib_type(
         await rebuild_hierarchy_cache(project.name)
 
     identifier = "name"
+
     for table_name in ("projects", "users"):
         rmv = ""
         if new_type == "string":

--- a/cli/migrate_attrib_type/migrate_attrib_type.py
+++ b/cli/migrate_attrib_type/migrate_attrib_type.py
@@ -1,0 +1,143 @@
+import time
+
+from ayon_server.cli import app
+from ayon_server.exceptions import BadRequestException
+from ayon_server.helpers.hierarchy_cache import rebuild_hierarchy_cache
+from ayon_server.helpers.inherited_attributes import rebuild_inherited_attributes
+from ayon_server.helpers.project_list import get_project_list
+from ayon_server.initialize import ayon_init
+from ayon_server.lib.postgres import Postgres
+from ayon_server.logging import logger
+from ayon_server.types import AttributeType
+
+
+async def _do_migration(
+    attrib_name: str, new_type: str, table_name: str, identifier: str
+) -> None:
+    if new_type == "string":
+        replacement = """
+            SELECT
+                __IDENTIFIER__,
+                CASE WHEN value IS NULL THEN NULL
+
+                -- if value is already a string, keep it
+                WHEN jsonb_typeof(value) = 'string'
+                    THEN value
+
+                -- if it was a list of strings, take the first element as the new value
+                -- we don't care about the data loss here, since the user was warned
+                WHEN jsonb_typeof(value) = 'array'
+                    THEN value->0
+
+                -- for other types, convert to string
+                ELSE to_jsonb(value::text)
+                END AS new_value
+            FROM attr_values
+        """
+
+    elif new_type == "list_of_strings":
+        replacement = """
+            SELECT
+                __IDENTIFIER__,
+                CASE WHEN value IS NULL THEN NULL
+
+                -- if value is already a list of strings, keep it
+                WHEN jsonb_typeof(value) = 'array'
+                    THEN value
+
+                -- if it was a single string, convert to a list with one element
+                WHEN jsonb_typeof(value) = 'string'
+                    THEN to_jsonb(ARRAY[value #>> '{}'])
+
+                -- for other types, convert to string and then to a list
+                ELSE to_jsonb(ARRAY[value::text])
+
+                END AS new_value
+            FROM attr_values
+        """
+
+    else:
+        raise BadRequestException(
+            f"Changing data type to '{new_type}' is not supported. "
+        )
+
+    query = f"""
+        WITH attr_values AS (
+            SELECT __IDENTIFIER__, (attrib->$1) AS value
+            FROM {table_name}
+            WHERE attrib ? $1
+        ),
+
+        new_values AS (
+            {replacement}
+        )
+
+        UPDATE {table_name} e
+        SET attrib = jsonb_set(
+            e.attrib,
+            ARRAY[$1],
+            n.new_value
+        )
+        FROM new_values n
+        WHERE e.id = n.id
+        AND e.attrib ? $1
+    """
+
+    query = query.replace("__IDENTIFIER__", identifier)
+    await Postgres.execute(query, attrib_name)
+
+
+@app.command()
+async def migrate_attrib_type(
+    attrib_name: str,
+    new_type: AttributeType,
+) -> None:
+    await ayon_init()
+
+    identifier = "id"
+
+    start_time = time.perf_counter()
+
+    projects = await get_project_list()
+    for project in projects:
+        for table_name in (
+            "folders",
+            "tasks",
+            "versions",
+            "representations",
+            "workfiles",
+        ):
+            await _do_migration(
+                attrib_name=attrib_name,
+                new_type=new_type,
+                table_name=f"project_{project.name}.{table_name}",
+                identifier=identifier,
+            )
+
+    for project in projects:
+        await rebuild_inherited_attributes(project.name)
+        await rebuild_hierarchy_cache(project.name)
+
+    identifier = "name"
+    for table_name in ("projects", "users"):
+        rmv = ""
+        if new_type == "string":
+            rm = ["min_items", "max_items", "gt", "lt", "ge", "le"]
+            rmv = " - " + " - ".join(f"'{r}'" for r in rm)
+
+        elif new_type == "list_of_strings":
+            rm = ["min_length", "max_length", "gt", "lt", "ge", "le"]
+            rmv = " - " + " - ".join(f"'{r}'" for r in rm)
+
+        await Postgres.execute(
+            f"UPDATE attributes SET data = (data || $1) {rmv} WHERE name = $2",
+            {"type": new_type},
+            attrib_name,
+        )
+
+    elapsed_time = time.perf_counter() - start_time
+
+    logger.info(
+        f"Migration of attribute '{attrib_name}' to type '{new_type}' "
+        f"completed in {elapsed_time:.2f} seconds. Restart the server now!"
+    )

--- a/cli/migrate_attrib_type/migrate_attrib_type.py
+++ b/cli/migrate_attrib_type/migrate_attrib_type.py
@@ -73,10 +73,13 @@ async def _do_migration(
         )
 
         UPDATE {table_name} e
-        SET attrib = jsonb_set(
-            e.attrib,
-            ARRAY[$1],
-            n.new_value
+        SET attrib = COALESCE(
+            jsonb_set(
+                e.attrib,
+                ARRAY[$1],
+                n.new_value
+            ),
+            '{{}}'::jsonb
         )
         FROM new_values n
         WHERE e.__IDENTIFIER__ = n.__IDENTIFIER__


### PR DESCRIPTION
This pull request introduces a new CLI command for migrating attribute types across projects and improves error handling and code organization in several modules. The main highlight is the addition of the `migrate_attrib_type` command, which allows for efficient and safe migration of attribute types in the database, along with related cache rebuilds. Other changes include better error logging and improved import practices.


Added a new CLI command `migrate_attrib_type` in `cli/migrate_attrib_type/migrate_attrib_type.py` to migrate an attribute's type (e.g., from string to list of strings) across all project tables, update metadata, and rebuild caches for consistency. This command handles data conversion and warns about potential data loss, providing logging and timing information for the operation.
