### PR TITLE
Add flag to suppress notifications when saving entities, creating reviewables or deleting activities

### DIFF
--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -58,7 +58,7 @@ async def create_activity(
     sender: str | None = None,
     sender_type: str | None = None,
     bump_entity_updated_at: bool = False,
-    send_notifications: bool = True,
+    create_events: bool = True,
 ) -> str:
     """Create an activity.
 
@@ -326,7 +326,7 @@ async def create_activity(
         "body": body,
     }
 
-    if send_notifications:
+    if create_events:
         with logger.contextualize(activity_id=activity_id, activity_type=activity_type):
             await EventStream.dispatch(
                 "activity.created",

--- a/ayon_server/activities/create_activity.py
+++ b/ayon_server/activities/create_activity.py
@@ -58,6 +58,7 @@ async def create_activity(
     sender: str | None = None,
     sender_type: str | None = None,
     bump_entity_updated_at: bool = False,
+    send_notifications: bool = True,
 ) -> str:
     """Create an activity.
 
@@ -325,84 +326,87 @@ async def create_activity(
         "body": body,
     }
 
-    with logger.contextualize(activity_id=activity_id, activity_type=activity_type):
-        await EventStream.dispatch(
-            "activity.created",
-            project=project_name,
-            description=f"Created {activity_type} activity",
-            summary=summary,
-            store=activity_type not in DO_NOT_TRACK_ACTIVITIES,
-            user=user_name,
-            sender=sender,
-            sender_type=sender_type,
-            payload=event_payload,
-        )
+    if send_notifications:
+        with logger.contextualize(activity_id=activity_id, activity_type=activity_type):
+            await EventStream.dispatch(
+                "activity.created",
+                project=project_name,
+                description=f"Created {activity_type} activity",
+                summary=summary,
+                store=activity_type not in DO_NOT_TRACK_ACTIVITIES,
+                user=user_name,
+                sender=sender,
+                sender_type=sender_type,
+                payload=event_payload,
+            )
 
-        # Send inbox notifications
+            # Send inbox notifications
 
-        notify_important: list[str] = []
-        notify_normal: list[str] = []
-        _prj: ProjectEntity | None = None
-        for ref in references:
-            if ref.entity_type != "user":
-                continue
-            assert ref.entity_name is not None, "This should have been checked before"
-            if ref.reference_type == "author":
-                continue
-
-            if category := data.get("category"):
-                category = str(category).strip()
-                if _prj is None:
-                    _prj = await ProjectEntity.load(project_name)
-                try:
-                    _usr = await UserEntity.load(ref.entity_name)
-                except NotFoundException:
-                    # User does not exist, skip notification
+            notify_important: list[str] = []
+            notify_normal: list[str] = []
+            _prj: ProjectEntity | None = None
+            for ref in references:
+                if ref.entity_type != "user":
                     continue
