### PR TITLE
Further version resolver optimizations

### DIFF
--- a/api/folders/list_folders.py
+++ b/api/folders/list_folders.py
@@ -12,7 +12,7 @@ from ayon_server.helpers.hierarchy_cache import rebuild_hierarchy_cache
 from ayon_server.lib.redis import Redis
 from ayon_server.logging import logger
 from ayon_server.types import OPModel
-from ayon_server.utils import camelize, json_dumps, json_loads
+from ayon_server.utils import RequestCoalescer, camelize, json_dumps, json_loads
 
 from .router import router
 
@@ -103,18 +103,8 @@ class FolderListLoader:
         self._executor = ThreadPoolExecutor(max_workers=10)
 
     async def get_folder_list(self, project_name: str) -> list[dict[str, Any]]:
-        async with self._lock:
-            if project_name not in self._current_futures:
-                self._current_futures[project_name] = asyncio.create_task(
-                    self._load_folders(project_name)
-                )
-
-        data = await self._current_futures[project_name]
-
-        async with self._lock:
-            self._current_futures.pop(project_name, None)
-
-        return data
+        coalesce = RequestCoalescer()
+        return await coalesce(self._load_folders, project_name)
 
     async def _load_folders(self, project_name: str) -> list[dict[str, Any]]:
         logger.trace(f"Loading folders for project {project_name}")

--- a/ayon_server/entities/core/projectlevel.py
+++ b/ayon_server/entities/core/projectlevel.py
@@ -273,11 +273,11 @@ class ProjectLevelEntity(BaseEntity):
             if auto_commit:
                 await self.commit()
 
-    async def commit(self) -> None:
-        await self.refresh_views(self.project_name)
+    async def commit(self, **kwargs: Any) -> None:
+        await self.refresh_views(self.project_name, **kwargs)
 
     @classmethod
-    async def refresh_views(cls, project_name: str) -> None:
+    async def refresh_views(cls, project_name: str, **kwargs) -> None:
         """Refresh the views for the entity type in the given project.
 
         This method should be overridden in subclasses to refresh.

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -161,6 +161,7 @@ class FolderEntity(ProjectLevelEntity):
 
             # This needs to run in save, not in refresh_views, because
             # we may need the hierarchy record in the same transaction
+            logger.trace(f"Refreshing {self.project_name} hierarchy")
             await Postgres.execute(
                 f"""
                 REFRESH MATERIALIZED VIEW
@@ -172,7 +173,7 @@ class FolderEntity(ProjectLevelEntity):
                 await self.commit()
 
     @classmethod
-    async def refresh_views(cls, project_name: str) -> None:
+    async def refresh_views(cls, project_name: str, **kwargs) -> None:
         """Refresh hierarchy materialized view on folder save."""
         logger.trace(f"Refreshing folder views for project {project_name}")
 
@@ -186,7 +187,10 @@ class FolderEntity(ProjectLevelEntity):
         #  - caches the hierarchy table in Redis
         #  - which depends on the exported_attributes table
 
-        await rebuild_inherited_attributes(project_name)
+        refresh_hierarchy = kwargs.get("refresh_hierarchy", True)
+        await rebuild_inherited_attributes(
+            project_name, refresh_hierarchy=refresh_hierarchy
+        )
         await rebuild_hierarchy_cache(project_name)
 
     async def delete(self, *args, auto_commit: bool = True, **kwargs) -> bool:

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -170,7 +170,7 @@ class FolderEntity(ProjectLevelEntity):
             )
 
             if auto_commit:
-                await self.commit()
+                await self.commit(refresh_hierarchy=False)  # already refreshed
 
     @classmethod
     async def refresh_views(cls, project_name: str, **kwargs) -> None:
