### PR TITLE
feat(activities): add activityId to inbox.message

### DIFF
--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -383,12 +383,13 @@ async def create_activity(
                 notify_normal.append(ref.entity_name)
 
         notify_description = body.split("\n")[0]
+        inbox_summary = {"activityId": activity_id, "activityType": activity_type}
         if notify_important:
             await EventStream.dispatch(
                 "inbox.message",
                 project=project_name,
                 description=notify_description,
-                summary={"isImportant": True},
+                summary={**inbox_summary, "isImportant": True},
                 recipients=notify_important,
                 store=False,
                 user=user_name,
@@ -398,7 +399,7 @@ async def create_activity(
                 "inbox.message",
                 project=project_name,
                 description=notify_description,
-                summary={"isImportant": False},
+                summary={**inbox_summary, "isImportant": False},
                 recipients=notify_normal,
                 store=False,
                 user=user_name,


### PR DESCRIPTION
## PR Checklist

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

`inbox.message` websocket events now carry `activityId` and `activityType` in the summary.

Now fronted can fetch exact message activity by id.

### Technical details

- `create_activity.py`, both dispatch sites (important + normal).
- `store=False`, so websocket payload only — no DB or event-schema change. Additive: old clients ignore the new keys.
- No GraphQL change needed; `project.activities(activityIds: [...])` already exists.

### Additional context

Used by ynput/ayon-frontend#2217 (inbox project filtering) for realtime top-ups.
