### PR TITLE
Remove audit trail configuration directive

### DIFF
--- a/api/addons/project_settings.py
+++ b/api/addons/project_settings.py
@@ -8,7 +8,6 @@ from ayon_server.addons import AddonLibrary
 from ayon_server.api.dependencies import CurrentUser, ProjectName, SiteID
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.bundles.project_bundles import has_project_bundle_addon
-from ayon_server.config import ayonconfig
 from ayon_server.entities import ProjectEntity
 from ayon_server.events import EventStream
 from ayon_server.exceptions import (
@@ -513,11 +512,10 @@ async def set_raw_addon_project_overrides(
             return EmptyResponse()
         original_data = res[0]["original_data"]
         updated_data = res[0]["updated_data"]
-        if ayonconfig.audit_trail:
-            payload = {
-                "originalValue": original_data or {},
-                "newValue": updated_data or {},
-            }
+        payload = {
+            "originalValue": original_data or {},
+            "newValue": updated_data or {},
+        }
 
         description = f"{addon_name} {addon_version} {variant} "
         description += "overrides changed using low-level API"

--- a/api/addons/studio_settings.py
+++ b/api/addons/studio_settings.py
@@ -7,7 +7,6 @@ from pydantic.error_wrappers import ValidationError
 from ayon_server.addons import AddonLibrary
 from ayon_server.api.dependencies import CurrentUser
 from ayon_server.api.responses import EmptyResponse
-from ayon_server.config import ayonconfig
 from ayon_server.events import EventStream
 from ayon_server.exceptions import (
     BadRequestException,
@@ -264,11 +263,10 @@ async def set_raw_addon_studio_overrides(
         return EmptyResponse()
     original_data = res[0]["original_data"]
     updated_data = res[0]["updated_data"]
-    if ayonconfig.audit_trail:
-        payload = {
-            "originalValue": original_data or {},
-            "newValue": updated_data or {},
-        }
+    payload = {
+        "originalValue": original_data or {},
+        "newValue": updated_data or {},
+    }
 
     description = (
         f"{addon_name} {addon_version} {variant} overrides changed using low-level API"

--- a/api/tasks/tasks.py
+++ b/api/tasks/tasks.py
@@ -6,7 +6,6 @@ from ayon_server.api.dependencies import (
     TaskID,
 )
 from ayon_server.api.responses import EmptyResponse, EntityIdResponse
-from ayon_server.config import ayonconfig
 from ayon_server.entities import TaskEntity
 from ayon_server.events import EventStream
 from ayon_server.exceptions import ForbiddenException
@@ -157,11 +156,10 @@ async def assign_users_to_task(
         "summary": {"entityId": task.id, "parentId": task.folder_id},
         "user": user.name,
     }
-    if ayonconfig.audit_trail:
-        event_payload["payload"] = {
-            "oldValue": list(original_assignees),
-            "newValue": list(assignees),
-        }
+    event_payload["payload"] = {
+        "oldValue": list(original_assignees),
+        "newValue": list(assignees),
+    }
 
     await EventStream.dispatch("entity.task.assignees_changed", **event_payload)
 

--- a/api/users/users.py
+++ b/api/users/users.py
@@ -176,10 +176,14 @@ async def delete_user(
 
     target_user = await UserEntity.load(user_name)
 
+    entity_data = target_user.dict_simple()
+    entity_data["data"].pop("password", None)
+    entity_data["data"].pop("apiKey", None)
+
     event: dict[str, Any] = {
         "description": f"User {user_name} deleted",
         "summary": {"entityName": user_name},
-        "payload": {"entityData": target_user.dict_simple()},
+        "payload": {"entityData": entity_data},
     }
 
     await target_user.delete()

--- a/api/users/users.py
+++ b/api/users/users.py
@@ -179,7 +179,7 @@ async def delete_user(
     event: dict[str, Any] = {
         "description": f"User {user_name} deleted",
         "summary": {"entityName": user_name},
-        "entityData": target_user.dict_simple(),
+        "payload": {"entityData": target_user.dict_simple()},
     }
 
     await target_user.delete()

--- a/api/users/users.py
+++ b/api/users/users.py
@@ -11,7 +11,6 @@ from ayon_server.api.dependencies import (
 from ayon_server.api.responses import EmptyResponse
 from ayon_server.auth.session import Session
 from ayon_server.auth.utils import validate_password
-from ayon_server.config import ayonconfig
 from ayon_server.entities import UserEntity
 from ayon_server.events import EventStream
 from ayon_server.exceptions import (
@@ -180,11 +179,8 @@ async def delete_user(
     event: dict[str, Any] = {
         "description": f"User {user_name} deleted",
         "summary": {"entityName": user_name},
+        "entityData": target_user.dict_simple(),
     }
-    if ayonconfig.audit_trail:
-        event["payload"] = {
-            "entityData": target_user.dict_simple(),
-        }
 
     await target_user.delete()
     await EventStream.dispatch("entity.user.deleted", **event)

--- a/ayon_server/config/ayonconfig.py
+++ b/ayon_server/config/ayonconfig.py
@@ -173,11 +173,6 @@ class AyonConfig(BaseModel):
         description="Disable REST API documentation",
     )
 
-    audit_trail: bool = Field(
-        default=True,
-        description="Enable audit trail",
-    )
-
     openapi_include_internal_endpoints: bool = Field(
         default=False,
         description="Include internal endpoints in the OpenAPI schema",

--- a/ayon_server/events/patch.py
+++ b/ayon_server/events/patch.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from ayon_server.config import ayonconfig
 from ayon_server.entities import ProjectEntity
 from ayon_server.entities.core import ProjectLevelEntity
 
@@ -118,12 +117,10 @@ def build_pl_entity_change_events(
                 }
             )
             result[-1]["summary"]["value"] = new_name
-            if ayonconfig.audit_trail:
-                payload = {
-                    "oldValue": original_entity.name,
-                    "newValue": new_name,
-                }
-                result[-1]["payload"] = payload
+            result[-1]["payload"] = {
+                "oldValue": original_entity.name,
+                "newValue": new_name,
+            }
 
     if (new_status := patch_data.get("status")) is not None:
         if new_status != original_entity.status:
@@ -138,12 +135,10 @@ def build_pl_entity_change_events(
                 }
             )
             result[-1]["summary"]["value"] = new_status
-            if ayonconfig.audit_trail:
-                payload = {
-                    "oldValue": original_entity.status,
-                    "newValue": new_status,
-                }
-                result[-1]["payload"] = payload
+            result[-1]["payload"] = {
+                "oldValue": original_entity.status,
+                "newValue": new_status,
+            }
 
     if (new_tags := patch_data.get("tags")) is not None:
         if new_tags != original_entity.tags:
@@ -161,12 +156,10 @@ def build_pl_entity_change_events(
                     }
                 )
                 result[-1]["summary"]["value"] = new_tags
-                if ayonconfig.audit_trail:
-                    payload = {
-                        "oldValue": original_entity.tags,
-                        "newValue": new_tags,
-                    }
-                    result[-1]["payload"] = payload
+                result[-1]["payload"] = {
+                    "oldValue": original_entity.tags,
+                    "newValue": new_tags,
+                }
 
     if new_attributes := patch_data.get("attrib", {}):
         evt = {
@@ -188,13 +181,13 @@ def build_pl_entity_change_events(
                 old_attributes.pop(key, None)
                 new_attributes.pop(key, None)
 
-        if ayonconfig.audit_trail:
-            evt["payload"] = {
-                "oldValue": old_attributes,
-                "newValue": new_attributes,
-            }
-            if calculated_attributes:
-                evt["payload"]["calculatedAttributes"] = list(calculated_attributes)  # type: ignore[index]
+        evt["payload"] = {
+            "oldValue": old_attributes,
+            "newValue": new_attributes,
+        }
+
+        if calculated_attributes:
+            evt["payload"]["calculatedAttributes"] = list(calculated_attributes)  # type: ignore[index]
 
         if new_attributes:
             attr_list = ", ".join(new_attributes.keys())
@@ -253,12 +246,10 @@ def build_pl_entity_change_events(
             # for simple columns, we include new value in summary as well
             result[-1]["summary"]["value"] = patch_data[column_name]
 
-        if ayonconfig.audit_trail:
-            payload = {
-                "oldValue": getattr(original_entity, column_name),
-                "newValue": patch_data[column_name],
-            }
-            result[-1]["payload"] = payload
+        result[-1]["payload"] = {
+            "oldValue": getattr(original_entity, column_name),
+            "newValue": patch_data[column_name],
+        }
 
     return result
 
@@ -294,12 +285,10 @@ def build_project_change_events(
             nval[key] = new_value
 
         if oval or nval:
-            if ayonconfig.audit_trail:
-                payload = {
-                    "oldValue": oval,
-                    "newValue": nval,
-                }
-                evt["payload"] = payload
+            evt["payload"] = {
+                "oldValue": oval,
+                "newValue": nval,
+            }
 
             result.append(evt)
 
@@ -331,17 +320,14 @@ def build_project_change_events(
                 description = "Project deactivated"
 
         evt = {
+            **common_data,
             "topic": f"entity.{etype}.{topic_name}",
             "description": description,
-            **common_data,
-        }
-        if ayonconfig.audit_trail:
-            payload = {
+            "payload": {
                 "oldValue": oval,
                 "newValue": nval,
-            }
-            evt["payload"] = payload
-
+            },
+        }
         result.append(evt)
 
     # Original entity.project.changed event

--- a/ayon_server/helpers/migrate_addon_settings.py
+++ b/ayon_server/helpers/migrate_addon_settings.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Any
 
-from ayon_server.config import ayonconfig
 from ayon_server.helpers.project_list import get_project_list
 from ayon_server.lib.postgres import Postgres
 
@@ -54,14 +53,12 @@ async def _migrate_addon_settings(
             original_data = res[0]["data"]
             if original_data != new_studio_overrides:
                 do_copy = True
-                if ayonconfig.audit_trail:
-                    event_payload["originalValue"] = original_data
-                    event_payload["newValue"] = new_studio_overrides
+                event_payload["originalValue"] = original_data
+                event_payload["newValue"] = new_studio_overrides
         else:
             do_copy = True
-            if ayonconfig.audit_trail:
-                event_payload["originalValue"] = {}
-                event_payload["newValue"] = new_studio_overrides
+            event_payload["originalValue"] = {}
+            event_payload["newValue"] = new_studio_overrides
 
         if do_copy:
             event_created = True
@@ -93,8 +90,7 @@ async def _migrate_addon_settings(
         if res:
             event_created = True
             event_description = "studio overrides removed during migration"
-            if ayonconfig.audit_trail:
-                event_payload = {"originalValue": res[0]["data"], "newValue": {}}
+            event_payload = {"originalValue": res[0]["data"], "newValue": {}}
 
     if event_created:
         summary = {
@@ -150,14 +146,12 @@ async def _migrate_addon_settings(
                 original_data = res[0]["data"]
                 if original_data != new_project_overrides:
                     do_copy = True
-                    if ayonconfig.audit_trail:
-                        event_payload["originalValue"] = original_data
-                        event_payload["newValue"] = new_project_overrides
+                    event_payload["originalValue"] = original_data
+                    event_payload["newValue"] = new_project_overrides
             else:
                 do_copy = True
-                if ayonconfig.audit_trail:
-                    event_payload["originalValue"] = {}
-                    event_payload["newValue"] = new_project_overrides
+                event_payload["originalValue"] = {}
+                event_payload["newValue"] = new_project_overrides
 
             if do_copy:
                 event_created = True
@@ -191,8 +185,7 @@ async def _migrate_addon_settings(
             if res:
                 event_created = True
                 event_description = "project overrides removed during migration"
-                if ayonconfig.audit_trail:
-                    event_payload = {"originalValue": res[0]["data"], "newValue": {}}
+                event_payload = {"originalValue": res[0]["data"], "newValue": {}}
 
         if event_created:
             summary = {

--- a/ayon_server/operations/project_level/entity_delete.py
+++ b/ayon_server/operations/project_level/entity_delete.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from ayon_server.config import ayonconfig
 from ayon_server.entities import UserEntity
 from ayon_server.entities.core import ProjectLevelEntity
 from ayon_server.exceptions import ForbiddenException
@@ -41,7 +40,6 @@ async def delete_project_level_entity(
             "user": user.name if user else None,
         }
     ]
-    if ayonconfig.audit_trail:
-        events[0]["payload"] = {"entityData": entity.dict_simple()}
+    events[0]["payload"] = {"entityData": entity.dict_simple()}
     await entity.delete(force=operation.force, auto_commit=False)
     return entity.id, events, 204

--- a/ayon_server/settings/set_addon_settings.py
+++ b/ayon_server/settings/set_addon_settings.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from ayon_server.addons import AddonLibrary
-from ayon_server.config import ayonconfig
 from ayon_server.events import EventStream
 from ayon_server.exceptions import BadRequestException
 from ayon_server.lib.postgres import Postgres
@@ -204,11 +203,10 @@ async def set_addon_settings(
 
     # Dispatch settings.changed event
 
-    if ayonconfig.audit_trail:
-        payload = {
-            "originalValue": original_data or {},
-            "newValue": updated_data or {},
-        }
+    payload = {
+        "originalValue": original_data or {},
+        "newValue": updated_data or {},
+    }
 
     otype = "project " if project_name else "studio "
     if site_id and user_name:


### PR DESCRIPTION
This pull request removes the `audit_trail` configuration flag from the codebase and refactors related logic. Previously, event payloads containing old and new values were only included if `audit_trail` was enabled; with this change, these payloads are always included. The code is simplified by removing conditional checks and the now-unused configuration option.

These changes ensure that audit-related event payloads are always present, and the codebase is cleaner and easier to maintain without the `audit_trail` feature flag. Audit trail became essential in various event handler and disabling it is no longer a good idea.