-                accessible_categories = (
-                    await ActivityCategories.get_accessible_categories(
-                        _usr,
-                        project=_prj,
-                    )
+                assert ref.entity_name is not None, (
+                    "This should have been checked before"
                 )
-                if category not in accessible_categories:
-                    # Just for debugging purposes
-                    # logger.trace(
-                    #     f"Not notifying user {ref.entity_name} "
-                    #     f"about activity {activity_id} "
-                    #     f"due to inaccessible category '{category}'"
-                    # )
+                if ref.reference_type == "author":
                     continue
 
-            if (
-                ref.reference_type in ["mention", "watching"]
-                and activity_type != "status.change"
-            ):
-                notify_important.append(ref.entity_name)
-            elif ref.entity_name not in notify_important:
-                notify_normal.append(ref.entity_name)
+                if category := data.get("category"):
+                    category = str(category).strip()
+                    if _prj is None:
+                        _prj = await ProjectEntity.load(project_name)
+                    try:
+                        _usr = await UserEntity.load(ref.entity_name)
+                    except NotFoundException:
+                        # User does not exist, skip notification
+                        continue
+                    accessible_categories = (
+                        await ActivityCategories.get_accessible_categories(
+                            _usr,
+                            project=_prj,
+                        )
+                    )
+                    if category not in accessible_categories:
+                        # Just for debugging purposes
+                        # logger.trace(
+                        #     f"Not notifying user {ref.entity_name} "
+                        #     f"about activity {activity_id} "
+                        #     f"due to inaccessible category '{category}'"
+                        # )
+                        continue
 
-        notify_description = body.split("\n")[0]
-        inbox_summary = {"activityId": activity_id, "activityType": activity_type}
-        if notify_important:
-            await EventStream.dispatch(
-                "inbox.message",
-                project=project_name,
-                description=notify_description,
-                summary={**inbox_summary, "isImportant": True},
-                recipients=notify_important,
-                store=False,
-                user=user_name,
-            )
-        if notify_normal:
-            await EventStream.dispatch(
-                "inbox.message",
-                project=project_name,
-                description=notify_description,
-                summary={**inbox_summary, "isImportant": False},
-                recipients=notify_normal,
-                store=False,
-                user=user_name,
-            )
+                if (
+                    ref.reference_type in ["mention", "watching"]
+                    and activity_type != "status.change"
+                ):
+                    notify_important.append(ref.entity_name)
+                elif ref.entity_name not in notify_important:
+                    notify_normal.append(ref.entity_name)
+
+            notify_description = body.split("\n")[0]
+            inbox_summary = {"activityId": activity_id, "activityType": activity_type}
+            if notify_important:
+                await EventStream.dispatch(
+                    "inbox.message",
+                    project=project_name,
+                    description=notify_description,
+                    summary={**inbox_summary, "isImportant": True},
+                    recipients=notify_important,
+                    store=False,
+                    user=user_name,
+                )
+            if notify_normal:
+                await EventStream.dispatch(
+                    "inbox.message",
+                    project=project_name,
+                    description=notify_description,
+                    summary={**inbox_summary, "isImportant": False},
+                    recipients=notify_normal,
+                    store=False,
+                    user=user_name,
+                )
 
     return activity_id

--- a/ayon_server/activities/delete_activity.py
+++ b/ayon_server/activities/delete_activity.py
@@ -17,6 +17,7 @@ async def delete_activity(
     is_admin: bool = False,
     sender: str | None = None,
     sender_type: str | None = None,
+    send_notifications=True,
 ) -> None:
     """Delete an activity.
 
@@ -90,16 +91,16 @@ async def delete_activity(
         )
 
         # Notify the front-end about the deleted activity
-
-        await EventStream.dispatch(
-            "activity.deleted",
-            project=project_name,
-            description=f"Deleted {activity_type} activity",
-            summary=summary,
-            store=activity_type not in DO_NOT_TRACK_ACTIVITIES,
-            user=user_name,
-            sender=sender,
-            sender_type=sender_type,
-        )
+        if send_notifications:
+            await EventStream.dispatch(
+                "activity.deleted",
+                project=project_name,
+                description=f"Deleted {activity_type} activity",
+                summary=summary,
+                store=activity_type not in DO_NOT_TRACK_ACTIVITIES,
+                user=user_name,
+                sender=sender,
+                sender_type=sender_type,
+            )
 
     return None

--- a/ayon_server/activities/delete_activity.py
+++ b/ayon_server/activities/delete_activity.py
@@ -17,7 +17,7 @@ async def delete_activity(
     is_admin: bool = False,
     sender: str | None = None,
     sender_type: str | None = None,
-    send_notifications=True,
+    create_events: bool = True,
 ) -> None:
     """Delete an activity.
 
@@ -91,7 +91,7 @@ async def delete_activity(
         )
 
         # Notify the front-end about the deleted activity
-        if send_notifications:
+        if create_events:
             await EventStream.dispatch(
                 "activity.deleted",
                 project=project_name,

--- a/ayon_server/entity_lists/entity_list.py
+++ b/ayon_server/entity_lists/entity_list.py
@@ -347,7 +347,7 @@ class EntityList:
         user: UserEntity | None = None,
         sender: str | None = None,
         sender_type: str | None = None,
-        send_notifications=True,
+        create_events: bool = True,
     ) -> EntityListSummary:
         """Save the entity list to the database"""
         _user = user or self._user
@@ -358,7 +358,7 @@ class EntityList:
                 user=_user,
                 sender=sender,
                 sender_type=sender_type,
-                send_notifications=send_notifications,
+                create_events=create_events,
             )
 
     async def delete(

--- a/ayon_server/entity_lists/entity_list.py
+++ b/ayon_server/entity_lists/entity_list.py
@@ -347,6 +347,7 @@ class EntityList:
         user: UserEntity | None = None,
         sender: str | None = None,
         sender_type: str | None = None,
+        send_notifications=True,
     ) -> EntityListSummary:
         """Save the entity list to the database"""
         _user = user or self._user
@@ -357,6 +358,7 @@ class EntityList:
                 user=_user,
                 sender=sender,
                 sender_type=sender_type,
