### PR TITLE
Background operation queue

### DIFF
--- a/api/operations/operations.py
+++ b/api/operations/operations.py
@@ -1,15 +1,15 @@
 from typing import Literal
 
-from fastapi import BackgroundTasks
-
 from ayon_server.api.context import get_request_context
 from ayon_server.api.dependencies import CurrentUser, ProjectName
+from ayon_server.background.operations_queue import (
+    BACKGROUND_OPS_TTL,
+    operations_queue,
+)
 from ayon_server.exceptions import ForbiddenException, NotFoundException
 from ayon_server.lib.redis import Redis
-from ayon_server.logging import logger
 from ayon_server.operations.project_level import (
     OperationModel,
-    OperationsProgress,
     OperationsResponseModel,
     ProjectLevelOperations,
 )
@@ -17,8 +17,6 @@ from ayon_server.types import Field, OPModel
 from ayon_server.utils.hashing import create_uuid
 
 from .router import router
-
-BACKGROUND_OPS_TTL = 1800  # 30 minutes
 
 
 class OperationsRequestModel(OPModel):
@@ -93,97 +91,19 @@ class BackgroundOperationsResponseModel(OPModel):
     result: OperationsResponseModel | None = None
 
 
-async def _execute_background_operations(
-    task_id: str,
-    ops: ProjectLevelOperations,
-    *,
-    can_fail: bool,
-) -> None:
-    try:
-        req_count = await Redis.incr(
-            "global",
-            "concurrent-background-operations",
-            ttl=BACKGROUND_OPS_TTL,
-        )
-
-        msg = "Starting background operations"
-        if req_count > 2:
-            msg += f" ({req_count - 1} already running)"
-            logger.debug(msg)
-        else:
-            logger.trace(msg)
-
-        await Redis.set_json(
-            "background-operations",
-            task_id,
-            {
-                "status": "in_progress",
-                "progress": 0.0,
-            },
-            ttl=BACKGROUND_OPS_TTL,
-        )
-
-        async def handle_progress(progress: OperationsProgress) -> None:
-            percent = (
-                (progress.index / progress.total) if progress.total else 0.0
-            ) * 100.0
-            try:
-                await Redis.set_json(
-                    "background-operations",
-                    task_id,
-                    {
-                        "status": "in_progress",
-                        "progress": percent,
-                    },
-                    ttl=BACKGROUND_OPS_TTL,
-                )
-                await Redis.expire(
-                    "global",
-                    "concurrent-background-operations",
-                    ttl=BACKGROUND_OPS_TTL,
-                )
-            except Exception:
-                pass  # not super important
-
-        response = await ops.process(
-            can_fail=can_fail,
-            raise_on_error=False,
-            wait_for_events=True,
-            progress_handler=handle_progress,
-        )
-
-        # TODO: To be discussed.
-        # should we use failed? probably not, because the task itself completed
-        # and the result is available. depending on can_fail,
-        # the result may contain errors, but the task itself is completed.
-        # status = "completed" if response.success else "failed"
-
-        await Redis.set_json(
-            "background-operations",
-            task_id,
-            {
-                "status": "completed",
-                "result": response.dict(),
-                "progress": 100.0,
-            },
-            ttl=BACKGROUND_OPS_TTL,
-        )
-
-    finally:
-        await Redis.decr("global", "concurrent-background-operations")
-
-
 @router.post("/projects/{project_name}/operations/background")
 async def background_operations(
     payload: OperationsRequestModel,
     project_name: ProjectName,
     user: CurrentUser,
-    background_tasks: BackgroundTasks,
 ) -> BackgroundOperationsResponseModel:
     """
     The same as `POST /projects/{project_name}/operations` but runs in the background.
     The response is returned immediately and contains a task ID that can be used to
     query the status of the task.
+
+    Queued tasks are processed one at a time per server replica, to avoid
+    overloading a single replica with concurrent operations.
     """
 
     request_context = get_request_context()
