### PR TITLE
Hide internal folder from the API

### DIFF
--- a/api/folders/folders.py
+++ b/api/folders/folders.py
@@ -3,6 +3,8 @@ from fastapi import Query
 from ayon_server.api.dependencies import CurrentUser, FolderID, ProjectName
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
 from ayon_server.entities import FolderEntity
+from ayon_server.exceptions import BadRequestException
+from ayon_server.helpers.hierarchy_cache import AYON_INTERNAL_FOLDER_NAME
 from ayon_server.operations.project_level import ProjectLevelOperations
 
 from .router import router
@@ -38,6 +40,9 @@ async def create_folder(
 ) -> EntityIdResponse:
     """Create a new folder."""
 
+    if post_data.name.startswith(AYON_INTERNAL_FOLDER_NAME):
+        raise BadRequestException("reserved folder name")
+
     ops = ProjectLevelOperations(project_name, user=user)
 
     ops.create("folder", **post_data.dict(exclude_unset=True))
@@ -64,6 +69,9 @@ async def update_folder(
     Once there is a version published, the folder's name and hierarchy
     cannot be changed.
     """
+
+    if post_data.name.startswith(AYON_INTERNAL_FOLDER_NAME):
+        raise BadRequestException("reserved folder name")
 
     ops = ProjectLevelOperations(project_name, user=user)
     ops.update("folder", folder_id, **post_data.dict(exclude_unset=True))

--- a/api/hierarchy/hierarchy.py
+++ b/api/hierarchy/hierarchy.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Query
 
 from ayon_server.access.utils import folder_access_list
 from ayon_server.api.dependencies import CurrentUser, ProjectName
+from ayon_server.helpers.hierarchy_cache import AYON_INTERNAL_FOLDER_NAME
 from ayon_server.lib.postgres import Postgres
 from ayon_server.types import Field, OPModel
 from ayon_server.utils import EntityID, SQLTool
@@ -73,7 +74,10 @@ async def get_folder_hierarchy(
 
     hierarchy = HierarchyResolver()
 
-    conds = []
+    conds = [
+        f"path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'",
+    ]
+
     if type_list:
         conds.append(f"folder_type IN {SQLTool.array(type_list)}")
 

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -404,3 +404,9 @@ def get_has_links_conds(
             f"{id_field} IN (SELECT input_id FROM project_{project_name}.links)",
         ]
     raise ValueError("Wrong has_links value")
+
+
+ARGIncludeInternalFolder = Annotated[
+    bool,
+    argdesc("Whether to include the AYON internal folder and its descendants"),
+]

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -18,12 +18,6 @@ from .pagination import encode_cursor
 DEFAULT_PAGE_SIZE = 100
 
 
-ARGIncludeInternalFolder = Annotated[
-    bool,
-    argdesc("Whether to include the AYON internal folder and its descendants"),
-]
-
-
 @strawberry.enum
 class HasLinksFilter(Enum):
     NONE = "none"
@@ -71,6 +65,10 @@ ARGLast = Annotated[int | None, argdesc("Pagination: last")]
 ARGBefore = Annotated[str | None, argdesc("Pagination: before")]
 ARGIds = Annotated[list[str] | None, argdesc("List of ids to be returned")]
 ARGHasLinks = Annotated[HasLinksFilter | None, argdesc("Filter by links presence")]
+ARGIncludeInternalFolder = Annotated[
+    bool,
+    argdesc("Whether to include the AYON internal folder and its descendants"),
+]
 
 
 class FieldInfo:

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -8,6 +8,7 @@ from ayon_server.graphql.connections import FoldersConnection
 from ayon_server.graphql.edges import FolderEdge
 from ayon_server.graphql.nodes.folder import FolderNode
 from ayon_server.graphql.types import Info
+from ayon_server.helpers.hierarchy_cache import AYON_INTERNAL_FOLDER_NAME
 from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import (
     validate_name,
@@ -161,7 +162,9 @@ async def get_folders(
         """,
     ]
     sql_group_by = ["folders.id", "pr.attrib", "ex.attrib", "hierarchy.path"]
-    sql_conditions = []
+    sql_conditions = [
+        f"ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'",
+    ]
     sql_having = []
 
     access_list = await create_folder_access_list(root, info)

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -24,6 +24,7 @@ from .common import (
     ARGFirst,
     ARGHasLinks,
     ARGIds,
+    ARGIncludeInternalFolder,
     ARGLast,
     AttributeFilterInput,
     ColumnMetadata,
@@ -125,6 +126,7 @@ async def get_folders(
         list[MetricTargetInput] | None,
         argdesc("Map of attribute names to lists of desired statistical aggregations"),
     ] = None,
+    include_internal_folder: ARGIncludeInternalFolder = False,
 ) -> FoldersConnection:
     """Return a list of folders."""
 
