### PR TITLE
Fix: Resolve latest only version

### DIFF
--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -432,7 +432,7 @@ async def get_versions(
     #
 
     if latest_only:
-        sql_conditions.append("lv.id IS NOT NULL")
+        sql_conditions.append("versions.id = lv.id")
 
     elif hero_only:
         # This returns actual (negative) hero versions only
@@ -444,7 +444,7 @@ async def get_versions(
         # This is provided mainly for backward compatibility and the pipeline
         # The frontend uses new featuredVersion filter instead
 
-        sql_conditions.append("(versions.version < 0 OR lv IS NOT NULL)")
+        sql_conditions.append("(versions.version < 0 OR versions.version IS NOT NULL)")
 
     elif has_hero:
         sql_conditions.append("hv.id IS NOT NULL")


### PR DESCRIPTION
This pull request makes minor adjustments to the SQL condition logic in the `get_versions` resolver to improve accuracy and maintain compatibility. The changes clarify how versions are filtered, especially when handling latest and hero versions.

- Query Logic Updates:
  * Changed the condition for `latest_only` to explicitly check that `versions.id` matches `lv.id`, ensuring only the latest version is selected.
  * Updated the backward compatibility condition to check for `versions.version IS NOT NULL` instead of `lv IS NOT NULL`, making the filter more explicit and robust.