@@ -189,7 +189,8 @@ class FolderEntity(ProjectLevelEntity):
 
         refresh_hierarchy = kwargs.get("refresh_hierarchy", True)
         await rebuild_inherited_attributes(
-            project_name, refresh_hierarchy=refresh_hierarchy
+            project_name,
+            refresh_hierarchy=refresh_hierarchy,
         )
         await rebuild_hierarchy_cache(project_name)
 

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -208,13 +208,7 @@ class FolderEntity(ProjectLevelEntity):
                     """,
                     self.path.lstrip("/"),
                 )
-
-            res = await super().delete()
-            if not res:
-                return False
-            elif auto_commit:
-                await self.commit()
-        return res
+            return await super().delete(*args, auto_commit=auto_commit, **kwargs)
 
     async def get_versions(self) -> list[str]:
         """Return of version ids associated with this folder."""

--- a/ayon_server/entities/project.py
+++ b/ayon_server/entities/project.py
@@ -204,7 +204,7 @@ class ProjectEntity(TopLevelEntity):
     #
 
     @classmethod
-    async def refresh_views(cls) -> None:
+    async def refresh_views(cls, **kwargs: Any) -> None:
         await build_project_list()
 
     async def commit(self):

--- a/ayon_server/entities/task.py
+++ b/ayon_server/entities/task.py
@@ -80,7 +80,7 @@ class TaskEntity(ProjectLevelEntity):
             await super().save(auto_commit=auto_commit)
 
     @classmethod
-    async def refresh_views(cls, project_name: str) -> None:
+    async def refresh_views(cls, project_name: str, **kwargs: Any) -> None:
         await rebuild_hierarchy_cache(project_name)
 
     async def ensure_create_access(self, user, **kwargs) -> None:

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -179,13 +179,18 @@ def create_child_folder_ctes(
 
     NOTE: the caller must wrap the combined CTE list in "WITH RECURSIVE",
     not plain "WITH", for this CTE's self-reference to be valid SQL.
+
+    Uses UNION, not UNION ALL: if folder_ids contains both a folder and one
+    of its own descendants, that descendant's subtree would otherwise be
+    reached by two different paths and recurse independently down each,
+    duplicating ids (and downstream, duplicating joined result rows).
     """
     return [
         f"""
         child_folder_ids AS (
             SELECT id FROM project_{project_name}.folders
             WHERE id IN {SQLTool.id_array(folder_ids)}
-            UNION ALL
+            UNION
             SELECT f.id
             FROM project_{project_name}.folders AS f
             INNER JOIN child_folder_ids AS cf ON f.parent_id = cf.id

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -165,26 +165,30 @@ def create_child_folder_ctes(
     project_name: str,
     folder_ids: list[str],
 ) -> list[str]:
-    """Create CTE queries for resolving child folder IDs based on parent paths."""
+    """Create a CTE resolving folder_ids plus all of their descendant folder
+    ids, by walking folders.parent_id (indexed via folder_parent_idx).
+
+    This walks the live folders table instead of matching path strings
+    against the hierarchy materialized view: a LIKE 'prefix/%' match against
+    a per-row dynamic prefix can't use hierarchy_path_idx, so postgres falls
+    back to scanning the whole view and can't estimate its selectivity,
+    which on a project with thousands of folders skews the planner's cost
+    estimate for the entire query (and, incidentally, the JIT decision that
+    estimate feeds into) badly enough to dominate query time. A recursive
+    walk over parent_id gives it real, estimable per-level index lookups.
+
+    NOTE: the caller must wrap the combined CTE list in "WITH RECURSIVE",
+    not plain "WITH", for this CTE's self-reference to be valid SQL.
+    """
     return [
         f"""
-        top_folder_paths AS (
-            SELECT path FROM project_{project_name}.hierarchy
-            WHERE id IN {SQLTool.id_array(folder_ids)}
-        )
-        """,
-        f"""
         child_folder_ids AS (
-            SELECT id FROM project_{project_name}.hierarchy
-            WHERE EXISTS (
-                SELECT 1
-                FROM top_folder_paths
-                WHERE project_{project_name}.hierarchy.path
-                LIKE top_folder_paths.path || '/%'
-            )
-            OR project_{project_name}.hierarchy.path = ANY (
-                SELECT path FROM top_folder_paths
-            )
+            SELECT id FROM project_{project_name}.folders
+            WHERE id IN {SQLTool.id_array(folder_ids)}
+            UNION ALL
+            SELECT f.id
+            FROM project_{project_name}.folders AS f
+            INNER JOIN child_folder_ids AS cf ON f.parent_id = cf.id
         )
         """,
     ]

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -164,6 +164,7 @@ async def create_folder_access_list(root, info) -> list[str] | None:
 def create_child_folder_ctes(
     project_name: str,
     folder_ids: list[str],
+    include_self: bool = True,
 ) -> list[str]:
     """Create a CTE resolving folder_ids plus all of their descendant folder
     ids, by walking folders.parent_id (indexed via folder_parent_idx).
@@ -177,6 +178,9 @@ def create_child_folder_ctes(
     estimate feeds into) badly enough to dominate query time. A recursive
     walk over parent_id gives it real, estimable per-level index lookups.
 
+    include_self=False resolves descendants only (e.g. for a "children of
+    these parents" filter), without folder_ids themselves.
+
     NOTE: the caller must wrap the combined CTE list in "WITH RECURSIVE",
     not plain "WITH", for this CTE's self-reference to be valid SQL.
 
@@ -185,11 +189,17 @@ def create_child_folder_ctes(
     reached by two different paths and recurse independently down each,
     duplicating ids (and downstream, duplicating joined result rows).
     """
+    base_case = (
+        f"SELECT id FROM project_{project_name}.folders "
+        f"WHERE id IN {SQLTool.id_array(folder_ids)}"
+        if include_self
+        else f"SELECT id FROM project_{project_name}.folders "
+        f"WHERE parent_id IN {SQLTool.id_array(folder_ids)}"
+    )
     return [
         f"""
         child_folder_ids AS (
-            SELECT id FROM project_{project_name}.folders
-            WHERE id IN {SQLTool.id_array(folder_ids)}
+            {base_case}
             UNION
             SELECT f.id
             FROM project_{project_name}.folders AS f

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -28,6 +28,7 @@ from .common import (
     ColumnMetadata,
     FieldInfo,
     argdesc,
+    create_child_folder_ctes,
     create_folder_access_list,
     get_has_links_conds,
     resolve,
@@ -356,30 +357,7 @@ async def get_folders(
             return FoldersConnection()
 
         if include_folder_children:
-            sql_cte.append(
-                f"""
-                top_folder_paths AS (
-                    SELECT id, path FROM project_{project_name}.hierarchy
-                    WHERE id IN {SQLTool.id_array(ids)}
-                )
-                """
-            )
-
-            sql_cte.append(
-                f"""
-                child_folder_ids AS (
-                    SELECT id FROM project_{project_name}.hierarchy
-                    WHERE EXISTS (
-                        SELECT 1 FROM top_folder_paths
-                        WHERE project_{project_name}.hierarchy.path
-                        LIKE top_folder_paths.path || '/%'
-                    )
-                    OR project_{project_name}.hierarchy.id
-                    IN (SELECT id FROM top_folder_paths)
-                )
-                """
-            )
-
+            sql_cte.extend(create_child_folder_ctes(project_name, ids))
             sql_conditions.append("folders.id IN (SELECT id FROM child_folder_ids)")
 
         else:
@@ -398,26 +376,8 @@ async def get_folders(
             return FoldersConnection()
 
         if include_folder_children:
-            sql_cte.append(
-                f"""
-                top_folder_paths AS (
-                    SELECT id, path FROM project_{project_name}.hierarchy
-                    WHERE id IN {SQLTool.id_array(parent_ids)}
-                )
-                """
-            )
-
-            sql_cte.append(
-                f"""
-                child_folder_ids AS (
-                    SELECT id FROM project_{project_name}.hierarchy
-                    WHERE EXISTS (
-                        SELECT 1 FROM top_folder_paths
-                        WHERE project_{project_name}.hierarchy.path
-                        LIKE top_folder_paths.path || '/%'
-                    )
-                )
-                """
+            sql_cte.extend(
+                create_child_folder_ctes(project_name, parent_ids, include_self=False)
             )
             sql_conditions.append("folders.id IN (SELECT id FROM child_folder_ids)")
         else:

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -644,7 +644,10 @@ async def get_products(
 
     if sql_cte:
         cte = ", ".join(sql_cte)
-        cte = f"WITH {cte}"
+        # RECURSIVE (harmless for the non-recursive CTEs here) is required
+        # when folder_ids+includeFolderChildren adds create_child_folder_ctes'
+        # self-referencing CTE.
+        cte = f"WITH RECURSIVE {cte}"
     else:
         cte = ""
 

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -551,7 +551,10 @@ async def get_tasks(
 
     if sql_cte:
         cte = ", ".join(sql_cte)
-        cte = f"WITH {cte}"
+        # RECURSIVE (harmless for the non-recursive CTEs here) is required
+        # when folder_ids+includeFolderChildren adds create_child_folder_ctes'
+        # self-referencing CTE.
+        cte = f"WITH RECURSIVE {cte}"
     else:
         cte = ""
 

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -295,8 +295,11 @@ async def get_tasks(
         if include_folder_children:
             use_folder_query = True
             sql_cte.extend(create_child_folder_ctes(project_name, folder_ids))
-            sql_conditions.append(
-                "tasks.folder_id IN (SELECT id FROM child_folder_ids)"
+            sql_joins.append(
+                """
+                INNER JOIN child_folder_ids AS cfi
+                ON tasks.folder_id = cfi.id
+                """
             )
 
         else:

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -425,7 +425,7 @@ async def get_versions(
     # products is unconditional in both roles: it is the root every
     # folder-side join hangs off (they all match on products.folder_id)
     # and what latestPerFolder groups by, and it supplies output columns.
-    joins.for_filter("products", "folder_ex")
+    joins.for_filter("products")
     joins.for_output("products", "folder_ex", "folders", "tasks")
 
     sql_columns = [

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -565,7 +565,6 @@ async def get_versions(
         # Same as above, but include latest if no hero exists
         # This is provided mainly for backward compatibility and the pipeline
         # The frontend uses new featuredVersion filter instead
-
         sql_conditions.append("(versions.version < 0 OR versions.version IS NOT NULL)")
 
     elif has_hero:
@@ -989,10 +988,10 @@ async def get_versions(
         {raw_data_end}
     """
 
-    print()
-    print("Versions query:")
-    print(query)
-    print()
+    # print()
+    # print("Versions query:")
+    # print(query)
+    # print()
 
     if stats_select_clause:
         field_stats = await generate_field_stats(query)

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -275,8 +275,19 @@ class Joins:
         return self._emit(self._for_filter | self._for_sort)
 
     @property
+    def hydrating(self) -> list[str]:
+        """Joins of a main query whose rows come from the page CTE.
+
+        The page has already been filtered, so re-joining anything that
+        only filters would just give the planner a second, wider way to
+        reach the same rows - and a chance to run the LATERALs against
+        that one instead of against the page.
+        """
+        return self._emit(self._for_sort | self._for_output) + self._extra
+
+    @property
     def all(self) -> list[str]:
-        """Joins of the main query."""
+        """Joins of a main query that filters the rows itself."""
         used = self._for_filter | self._for_sort | self._for_output
         return self._emit(used) + self._extra
 
@@ -411,11 +422,11 @@ async def get_versions(
     sql_conditions = []
 
     joins = Joins(project_name)
-    # products is the root every folder-side join hangs off (they all
-    # match on products.folder_id), and it is what latestPerFolder groups
-    # by, so it takes part in filtering unconditionally.
+    # products is unconditional in both roles: it is the root every
+    # folder-side join hangs off (they all match on products.folder_id)
+    # and what latestPerFolder groups by, and it supplies output columns.
     joins.for_filter("products")
-    joins.for_output("folder_ex", "folders", "tasks")
+    joins.for_output("products", "folder_ex", "folders", "tasks")
 
     sql_columns = [
         "versions.*",
@@ -843,6 +854,9 @@ async def get_versions(
         sql_columns.extend(product_columns)
         joins.add(*product_joins)
 
+        # The block reads columns off both, and supplies only the
+        # public.projects join itself.
+        joins.for_output("folders", "folder_ex")
         folder_columns, folder_joins = get_folder_fields_block(
             project_name, "products.folder_id", sql_joins=joins.all
         )
@@ -871,6 +885,7 @@ async def get_versions(
             raise ValueError(f"Invalid sort_by value: {sort_by}")
 
     sql_from = f"project_{project_name}.versions AS versions"
+    main_joins = joins.all
 
     ordering = ""
     cursor = "''"
@@ -911,6 +926,7 @@ async def get_versions(
             INNER JOIN project_{project_name}.versions AS versions
             ON versions.id = page.id
             """
+        main_joins = joins.hydrating
         sql_conditions = []
 
     #
@@ -967,7 +983,7 @@ async def get_versions(
         {raw_data_start}
         SELECT {cursor}, {", ".join(sql_columns)}
         FROM {sql_from}
-        {" ".join(joins.all)}
+        {" ".join(main_joins)}
         {SQLTool.conditions(sql_conditions)}
         {ordering}
         {raw_data_end}

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -425,7 +425,7 @@ async def get_versions(
     # products is unconditional in both roles: it is the root every
     # folder-side join hangs off (they all match on products.folder_id)
     # and what latestPerFolder groups by, and it supplies output columns.
-    joins.for_filter("products")
+    joins.for_filter("products", "folder_ex")
     joins.for_output("products", "folder_ex", "folders", "tasks")
 
     sql_columns = [

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -260,33 +260,31 @@ async def get_versions(
         sql_columns.append("comments.comments AS latest_comments")
 
     if fields.any_endswith("hasReviewables") or (has_reviewables is not None):
-        sql_cte.append(
+        # A correlated LATERAL probe (indexed on activity_references.entity_id)
+        # instead of a "reviewables" CTE: the CTE gets referenced twice here
+        # (column + filter), which forces postgres to materialize it, i.e.
+        # compute reviewable status for every version in the whole project
+        # before pagination is applied, rather than per-row on demand.
+        sql_joins.append(
             f"""
-            reviewables AS (
-                SELECT entity_id FROM project_{project_name}.activity_feed
+            LEFT JOIN LATERAL (
+                SELECT entity_id AS id
+                FROM project_{project_name}.activity_feed
                 WHERE entity_type = 'version'
                 AND activity_type = 'reviewable'
-            )
+                AND entity_id = versions.id
+                LIMIT 1
+            ) rv ON true
             """
         )
 
-        sql_columns.append(
-            """
-            EXISTS (
-            SELECT 1 FROM reviewables WHERE entity_id = versions.id
-            ) AS has_reviewables
-            """
-        )
+        sql_columns.append("rv IS NOT NULL AS has_reviewables")
 
         if has_reviewables is not None:
             if has_reviewables:
-                sql_conditions.append(
-                    "EXISTS (SELECT 1 FROM reviewables WHERE entity_id = versions.id)"
-                )
+                sql_conditions.append("rv IS NOT NULL")
             else:
-                sql_conditions.append(
-                    "NOT EXISTS (SELECT 1 FROM reviewables WHERE entity_id = versions.id)"  # noqa 501
-                )
+                sql_conditions.append("rv IS NULL")
 
     #
     # Direct, version-specific filtering
@@ -820,10 +818,10 @@ async def get_versions(
         {raw_data_end}
     """
 
-    # print()
-    # print("Versions query:")
-    # print(query)
-    # print()
+    print()
+    print("Versions query:")
+    print(query)
+    print()
 
     if stats_select_clause:
         field_stats = await generate_field_stats(query)

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -26,7 +26,7 @@ from ayon_server.graphql.resolvers.common import (
 )
 from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
-from ayon_server.sqlfilter import QueryFilter, build_filter
+from ayon_server.sqlfilter import QueryFilter, build_filter, filter_columns
 from ayon_server.types import (
     validate_name_list,
     validate_status_list,
@@ -59,6 +59,226 @@ SORT_OPTIONS = {
     "taskType": "tasks.task_type",
     "path": "",  # special case handled in the code (is here for docs)
 }
+
+# Joins the sortable columns come from. Sort keys that aren't listed here
+# (and attrib.* sorting) are columns of the versions table itself.
+SORT_JOINS = {
+    "productType": ("products",),
+    "productBaseType": ("products",),
+    "productName": ("products",),
+    "folderName": ("folders",),
+    "folderType": ("folders",),
+    "taskName": ("tasks",),
+    "taskType": ("tasks",),
+    "path": ("folder_ex", "products"),
+}
+
+# Backwards-compat fallback for projects with NULL product_base_type
+PRODUCT_BASE_TYPE = "COALESCE(products.product_base_type, products.product_type)"
+
+# Columns of the `filter` argument that don't live on the versions table:
+# the expression that provides them, and the join it comes from.
+FILTER_COLUMN_SOURCES = {
+    "product_type": ("products.product_type", "products"),
+    "product_base_type": (PRODUCT_BASE_TYPE, "products"),
+    "task_type": ("tasks.task_type", "tasks"),
+    "folder_type": ("folders.folder_type", "folders"),
+    "hero_version_id": ("hv.hero_version_id", "hv"),
+}
+
+
+def available_joins(project_name: str) -> dict[str, str]:
+    """Every join the versions query can use, keyed by its SQL alias.
+
+    Order matters: joins are emitted in the order they are defined here,
+    so a join may only reference the versions table or an alias above it.
+    """
+    return {
+        "products": f"""
+            INNER JOIN project_{project_name}.products AS products
+            ON products.id = versions.product_id
+            """,
+        "folder_ex": f"""
+            INNER JOIN project_{project_name}.exported_attributes AS folder_ex
+            ON folder_ex.folder_id = products.folder_id
+            """,
+        "folders": f"""
+            INNER JOIN project_{project_name}.folders AS folders
+            ON folders.id = products.folder_id
+            """,
+        "tasks": f"""
+            LEFT JOIN project_{project_name}.tasks AS tasks
+            ON tasks.id = versions.task_id
+            """,
+        # Descendants of folder_ids, resolved by create_child_folder_ctes
+        "cfi": """
+            INNER JOIN child_folder_ids AS cfi
+            ON cfi.id = products.folder_id
+            """,
+        "gav": """
+            INNER JOIN guest_accessible_versions AS gav
+            ON gav.entity_id = versions.id
+            """,
+        # One version per folder, resolved by the latestPerFolder CTE.
+        # Looked up via the unique version_creation_order_idx.
+        "lvpf": """
+            INNER JOIN latest_versions_per_folder AS lvpf
+            ON lvpf.creation_order = versions.creation_order
+            """,
+        # A correlated LATERAL fetch (indexed via activity_origin_desc_idx on
+        # entity_type, entity_id, created_at DESC) instead of a CTE that
+        # aggregates every version's comments project-wide and then joins
+        # that back in: with several other LATERAL joins (rv/lv/ldv/hv)
+        # already forcing this query into a nested-loop-heavy plan, postgres
+        # was never promoting that join to a hash join, and instead
+        # rescanning the whole aggregated comment set per output row.
+        "comments": f"""
+            LEFT JOIN LATERAL (
+                SELECT json_agg(
+                    json_build_object(
+                        'activity_id', activity_id,
+                        'body', body,
+                        'author', author,
+                        'created_at', created_at
+                    )
+                    ORDER BY created_at DESC
+                ) AS comments
+                FROM (
+                    SELECT
+                        activity_id,
+                        body,
+                        activity_data->>'author' AS author,
+                        created_at
+                    FROM project_{project_name}.activity_feed
+                    WHERE activity_type = 'comment'
+                    AND entity_type = 'version'
+                    AND reference_type = 'origin'
+                    AND entity_id = versions.id
+                    ORDER BY created_at DESC
+                    LIMIT 5
+                ) x
+            ) comments ON true
+            """,
+        # A correlated LATERAL probe (indexed on activity_references.entity_id)
+        # instead of a "reviewables" CTE: the CTE gets referenced twice here
+        # (column + filter), which forces postgres to materialize it, i.e.
+        # compute reviewable status for every version in the whole project
+        # before pagination is applied, rather than per-row on demand.
+        "rv": f"""
+            LEFT JOIN LATERAL (
+                SELECT entity_id AS id
+                FROM project_{project_name}.activity_feed
+                WHERE entity_type = 'version'
+                AND activity_type = 'reviewable'
+                AND entity_id = versions.id
+                LIMIT 1
+            ) rv ON true
+            """,
+        "lv": f"""
+            LEFT JOIN LATERAL (
+                SELECT id
+                FROM project_{project_name}.versions lv_inner
+                WHERE lv_inner.product_id = versions.product_id
+                AND lv_inner.version >= 0
+                ORDER BY lv_inner.creation_order DESC
+                LIMIT 1
+            ) lv ON true
+            """,
+        # Depends on the done_statuses CTE
+        "ldv": f"""
+            LEFT JOIN LATERAL (
+                SELECT v.id
+                FROM project_{project_name}.versions v
+                WHERE v.product_id = versions.product_id
+                AND v.version >= 0
+                AND v.status IN (SELECT name FROM done_statuses)
+                ORDER BY v.creation_order DESC
+                LIMIT 1
+            ) ldv ON true
+            """,
+        "hv": f"""
+            LEFT JOIN LATERAL (
+                SELECT
+                    versions.id AS id,
+                    hero_versions.id AS hero_version_id
+                FROM project_{project_name}.versions AS hero_versions
+                WHERE hero_versions.product_id = versions.product_id
+                AND hero_versions.version < 0
+                AND ABS(hero_versions.version) = versions.version
+                LIMIT 1
+            ) hv ON true
+            """,
+    }
+
+
+class Joins:
+    """Joins used by a single versions query, tracked by what needs them.
+
+    Every join is requested by its SQL alias, along with the reason:
+
+      - `for_filter` - one of the WHERE conditions references it
+      - `for_sort`   - one of the ORDER BY expressions references it
+      - `for_output` - a requested field needs one of its columns
+
+    The query is built in stages and each stage takes only what it needs:
+    latestPerFolder reduces the set to one version per folder using
+    `filtering`, the page CTE picks the rows to return using `selecting`,
+    and the main query hydrates that page using `all`. That is what keeps
+    the LATERALs out of the first two stages - being correlated, they
+    would otherwise be evaluated for every version the filters match,
+    rather than once per returned row.
+    """
+
+    def __init__(self, project_name: str) -> None:
+        self._available = available_joins(project_name)
+        self._for_filter: set[str] = set()
+        self._for_sort: set[str] = set()
+        self._for_output: set[str] = set()
+        self._extra: list[str] = []
+
+    def for_filter(self, *aliases: str) -> None:
+        self._for_filter.update(aliases)
+
+    def for_sort(self, *aliases: str) -> None:
+        self._for_sort.update(aliases)
+
+    def for_output(self, *aliases: str) -> None:
+        self._for_output.update(aliases)
+
+    def replace_filtering(self, *aliases: str) -> None:
+        """Drop the filtering joins in favour of ones that subsume them.
+
+        latestPerFolder bakes every condition - and the joins those
+        conditions needed - into a CTE of its own, so from that point on
+        joining that CTE is all the filtering the query has left to do.
+        """
+        self._for_filter = set(aliases)
+
+    def add(self, *sql: str) -> None:
+        """Add ready-made joins that only the main query needs.
+
+        Used for the dynamically built folder/product field blocks.
+        """
+        self._extra.extend(sql)
+
+    def _emit(self, aliases: set[str]) -> list[str]:
+        return [sql for alias, sql in self._available.items() if alias in aliases]
+
+    @property
+    def filtering(self) -> list[str]:
+        """Joins needed to evaluate the WHERE conditions."""
+        return self._emit(self._for_filter)
+
+    @property
+    def selecting(self) -> list[str]:
+        """Joins needed to pick and order the rows of a page."""
+        return self._emit(self._for_filter | self._for_sort)
+
+    @property
+    def all(self) -> list[str]:
+        """Joins of the main query."""
+        used = self._for_filter | self._for_sort | self._for_output
+        return self._emit(used) + self._extra
 
 
 async def get_versions(
@@ -189,24 +409,13 @@ async def get_versions(
 
     sql_cte = []
     sql_conditions = []
-    sql_joins = [
-        f"""
-        INNER JOIN project_{project_name}.products AS products
-        ON products.id = versions.product_id
-        """,
-        f"""
-        INNER JOIN project_{project_name}.exported_attributes AS folder_ex
-        ON folder_ex.folder_id = products.folder_id
-        """,
-        f"""
-        INNER JOIN project_{project_name}.folders AS folders
-        ON folders.id = products.folder_id
-        """,
-        f"""
-        LEFT JOIN project_{project_name}.tasks AS tasks
-        ON tasks.id = versions.task_id
-        """,
-    ]
+
+    joins = Joins(project_name)
+    # products is the root every folder-side join hangs off (they all
+    # match on products.folder_id), and it is what latestPerFolder groups
+    # by, so it takes part in filtering unconditionally.
+    joins.for_filter("products")
+    joins.for_output("folder_ex", "folders", "tasks")
 
     sql_columns = [
         "versions.*",
@@ -216,66 +425,15 @@ async def get_versions(
     ]
 
     if fields.any_endswith("latestComments"):
-        # A correlated LATERAL fetch (indexed via activity_origin_desc_idx on
-        # entity_type, entity_id, created_at DESC) instead of a CTE that
-        # aggregates every version's comments project-wide and then joins
-        # that back in: with several other LATERAL joins (rv/lv/ldv/hv)
-        # already forcing this query into a nested-loop-heavy plan, postgres
-        # was never promoting that join to a hash join, and instead
-        # rescanning the whole aggregated comment set per output row.
-        sql_joins.append(
-            f"""
-            LEFT JOIN LATERAL (
-                SELECT json_agg(
-                    json_build_object(
-                        'activity_id', activity_id,
-                        'body', body,
-                        'author', author,
-                        'created_at', created_at
-                    )
-                    ORDER BY created_at DESC
-                ) AS comments
-                FROM (
-                    SELECT
-                        activity_id,
-                        body,
-                        activity_data->>'author' AS author,
-                        created_at
-                    FROM project_{project_name}.activity_feed
-                    WHERE activity_type = 'comment'
-                    AND entity_type = 'version'
-                    AND reference_type = 'origin'
-                    AND entity_id = versions.id
-                    ORDER BY created_at DESC
-                    LIMIT 5
-                ) x
-            ) comments ON true
-            """
-        )
+        joins.for_output("comments")
         sql_columns.append("comments.comments AS latest_comments")
 
     if fields.any_endswith("hasReviewables") or (has_reviewables is not None):
-        # A correlated LATERAL probe (indexed on activity_references.entity_id)
-        # instead of a "reviewables" CTE: the CTE gets referenced twice here
-        # (column + filter), which forces postgres to materialize it, i.e.
-        # compute reviewable status for every version in the whole project
-        # before pagination is applied, rather than per-row on demand.
-        sql_joins.append(
-            f"""
-            LEFT JOIN LATERAL (
-                SELECT entity_id AS id
-                FROM project_{project_name}.activity_feed
-                WHERE entity_type = 'version'
-                AND activity_type = 'reviewable'
-                AND entity_id = versions.id
-                LIMIT 1
-            ) rv ON true
-            """
-        )
-
+        joins.for_output("rv")
         sql_columns.append("rv IS NOT NULL AS has_reviewables")
 
         if has_reviewables is not None:
+            joins.for_filter("rv")
             if has_reviewables:
                 sql_conditions.append("rv IS NOT NULL")
             else:
@@ -338,13 +496,8 @@ async def get_versions(
 
         if include_folder_children:
             sql_cte.extend(create_child_folder_ctes(project_name, folder_ids))
-
-            sql_joins.append(
-                """
-                INNER JOIN child_folder_ids AS cfi
-                ON cfi.id = products.folder_id
-                """
-            )
+            # The join itself is the filter
+            joins.for_filter("cfi")
 
         else:
             sql_conditions.append(
@@ -373,43 +526,7 @@ async def get_versions(
             """
         )
 
-        sql_joins.extend(
-            [
-                f"""
-                LEFT JOIN LATERAL (
-                    SELECT id
-                    FROM project_{project_name}.versions lv_inner
-                    WHERE lv_inner.product_id = versions.product_id
-                    AND lv_inner.version >= 0
-                    ORDER BY lv_inner.creation_order DESC
-                    LIMIT 1
-                ) lv ON true
-                """,
-                f"""
-                LEFT JOIN LATERAL (
-                    SELECT v.id
-                    FROM project_{project_name}.versions v
-                    WHERE v.product_id = versions.product_id
-                    AND v.version >= 0
-                    AND v.status IN (SELECT name FROM done_statuses)
-                    ORDER BY v.creation_order DESC
-                    LIMIT 1
-                ) ldv ON true
-                """,
-                f"""
-                LEFT JOIN LATERAL (
-                    SELECT
-                        versions.id AS id,
-                        hero_versions.id AS hero_version_id
-                    FROM project_{project_name}.versions AS hero_versions
-                    WHERE hero_versions.product_id = versions.product_id
-                    AND hero_versions.version < 0
-                    AND ABS(hero_versions.version) = versions.version
-                    LIMIT 1
-                ) hv ON true
-                """,
-            ]
-        )
+        joins.for_output("lv", "ldv", "hv")
 
         sql_columns.extend(
             [
@@ -425,6 +542,7 @@ async def get_versions(
     #
 
     if latest_only:
+        joins.for_filter("lv")
         sql_conditions.append("versions.id = lv.id")
 
     elif hero_only:
@@ -440,6 +558,7 @@ async def get_versions(
         sql_conditions.append("(versions.version < 0 OR versions.version IS NOT NULL)")
 
     elif has_hero:
+        joins.for_filter("hv")
         sql_conditions.append("hv.id IS NOT NULL")
 
     #
@@ -453,10 +572,13 @@ async def get_versions(
         coalesce_args = []
         for flag in featured_only:
             if flag == "hero":
+                joins.for_filter("hv")
                 coalesce_args.append("hv.id")
             elif flag == "latestDone":
+                joins.for_filter("ldv")
                 coalesce_args.append("ldv.id")
             elif flag == "latest":
+                joins.for_filter("lv")
                 coalesce_args.append("lv.id")
             else:
                 raise BadRequestException(
@@ -518,16 +640,13 @@ async def get_versions(
                     )
                 """
             )
-        sql_joins.append(
-            """
-            INNER JOIN guest_accessible_versions AS gav
-            ON gav.entity_id = versions.id
-            """
-        )
+        # The join itself is the filter
+        joins.for_filter("gav")
 
     elif not user.is_manager:
         access_list = await create_folder_access_list(root, info)
         if access_list is not None:
+            joins.for_filter("folder_ex")
             sql_conditions.append(
                 f"folder_ex.path like ANY ('{{ {','.join(access_list)} }}')"
             )
@@ -537,6 +656,7 @@ async def get_versions(
     #
 
     if search:
+        joins.for_filter("folder_ex")
         terms = slugify(search, make_set=True, min_length=2, split_chars=" ")
 
         for term in terms:
@@ -556,11 +676,6 @@ async def get_versions(
     #
     # Filter
     #
-
-    # Backwards-compat fallback for projects with NULL product_base_type
-    product_base_type_expr = (
-        "COALESCE(products.product_base_type, products.product_type)"
-    )
 
     if filter:
         column_whitelist = [
@@ -593,14 +708,14 @@ async def get_versions(
             column_whitelist=column_whitelist,
             table_prefix="versions",
             column_map={
-                "product_type": "products.product_type",
-                "product_base_type": product_base_type_expr,
-                "task_type": "tasks.task_type",
-                "folder_type": "folders.folder_type",
-                "hero_version_id": "hv.hero_version_id",
+                column: expression
+                for column, (expression, _) in FILTER_COLUMN_SOURCES.items()
             },
         ):
             sql_conditions.append(fcond)
+            for column in filter_columns(fq):
+                if source := FILTER_COLUMN_SOURCES.get(column):
+                    joins.for_filter(source[1])
 
     if product_filter:
         column_whitelist = [
@@ -627,7 +742,7 @@ async def get_versions(
             column_whitelist=column_whitelist,
             table_prefix="products",
             column_map={
-                "product_base_type": product_base_type_expr,
+                "product_base_type": PRODUCT_BASE_TYPE,
             },
         ):
             sql_conditions.append(fcond)
@@ -658,6 +773,7 @@ async def get_versions(
             table_prefix="tasks",
         ):
             sql_conditions.append(fcond)
+            joins.for_filter("tasks")
 
     if folder_filter:
         column_whitelist = [
@@ -685,6 +801,7 @@ async def get_versions(
             column_map={"attrib": "folder_ex.attrib"},
         ):
             sql_conditions.append(fcond)
+            joins.for_filter("folders", "folder_ex")
             use_folder_query = True
 
     #
@@ -692,37 +809,45 @@ async def get_versions(
     #
 
     if latest_per_folder:
+        # creation_order is unique and monotonic within a project, so the
+        # highest one in a folder *is* the folder's latest version, and
+        # max() over a hash aggregate (one entry per folder) replaces what
+        # DISTINCT ON (folder_id) can only do as a full sort of every
+        # matching version.
+        #
+        # joins.filtering keeps out everything the conditions don't need,
+        # which matters most for the LATERALs feeding latestComments /
+        # isLatest / hasReviewables: they are correlated subqueries, so
+        # having them in here means running them once per version in the
+        # project rather than once per returned row.
         sql_cte.append(
             f"""
-            latest_matching_versions AS (
-                SELECT DISTINCT ON (products.folder_id) versions.id
+            latest_versions_per_folder AS MATERIALIZED (
+                SELECT max(versions.creation_order) AS creation_order
                 FROM project_{project_name}.versions AS versions
-                {" ".join(sql_joins)}
+                {" ".join(joins.filtering)}
                 {SQLTool.conditions(sql_conditions)}
-                ORDER BY products.folder_id, versions.creation_order DESC
+                GROUP BY products.folder_id
             )
             """
         )
-        sql_joins.append(
-            """
-            INNER JOIN latest_matching_versions AS lmv
-            ON lmv.id = versions.id
-            """
-        )
-        # Every condition above is already baked into latest_matching_versions,
-        # so the outer query only needs to look rows up by id (primary key).
+
+        # Everything above is now baked into latest_versions_per_folder,
+        # so joining it replaces both the conditions and the joins they
+        # needed. products stays: the sort and output joins hang off it.
+        joins.replace_filtering("products", "lvpf")
         sql_conditions = []
 
     if any("product" in str(field) for field in fields) or use_folder_query:
         product_columns, product_joins = get_product_fields_block()
         sql_columns.extend(product_columns)
-        sql_joins.extend(product_joins)
+        joins.add(*product_joins)
 
         folder_columns, folder_joins = get_folder_fields_block(
-            project_name, "products.folder_id", sql_joins=sql_joins
+            project_name, "products.folder_id", sql_joins=joins.all
         )
         sql_columns.extend(folder_columns)
-        sql_joins.extend(folder_joins)
+        joins.add(*folder_joins)
 
     #
     # Pagination
@@ -730,6 +855,7 @@ async def get_versions(
 
     order_by = ["versions.creation_order"]
     if sort_by is not None:
+        joins.for_sort(*SORT_JOINS.get(sort_by, ()))
         if sort_by == "status":
             status_type_case = get_status_sort_case(project, "versions.status")
             order_by.insert(0, status_type_case)
@@ -744,6 +870,8 @@ async def get_versions(
         else:
             raise ValueError(f"Invalid sort_by value: {sort_by}")
 
+    sql_from = f"project_{project_name}.versions AS versions"
+
     ordering = ""
     cursor = "''"
     if not calculate_statistics and not calculate_specific_statistics:
@@ -755,6 +883,35 @@ async def get_versions(
             before,
         )
         sql_conditions.append(paging_conds)
+
+        # Pick the page first, using only the joins needed to filter and
+        # sort, and hydrate those rows below. The main query is a wide one
+        # - every LATERAL in it is correlated, and the field blocks join
+        # in whole folders and products - and without this it all happens
+        # before ORDER BY ... LIMIT, i.e. for every version the filters
+        # match. Postgres can't defer it on its own: a LIMIT makes a
+        # fast-start nested loop look cheap, so it starts feeding rows
+        # through the LATERALs in sort order and hopes to hit the limit
+        # early, which never happens when the surviving rows are rare.
+        sql_cte.append(
+            f"""
+            page AS MATERIALIZED (
+                SELECT versions.id
+                FROM project_{project_name}.versions AS versions
+                {" ".join(joins.selecting)}
+                {SQLTool.conditions(sql_conditions)}
+                {ordering}
+            )
+            """
+        )
+
+        # Rows to return, and nothing else, drive the main query.
+        sql_from = f"""
+            page
+            INNER JOIN project_{project_name}.versions AS versions
+            ON versions.id = page.id
+            """
+        sql_conditions = []
 
     #
     # Query
@@ -809,8 +966,8 @@ async def get_versions(
         {cte}
         {raw_data_start}
         SELECT {cursor}, {", ".join(sql_columns)}
-        FROM project_{project_name}.versions AS versions
-        {" ".join(sql_joins)}
+        FROM {sql_from}
+        {" ".join(joins.all)}
         {SQLTool.conditions(sql_conditions)}
         {ordering}
         {raw_data_end}

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -216,45 +216,40 @@ async def get_versions(
     ]
 
     if fields.any_endswith("latestComments"):
-        sql_cte.append(
+        # A correlated LATERAL fetch (indexed via activity_origin_desc_idx on
+        # entity_type, entity_id, created_at DESC) instead of a CTE that
+        # aggregates every version's comments project-wide and then joins
+        # that back in: with several other LATERAL joins (rv/lv/ldv/hv)
+        # already forcing this query into a nested-loop-heavy plan, postgres
+        # was never promoting that join to a hash join, and instead
+        # rescanning the whole aggregated comment set per output row.
+        sql_joins.append(
             f"""
-            comments AS (
-                SELECT
-                    entity_id,
-                    json_agg(
-                        json_build_object(
-                            'activity_id', activity_id,
-                            'body', body,
-                            'author', author,
-                            'created_at', created_at
-                        )
-                        ORDER BY created_at DESC
-                    ) AS comments
+            LEFT JOIN LATERAL (
+                SELECT json_agg(
+                    json_build_object(
+                        'activity_id', activity_id,
+                        'body', body,
+                        'author', author,
+                        'created_at', created_at
+                    )
+                    ORDER BY created_at DESC
+                ) AS comments
                 FROM (
                     SELECT
                         activity_id,
-                        entity_id,
                         body,
                         activity_data->>'author' AS author,
-                        created_at,
-                        row_number() OVER (
-                            PARTITION BY entity_id
-                            ORDER BY created_at DESC
-                        ) AS rn
+                        created_at
                     FROM project_{project_name}.activity_feed
                     WHERE activity_type = 'comment'
                     AND entity_type = 'version'
                     AND reference_type = 'origin'
+                    AND entity_id = versions.id
+                    ORDER BY created_at DESC
+                    LIMIT 5
                 ) x
-                WHERE rn <= 5
-                GROUP BY entity_id
-            )
-            """
-        )
-        sql_joins.append(
-            """
-            LEFT JOIN comments
-            ON comments.entity_id = versions.id
+            ) comments ON true
             """
         )
         sql_columns.append("comments.comments AS latest_comments")
@@ -767,7 +762,10 @@ async def get_versions(
 
     if sql_cte:
         cte = ", ".join(sql_cte)
-        cte = f"WITH {cte}"
+        # RECURSIVE (harmless for the non-recursive CTEs here) is required
+        # when folder_ids+includeFolderChildren adds create_child_folder_ctes'
+        # self-referencing CTE.
+        cte = f"WITH RECURSIVE {cte}"
     else:
         cte = ""
 

--- a/ayon_server/helpers/inherited_attributes.py
+++ b/ayon_server/helpers/inherited_attributes.py
@@ -76,15 +76,19 @@ async def _rebuild_from(project_name: str, project_attrib: dict[str, Any]) -> No
 async def rebuild_inherited_attributes(
     project_name: str,
     pattr: dict[str, Any] | None = None,
+    *,
+    refresh_hierarchy: bool = True,
     **kwargs,  # TODO: catch kwargs and log deprecation warning
 ):
     """Rebuild inherited attributes for all objects in the project."""
     start = time.monotonic()
 
     async with Postgres.transaction():
-        await Postgres.execute(
-            f"REFRESH MATERIALIZED VIEW project_{project_name}.hierarchy"
-        )
+        if refresh_hierarchy:
+            logger.trace(f"Refreshing {project_name} hierarchy")
+            await Postgres.execute(
+                f"REFRESH MATERIALIZED VIEW project_{project_name}.hierarchy"
+            )
 
         if pattr is None:
             project_attrib = attribute_library.project_defaults

--- a/ayon_server/lib/postgres.py
+++ b/ayon_server/lib/postgres.py
@@ -119,6 +119,11 @@ class Postgres:
             max_size=ayonconfig.postgres_pool_size,
             max_inactive_connection_lifetime=20,
             init=postgres_setup,
+            # Resolvers build ad-hoc SQL (conditions inlined into the query
+            # text, not parameterized), so almost every request gets its own
+            # distinct plan - postgres never amortizes JIT compilation across
+            # repeated executions the way a prepared-statement app would.
+            server_settings={"jit": "off"},
         )
 
     @classmethod

--- a/ayon_server/metrics/system.py
+++ b/ayon_server/metrics/system.py
@@ -100,6 +100,11 @@ class SystemMetrics:
         proc_mem = process.memory_info()
 
         redis_size = await Redis.get_total_size()
+        try:
+            cbo = await Redis.get("global", "concurrent-background-operations")
+            cbo_count = int(cbo.decode()) if cbo else 0
+        except Exception:
+            cbo_count = 0
 
         return [
             Metric("cpu_usage", psutil.cpu_percent()),
@@ -111,6 +116,10 @@ class SystemMetrics:
             Metric("runtime_seconds", time.time() - self.run_time),
             Metric("redis_size_total", redis_size),
             Metric("asyncio_tasks", len(asyncio.all_tasks())),
+            Metric(
+                "concurrent_background_operations",
+                cbo_count,
+            ),
         ]
 
     async def render_prometheus(self) -> str:

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -124,6 +124,23 @@ class QueryFilter(OPModel):
         return v.lower()
 
 
+def filter_columns(f: QueryFilter) -> set[str]:
+    """Return the set of columns a filter references.
+
+    Columns are returned in their snake_case form, without the path to
+    the key within JSON columns, so `attrib/fps` is reported as `attrib`.
+    Resolvers use this to find out which joins a filter needs.
+    """
+    result: set[str] = set()
+    for condition in f.conditions:
+        if isinstance(condition, QueryFilter):
+            result |= filter_columns(condition)
+        else:
+            key = condition.key.replace("/", ".").split(".")[0]
+            result.add(camel_to_snake(key.strip()))
+    return result
+
+
 JSON_FIELDS = [
     "summary",
     "payload",


### PR DESCRIPTION
This pull request introduces several performance and maintainability improvements across the codebase, primarily focused on optimizing SQL queries, improving concurrency, and enhancing metrics. The most significant changes include a major rewrite of how child folder queries are handled (now using recursive CTEs for better performance), improvements to concurrency handling in folder listing, and enhanced metrics reporting. Additionally, several GraphQL resolvers have been refactored to use more efficient SQL constructs, and database server settings have been tuned for the app's query patterns.

**Folder and Hierarchy Query Optimization**
* Replaced previous path-based child folder resolution with a new `create_child_folder_ctes` function that uses recursive CTEs and indexed `parent_id` lookups, greatly improving query performance and planner accuracy for large projects. [
* Updated all GraphQL resolvers that use child folder CTEs to utilize the new function and ensure `WITH RECURSIVE` is used when needed. 

**Concurrency and Caching Improvements**
* Refactored the folder list endpoint to use a `RequestCoalescer` for more efficient handling of concurrent requests, replacing manual lock and future management. 

**Metrics and Observability**
* Added a new metric for concurrent background operations, reporting the value from Redis, and improved error handling around this metric.

**SQL and Query Plan Enhancements**
* Refactored version resolver logic to use correlated LATERAL joins for fetching latest comments and reviewable status, avoiding expensive CTE materialization and improving query performance. 
* Disabled Postgres JIT compilation for this connection pool, as the app's dynamic SQL generation prevents plan reuse and JIT amortization.


These changes collectively improve the scalability, reliability, and observability of the system, especially for large projects and under high concurrency.