@@ -162,12 +164,13 @@ async def get_folders(
         """,
     ]
     sql_group_by = ["folders.id", "pr.attrib", "ex.attrib", "hierarchy.path"]
-    sql_conditions = [
-        f"ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'",
-    ]
+    sql_conditions = []
     sql_having = []
 
     access_list = await create_folder_access_list(root, info)
+
+    if not include_internal_folder:
+        sql_conditions.append(f"ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
 
     if access_list is not None:
         sql_conditions.append(

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -12,6 +12,7 @@ from ayon_server.graphql.resolvers.common import (
     ARGFirst,
     ARGHasLinks,
     ARGIds,
+    ARGIncludeInternalFolder,
     ARGLast,
     ColumnMetadata,
     FieldInfo,
@@ -25,6 +26,7 @@ from ayon_server.graphql.resolvers.common import (
 )
 from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
+from ayon_server.helpers.hierarchy_cache import AYON_INTERNAL_FOLDER_NAME
 from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import (
     validate_name_list,
@@ -137,6 +139,7 @@ async def get_products(
         list[MetricTargetInput] | None,
         argdesc("Map of attribute names to lists of desired statistical aggregations"),
     ] = None,
+    include_internal_folder: ARGIncludeInternalFolder = False,
 ) -> ProductsConnection:
     """Return a list of products."""
 
@@ -170,6 +173,9 @@ async def get_products(
 
     sql_cte = []
     sql_conditions = []
+
+    if not include_internal_folder:
+        sql_conditions.append(f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
 
     if ids is not None:
         if not ids:

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -147,7 +147,7 @@ async def get_representations(
 
         if not include_internal_folder:
             sql_conditions.append(
-                f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
+                f"hierarchy.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
             )
 
         if access_list is not None:

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -11,6 +11,7 @@ from ayon_server.graphql.resolvers.common import (
     ARGFirst,
     ARGHasLinks,
     ARGIds,
+    ARGIncludeInternalFolder,
     ARGLast,
     FieldInfo,
     argdesc,
@@ -20,6 +21,7 @@ from ayon_server.graphql.resolvers.common import (
 )
 from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
+from ayon_server.helpers.hierarchy_cache import AYON_INTERNAL_FOLDER_NAME
 from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import validate_name_list, validate_status_list
 from ayon_server.utils import SQLTool
@@ -46,6 +48,7 @@ async def get_representations(
     has_links: ARGHasLinks = None,
     search: Annotated[str | None, argdesc("Fuzzy text search filter")] = None,
     filter: Annotated[str | None, argdesc("Filter tasks using QueryFilter")] = None,
+    include_internal_folder: ARGIncludeInternalFolder = False,
 ) -> RepresentationsConnection:
     """Return a list of representations."""
 
@@ -140,6 +143,11 @@ async def get_representations(
                 "versions.version AS _version_number",
             ]
         )
+
+        if not include_internal_folder:
+            sql_conditions.append(
+                f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
+            )
 
         if access_list is not None:
             sql_conditions.append(

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -15,6 +15,7 @@ from ayon_server.graphql.resolvers.common import (
     ARGFirst,
     ARGHasLinks,
     ARGIds,
+    ARGIncludeInternalFolder,
     ARGLast,
     AttributeFilterInput,
     ColumnMetadata,
@@ -28,6 +29,7 @@ from ayon_server.graphql.resolvers.common import (
     sortdesc,
 )
 from ayon_server.graphql.types import Info
+from ayon_server.helpers.hierarchy_cache import AYON_INTERNAL_FOLDER_NAME
 from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import (
     sanitize_string_list,
@@ -183,6 +185,7 @@ async def get_tasks(
         list[MetricTargetInput] | None,
         argdesc("Map of attribute names to lists of desired statistical aggregations"),
     ] = None,
+    include_internal_folder: ARGIncludeInternalFolder = False,
 ) -> TasksConnection:
     """Return a list of tasks."""
 
@@ -282,6 +285,9 @@ async def get_tasks(
             ON c.entity_id = tasks.id
             """
         )
