### PR TITLE
Implemented saving data.mediaInfo for video attached in comments

### DIFF
--- a/api/files/files.py
+++ b/api/files/files.py
@@ -103,6 +103,23 @@ async def upload_project_file(
             file_id,
         )
 
+    if content_type.startswith("video"):
+        try:
+            media_info = await storage.extract_media_info(file_id)
+        except Exception as e:
+            logger.warning(f"Failed to extract media info for {file_id}: {e}")
+            media_info = {}
+        if media_info:
+            await Postgres.execute(
+                f"""
+                UPDATE project_{project_name}.files
+                SET data = data || $1::jsonb
+                WHERE id = $2
+                """,
+                {"mediaInfo": media_info},
+                file_id,
+            )
+
     return CreateFileResponseModel(id=file_id)
 
 

--- a/ayon_server/activities/utils.py
+++ b/ayon_server/activities/utils.py
@@ -106,6 +106,9 @@ async def process_activity_files(
         if mime := data.get("mime"):
             file_info["mime"] = mime
 
+        if media_info := data.get("mediaInfo"):
+            file_info["mediaInfo"] = media_info
+
         result.append(file_info)
 
     return result

--- a/ayon_server/files/project_storage.py
+++ b/ayon_server/files/project_storage.py
@@ -392,7 +392,8 @@ class ProjectStorage:
             f"""
             SELECT size,
             data->>'mime' as content_type,
-            data->>'filename' as filename
+            data->>'filename' as filename,
+            data->'mediaInfo' as media_info
             FROM project_{self.project_name}.files
             WHERE id = $1
             """,
@@ -413,6 +414,7 @@ class ProjectStorage:
             if finfo:
                 result.filename = finfo["filename"]
                 result.content_type = finfo["content_type"]
+                result.media_info = finfo.get("media_info")
                 return result
 
         raise AyonException("Unknown storage type")

--- a/ayon_server/graphql/nodes/activity.py
+++ b/ayon_server/graphql/nodes/activity.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any
 
 import strawberry
+from strawberry.scalars import JSON
 
 from ayon_server.activities.activity_categories import ActivityCategories
 from ayon_server.exceptions import ForbiddenException
@@ -40,6 +41,9 @@ class ActivityFileNode:
     author: str | None = strawberry.field()
     name: str | None = strawberry.field()
     mime: str | None = strawberry.field()
+    media_info: JSON | None = strawberry.field(
+        default=None, description="Media info extracted from the file"
+    )
     created_at: datetime = strawberry.field()
     updated_at: datetime = strawberry.field()
 
@@ -191,6 +195,7 @@ class ActivityNode:
                     size=str(file.get("size", "0")),
                     author=file.get("author"),
                     mime=file.get("mime"),
+                    media_info=file.get("mediaInfo"),
                     created_at=file["created_at"],
                     updated_at=file["updated_at"],
                 )

--- a/ayon_server/models/file_info.py
+++ b/ayon_server/models/file_info.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import root_validator
 
 from .rest_model import RestModel
@@ -26,6 +28,7 @@ class FileInfo(RestModel):
     size: int
     filename: str = "unknown"
     content_type: str = "application/octet-stream"
+    media_info: dict[str, Any] | None = None
 
     @root_validator(pre=True)
     def set_content_type(cls, values):


### PR DESCRIPTION
## Description of changes

Uses `ffprobe` to store `mediaInfo` for videos uploaded via Activity comment in similar fashion as `reviewables` have.

Will be used for proper playback by correct `fps`.


### Additional context

Use `api/projects/ayon_project/files/{video_file_attached_in_comment}/info` for testing