@@ -205,19 +125,16 @@ async def background_operations(
 
     task_id = create_uuid()
 
-    background_tasks.add_task(
-        _execute_background_operations,
-        task_id,
-        ops,
-        can_fail=payload.can_fail,
-    )
-
+    # Set the initial status before enqueueing: the queue worker may start
+    # processing (and overwrite the status) as soon as the item is queued.
     await Redis.set_json(
         "background-operations",
         task_id,
         {"status": "pending"},
         ttl=BACKGROUND_OPS_TTL,
     )
+    await operations_queue.enqueue(task_id, ops, can_fail=payload.can_fail)
+
     return BackgroundOperationsResponseModel(id=task_id)
 
 

--- a/ayon_server/background/operations_queue.py
+++ b/ayon_server/background/operations_queue.py
@@ -1,0 +1,126 @@
+import asyncio
+from typing import NamedTuple
+
+from ayon_server.background.background_worker import BackgroundWorker
+from ayon_server.lib.redis import Redis
+from ayon_server.logging import log_traceback, logger
+from ayon_server.operations.project_level import (
+    OperationsProgress,
+    ProjectLevelOperations,
+)
+
+BACKGROUND_OPS_TTL = 1800  # 30 minutes
+
+
+class QueuedOperations(NamedTuple):
+    task_id: str
+    ops: ProjectLevelOperations
+    can_fail: bool
+
+
+async def _execute_background_operations(
+    task_id: str,
+    ops: ProjectLevelOperations,
+    *,
+    can_fail: bool,
+) -> None:
+    await Redis.set_json(
+        "background-operations",
+        task_id,
+        {
+            "status": "in_progress",
+            "progress": 0.0,
+        },
+        ttl=BACKGROUND_OPS_TTL,
+    )
+
+    async def handle_progress(progress: OperationsProgress) -> None:
+        percent = ((progress.index / progress.total) if progress.total else 0.0) * 100.0
+        try:
+            await Redis.set_json(
+                "background-operations",
+                task_id,
+                {
+                    "status": "in_progress",
+                    "progress": percent,
+                },
+                ttl=BACKGROUND_OPS_TTL,
+            )
+        except Exception:
+            pass  # not super important
+
+    response = await ops.process(
+        can_fail=can_fail,
+        raise_on_error=False,
+        wait_for_events=True,
+        progress_handler=handle_progress,
+    )
+
+    # TODO: To be discussed.
+    # should we use failed? probably not, because the task itself completed
+    # and the result is available. depending on can_fail,
+    # the result may contain errors, but the task itself is completed.
+    # status = "completed" if response.success else "failed"
+
+    await Redis.set_json(
+        "background-operations",
+        task_id,
+        {
+            "status": "completed",
+            "result": response.dict(),
+            "progress": 100.0,
+        },
+        ttl=BACKGROUND_OPS_TTL,
+    )
+
+
+class OperationsQueue(BackgroundWorker):
+    """Serializes background project operations within a single replica.
+
+    Background operations (POST .../operations/background) used to be fired
+    off as unmanaged fastapi BackgroundTasks - one per request, with no limit
+    on how many could run at once. That allowed concurrent requests to clash
+    on the same project (e.g. piling up materialized view refreshes) and let
+    a burst of requests overload a single replica.
+
+    This worker processes queued operations one at a time, per replica.
+    It does not coordinate across replicas.
+    """
+
+    def initialize(self):
+        self.queue: asyncio.Queue[QueuedOperations] = asyncio.Queue()
+
+    async def enqueue(
+        self,
+        task_id: str,
+        ops: ProjectLevelOperations,
+        *,
+        can_fail: bool,
+    ) -> None:
+        req_count = await Redis.incr(
+            "global",
+            "concurrent-background-operations",
+            ttl=BACKGROUND_OPS_TTL,
+        )
+        msg = "Queueing background operations"
+        if req_count > 2:
+            msg += f" ({req_count - 1} already queued or running)"
+            logger.debug(msg)
+        else:
+            logger.trace(msg)
+
+        await self.queue.put(QueuedOperations(task_id, ops, can_fail))
+
+    async def run(self):
+        while True:
+            task_id, ops, can_fail = await self.queue.get()
+            try:
+                await _execute_background_operations(task_id, ops, can_fail=can_fail)
+            except Exception:
+                log_traceback(f"Background operations task {task_id} failed")
+            finally:
+                self.queue.task_done()
+                await Redis.decr("global", "concurrent-background-operations")
+
+
+operations_queue = OperationsQueue()

--- a/ayon_server/background/workers.py
+++ b/ayon_server/background/workers.py
@@ -3,6 +3,7 @@ from ayon_server.installer import background_installer
 from .background_worker import BackgroundWorker
 from .invalidate_actions import invalidate_actions
 from .log_collector import log_collector
+from .operations_queue import operations_queue
 
 
 class BackgroundWorkers:
@@ -24,6 +25,7 @@ class BackgroundWorkers:
             background_installer,
             invalidate_actions,
             log_collector,
+            operations_queue,
         ]
 
     def start(self):

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -205,12 +205,7 @@ class FolderEntity(ProjectLevelEntity):
                     self.path.lstrip("/"),
                 )
 
-            res = await super().delete()
-            if not res:
-                return False
-            elif auto_commit:
-                await self.commit()
-        return res
+            return await super().delete(*args, auto_commit=auto_commit, **kwargs)
 
     async def get_versions(self) -> list[str]:
         """Return of version ids associated with this folder."""


### PR DESCRIPTION
This pull request refactors how background project operations are managed and executed. Previously, background operations were handled as unmanaged FastAPI `BackgroundTasks`, which could lead to concurrent execution issues and overload a single server replica. The new implementation introduces a dedicated operations queue and worker to serialize execution, ensuring only one background operation runs at a time per replica. The logic for queueing and executing background operations has been moved into a new module, and the relevant API endpoint has been updated accordingly.

**Background operations management:**

* Introduced a new `OperationsQueue` class in `ayon_server/background/operations_queue.py` to serialize background project operations, ensuring only one runs at a time per server replica. This prevents concurrent background tasks from overloading a single replica.
* Moved the logic for executing background operations from `api/operations/operations.py` to the new `operations_queue.py` module, including Redis status updates and progress handling. 
* Updated the API endpoint in `api/operations/operations.py` to enqueue background operations via the new queue instead of using FastAPI `BackgroundTasks`. The endpoint now sets the initial task status and queues the operation for serialized processing.

**Worker registration:**

* Registered the new `operations_queue` worker in the background workers list in `ayon_server/background/workers.py`, ensuring it starts with the application.

**Code cleanup and bug fixes:**

* Simplified the `delete` method in `ayon_server/entities/folder.py` to properly pass arguments to the superclass and handle `auto_commit` consistently.


This is a proof of idea, open for experiments.