+                send_notifications=send_notifications,
             )
 
     async def delete(

--- a/ayon_server/entity_lists/save_entity_list.py
+++ b/ayon_server/entity_lists/save_entity_list.py
@@ -13,7 +13,7 @@ async def save_entity_list(
     user: UserEntity | None = None,
     sender: str | None = None,
     sender_type: str | None = None,
-    send_notifications=True,
+    create_events: bool = True,
 ) -> EntityListSummary:
     """
     Save the entity list to the database.
@@ -162,7 +162,7 @@ async def save_entity_list(
 
     description = f"Entity list {payload.label} {mode}"
 
-    if send_notifications:
+    if create_events:
         await EventStream.dispatch(
             f"entity_list.{mode}",
             description=description,

--- a/ayon_server/entity_lists/save_entity_list.py
+++ b/ayon_server/entity_lists/save_entity_list.py
@@ -13,6 +13,7 @@ async def save_entity_list(
     user: UserEntity | None = None,
     sender: str | None = None,
     sender_type: str | None = None,
+    send_notifications=True,
 ) -> EntityListSummary:
     """
     Save the entity list to the database.
@@ -161,13 +162,15 @@ async def save_entity_list(
 
     description = f"Entity list {payload.label} {mode}"
 
-    await EventStream.dispatch(
-        f"entity_list.{mode}",
-        description=description,
-        summary=summary.dict(),
-        project=project_name,
-        user=user.name if user else None,
-        sender=sender,
-        sender_type=sender_type,
-    )
+    if send_notifications:
+        await EventStream.dispatch(
+            f"entity_list.{mode}",
+            description=description,
+            summary=summary.dict(),
+            project=project_name,
+            user=user.name if user else None,
+            sender=sender,
+            sender_type=sender_type,
+        )
+
     return summary

--- a/ayon_server/reviewables/create_reviewable.py
+++ b/ayon_server/reviewables/create_reviewable.py
@@ -38,6 +38,7 @@ async def create_reviewable(
     user_name: str | None = None,
     sender: str | None = None,
     sender_type: str | None = None,
+    send_notifications: bool = True,
 ) -> ReviewableModel:
     """Creates a reviewable for a given version.
 
@@ -83,6 +84,7 @@ async def create_reviewable(
         data={"reviewableLabel": label},
         user_name=user_name,
         bump_entity_updated_at=True,
+        send_notifications=send_notifications,
     )
 
     summary = {
@@ -136,15 +138,16 @@ async def create_reviewable(
             f"for version {version.id}"
         )
 
-    await EventStream.dispatch(
-        "reviewable.created",
-        sender=sender,
-        sender_type=sender_type,
-        user=user_name,
-        project=project_name,
-        summary=summary,
-        description=f"Reviewable '{file_name}' uploaded",
-    )
+    if send_notifications:
+        await EventStream.dispatch(
+            "reviewable.created",
+            sender=sender,
+            sender_type=sender_type,
+            user=user_name,
+            project=project_name,
+            summary=summary,
+            description=f"Reviewable '{file_name}' uploaded",
+        )
 
     return ReviewableModel(
         file_id=file_id,

--- a/ayon_server/reviewables/create_reviewable.py
+++ b/ayon_server/reviewables/create_reviewable.py
@@ -38,7 +38,7 @@ async def create_reviewable(
     user_name: str | None = None,
     sender: str | None = None,
     sender_type: str | None = None,
-    send_notifications: bool = True,
+    create_events: bool = True,
 ) -> ReviewableModel:
     """Creates a reviewable for a given version.
 
@@ -84,7 +84,7 @@ async def create_reviewable(
         data={"reviewableLabel": label},
         user_name=user_name,
         bump_entity_updated_at=True,
-        send_notifications=send_notifications,
+        create_events=create_events,
     )
 
     summary = {
@@ -138,7 +138,7 @@ async def create_reviewable(
             f"for version {version.id}"
         )
 
-    if send_notifications:
+    if create_events:
         await EventStream.dispatch(
             "reviewable.created",
             sender=sender,


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [ ] Referenced issue is linked

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Adds the ability to perform certain operations without sending websocket notifications. The operations are:

- `EntityList.save`
- `create_reviewable`
- `delete_activity`

These functions get an optional `create_events` boolean flag which is true by default.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

### Additional context

For some addons, we have the use case of frequently updating an entity list of versions and replacing reviewables on those versions. This allows the addon to auto-save user's changes on the list/version. In order not to flood the event logs and reports with too many messages, we need a way to make the updates without sending notifications.

<!-- Add any other context or screenshots here. -->