+
+    if not include_internal_folder:
+        sql_conditions.append(f"hierarchy.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
 
     if ids is not None:
         if not ids:

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -12,6 +12,7 @@ from ayon_server.graphql.resolvers.common import (
     ARGFirst,
     ARGHasLinks,
     ARGIds,
+    ARGIncludeInternalFolder,
     ARGLast,
     ColumnMetadata,
     FieldInfo,
@@ -26,6 +27,7 @@ from ayon_server.graphql.resolvers.common import (
 )
 from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
+from ayon_server.helpers.hierarchy_cache import AYON_INTERNAL_FOLDER_NAME
 from ayon_server.sqlfilter import QueryFilter, build_filter, filter_columns
 from ayon_server.types import (
     validate_name_list,
@@ -404,6 +406,7 @@ async def get_versions(
         list[MetricTargetInput] | None,
         argdesc("Map of attribute names to lists of desired statistical aggregations"),
     ] = None,
+    include_internal_folder: ARGIncludeInternalFolder = False,
 ) -> VersionsConnection:
     """Return a list of versions."""
 
@@ -434,6 +437,9 @@ async def get_versions(
         "folder_ex.path AS _folder_path",
         "products.name AS _product_name",
     ]
+
+    if not include_internal_folder:
+        sql_conditions.append(f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
 
     if fields.any_endswith("latestComments"):
         joins.for_output("comments")

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -439,9 +439,6 @@ async def get_versions(
         "products.name AS _product_name",
     ]
 
-    if not include_internal_folder:
-        sql_conditions.append(f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
-
     if fields.any_endswith("latestComments"):
         joins.for_output("comments")
         sql_columns.append("comments.comments AS latest_comments")
@@ -614,6 +611,10 @@ async def get_versions(
         sql_conditions.extend(
             get_has_links_conds(project_name, "versions.id", has_links)
         )
+
+    if not include_internal_folder:
+        joins.for_filter("folder_ex")
+        sql_conditions.append(f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
 
     #
     # Access control

--- a/ayon_server/graphql/resolvers/workfiles.py
+++ b/ayon_server/graphql/resolvers/workfiles.py
@@ -10,6 +10,7 @@ from ayon_server.graphql.resolvers.common import (
     ARGFirst,
     ARGHasLinks,
     ARGIds,
+    ARGIncludeInternalFolder,
     ARGLast,
     FieldInfo,
     argdesc,
@@ -20,6 +21,7 @@ from ayon_server.graphql.resolvers.common import (
 )
 from ayon_server.graphql.resolvers.pagination import create_pagination
 from ayon_server.graphql.types import Info
+from ayon_server.helpers.hierarchy_cache import AYON_INTERNAL_FOLDER_NAME
 from ayon_server.types import validate_name_list, validate_status_list
 from ayon_server.utils import SQLTool, slugify
 
@@ -52,6 +54,7 @@ async def get_workfiles(
     has_links: ARGHasLinks = None,
     search: Annotated[str | None, argdesc("Fuzzy text search filter")] = None,
     sort_by: Annotated[str | None, sortdesc(SORT_OPTIONS)] = None,
+    include_internal_folder: ARGIncludeInternalFolder = False,
 ) -> WorkfilesConnection:
     """Return a list of workfiles."""
 
@@ -132,6 +135,11 @@ async def get_workfiles(
                 """,
             ]
         )
+
+        if not include_internal_folder:
+            sql_conditions.append(
+                f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
+            )
 
         if access_list is not None:
             sql_conditions.append(

--- a/ayon_server/helpers/hierarchy_cache.py
+++ b/ayon_server/helpers/hierarchy_cache.py
@@ -6,6 +6,8 @@ from ayon_server.lib.redis import Redis
 from ayon_server.logging import logger
 from ayon_server.utils import json_dumps
 
+AYON_INTERNAL_FOLDER_NAME = "__ayon_internal__"
+
 
 async def rebuild_hierarchy_cache(project_name: str) -> list[dict[str, Any]]:
     start_time = time.monotonic()
@@ -70,6 +72,8 @@ async def rebuild_hierarchy_cache(project_name: str) -> list[dict[str, Any]]:
 
         LEFT JOIN reviewables r
         ON r.folder_id = f.id
+
+        WHERE ea.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'
 
         GROUP BY f.id, ea.attrib, ea.path, fwv.ancestor_id, r.folder_id
     """


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [ ] Referenced issue is linked

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Introduces the concept of an internal folder called `__ayon_internal__` which can be used to store a hierarchy of entities meant to be hidden in regular AYON UI. This folder and its descendants are never returned by the API.

When creating a new folder or patching an existing one, the folder name cannot start with `__ayon_internal__`, otherwise a Bad Request exception is thrown.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

### Additional context

This functionality is useful for whenever we want to create a hierarchy of entities that isn't supposed to appear in the AYON UI. For instance, an addon might keep its own folder with various entities which are only supposed to be accessed by it.

<!-- Add any other context or screenshots here. -->
