### PR TITLE
Teams and additional filters in users enum resolver

### DIFF
--- a/ayon_server/enum/resolvers/enum_users.py
+++ b/ayon_server/enum/resolvers/enum_users.py
@@ -1,7 +1,8 @@
+from collections.abc import Iterable
 from typing import Any
 
 from ayon_server.config import ayonconfig
-from ayon_server.entities import ProjectEntity
+from ayon_server.entities import ProjectEntity, UserEntity
 from ayon_server.enum.base_resolver import BaseEnumResolver
 from ayon_server.enum.enum_item import EnumItem
 from ayon_server.exceptions import ForbiddenException
@@ -14,6 +15,73 @@ query = """
     SELECT name, attrib, data, active FROM public.users
     ORDER BY COALESCE(attrib->>'fullName', name)
 """
+
+
+def should_list_user(
+    current_user: UserEntity | None,
+    context: dict[str, Any],
+    udata: dict[str, Any],
+    *,
+    project_name: str | None,
+    skip_if_not_ag: Iterable[str] | None,
+    has_all_user_access: bool,
+) -> bool:
+    """
+    Exclude users that the current user has no access to.
+    Excluded users won't be returned at all opposed to being returned as hidden
+    """
+    is_admin = udata.get("isAdmin", False)
+    is_manager = udata.get("isManager", False)
+
+    if is_admin or is_manager:
+        # we always show admins and managers
+        return True
+
+    if not project_name:
+        return has_all_user_access
+
+    # now we are in project scope
+
+    ags = udata.get("accessGroups", {}).get(project_name, [])
+    if not ags:
+        return False
+
+    if not skip_if_not_ag:
+        return True
+
+    return bool(set(ags).intersection(set(skip_if_not_ag)))
+
+
+def should_hide_user(
+    current_user: UserEntity | None,
+    context: dict[str, Any],
+    udata: dict[str, Any],
+    *,
+    active: bool = True,
+    user_pool_ids: list[str] | None = None,
+) -> bool:
+    """
+    Hide users that the current user has acccess to,
+    but should be hidden from the list. That allows displaying
+    them, but not selecting them.
+    """
+
+    if (
+        current_user
+        and (not current_user.data.get("isSupport", False))
+        and udata.get("isSupport", False)
+    ):
+        # we don't show support users to non-support users
+        return True
+
+    if context.get("hide_inactive"):
+        if not active:
+            return True
+
+        if user_pool_ids and (udata.get("userPool") not in user_pool_ids):
+            return True
+
+    return False
 
 
 class UsersEnumResolver(BaseEnumResolver):
@@ -67,77 +135,36 @@ class UsersEnumResolver(BaseEnumResolver):
             if not current_user_ags:
                 raise ForbiddenException("You don't have access to this project")
 
-        def should_list_user(udata: dict[str, Any]) -> bool:
-            """
-            Exclude users that the current user has no access to.
-            Excluded users won't be returned at all opposed to being returned as hidden
-            """
-            is_admin = udata.get("isAdmin", False)
-            is_manager = udata.get("isManager", False)
-
-            if is_admin or is_manager:
-                # we always show admins and managers
-                return True
-
-            if not project_name:
-                return has_all_user_access
-
-            # now we are in project scope
-
-            ags = udata.get("accessGroups", {}).get(project_name, [])
-            if not ags:
-                return False
-
-            if not skip_if_not_ag:
-                return True
-
-            return bool(set(ags).intersection(set(skip_if_not_ag)))
-
         user_pool_ids = [
             pool.id for pool in await AuthUtils.get_user_pools() if pool.valid
         ]
-
-        def should_hide_user(
-            udata: dict[str, Any],
-            *,
-            active: bool = True,
-        ) -> bool:
-            """
-            Hide users that the current user has acccess to,
-            but should be hidden from the list. That allows displaying
-            them, but not selecting them.
-            """
-
-            if (
-                current_user
-                and (not current_user.data.get("isSupport", False))
-                and udata.get("isSupport", False)
-            ):
-                # we don't show support users to non-support users
-                return True
-
-            if context.get("hide_inactive"):
-                if not active:
-                    return True
-
-                if user_pool_ids and (udata.get("userPool") not in user_pool_ids):
-                    return True
-
-            return False
 
         async with Postgres.transaction():
             stmt = await Postgres.prepare(query)
             async for row in stmt.cursor():
                 name, attrib, udata, active = row
 
-                if not should_list_user(udata):
+                if not should_list_user(
+                    current_user,
+                    context,
+                    udata,
+                    project_name=project_name,
+                    skip_if_not_ag=skip_if_not_ag,
+                    has_all_user_access=has_all_user_access,
+                ):
                     continue
 
                 item = EnumItem(
                     value=name,
                     label=attrib.get("fullName") or name,
                     group="Users",
-                    hidden=should_hide_user(udata, active=active),
+                    hidden=should_hide_user(
+                        current_user,
+                        context,
+                        udata,
+                        active=active,
+                        user_pool_ids=user_pool_ids,
+                    ),
                     icon=IconModel(
                         type="url",
                         url=f"/api/users/{name}/avatar",

--- a/ayon_server/enum/resolvers/enum_users.py
+++ b/ayon_server/enum/resolvers/enum_users.py
@@ -1,15 +1,17 @@
 from typing import Any
 
 from ayon_server.config import ayonconfig
+from ayon_server.entities import ProjectEntity
 from ayon_server.enum.base_resolver import BaseEnumResolver
 from ayon_server.enum.enum_item import EnumItem
 from ayon_server.exceptions import ForbiddenException
+from ayon_server.helpers.auth_utils import AuthUtils
 from ayon_server.lib.postgres import Postgres
 from ayon_server.models import IconModel
 from ayon_server.types import AttributeType
 
 query = """
-    SELECT name, attrib, data FROM public.users
+    SELECT name, attrib, data, active FROM public.users
     ORDER BY COALESCE(attrib->>'fullName', name)
 """
 
@@ -18,7 +20,13 @@ class UsersEnumResolver(BaseEnumResolver):
     name = "users"
 
     async def get_accepted_params(self) -> dict[str, AttributeType]:
-        return {"project_name": "string"}
+        return {
+            "project_name": "string",
+            "include_teams": "boolean",
+            "include_support": "boolean",
+            "hide_inactive": "boolean",  # Hide inactive users and users without license
+            "hide_users": "boolean",  # Hide all users (when listing teams only)
+        }
 
     async def resolve(self, context: dict[str, Any]) -> list[EnumItem]:
         result: list[EnumItem] = []
@@ -60,17 +68,13 @@ class UsersEnumResolver(BaseEnumResolver):
             if not current_user_ags:
                 raise ForbiddenException("You don't have access to this project")
 
-        def should_show_user(udata: dict[str, Any]) -> bool:
+        def should_list_user(udata: dict[str, Any]) -> bool:
+            """
+            Exclude users that the current user has no access to.
+            Excluded users won't be returned at all opposed to being returned as hidden
+            """
             is_admin = udata.get("isAdmin", False)
             is_manager = udata.get("isManager", False)
-
-            if (
-                current_user
-                and (not current_user.data.get("isSupport", False))
-                and udata.get("isSupport", False)
-            ):
-                # we don't show support users to non-support users
-                return False
 
             if is_admin or is_manager:
                 # we always show admins and managers
@@ -90,20 +94,69 @@ class UsersEnumResolver(BaseEnumResolver):
 
             return bool(set(ags).intersection(set(skip_if_not_ag)))
 
+        user_pool_ids = [
+            pool.id for pool in await AuthUtils.get_user_pools() if pool.valid
+        ]
+
+        def should_hide_user(
+            udata: dict[str, Any],
+            *,
+            active: bool = True,
+        ) -> bool:
+            """
+            Hide users that the current user has acccess to,
+            but should be hidden from the list. That allows displaying
+            them, but not selecting them.
+            """
+
+            if (
+                current_user
+                and (not current_user.data.get("isSupport", False))
+                and udata.get("isSupport", False)
+            ):
+                # we don't show support users to non-support users
+                return True
+
+            if context.get("hide_inactive"):
+                if not active:
+                    return True
+
+                if user_pool_ids and udata.get("userPool") not in user_pool_ids:
+                    return True
+
+            return False
+
         async with Postgres.transaction():
             stmt = await Postgres.prepare(query)
             async for row in stmt.cursor():
-                name, attrib, udata = row
+                name, attrib, udata, active = row
 
-                if not should_show_user(udata):
+                if not should_list_user(udata):
                     continue
 
                 item = EnumItem(
                     value=name,
                     label=attrib.get("fullName") or name,
+                    group="Users",
+                    hidden=should_hide_user(udata, active=active),
                     icon=IconModel(
                         type="url",
                         url=f"/api/users/{name}/avatar",
+                    ),
+                )
+                result.append(item)
+
+        if context.get("include_teams") and context.get("project_name"):
+            project = await ProjectEntity.load(context["project_name"])
+            for team in project.data.get("teams", []):
+                team_name = team.get("name") or "Unnamed Team"
+                item = EnumItem(
+                    value=f"team:{team_name}",
+                    label=team_name,
+                    group="Teams",
+                    icon=IconModel(
+                        type="material-symbols",
+                        name="group",
                     ),
                 )
                 result.append(item)

--- a/ayon_server/enum/resolvers/enum_users.py
+++ b/ayon_server/enum/resolvers/enum_users.py
@@ -23,7 +23,6 @@ class UsersEnumResolver(BaseEnumResolver):
         return {
             "project_name": "string",
             "include_teams": "boolean",
-            "include_support": "boolean",
             "hide_inactive": "boolean",  # Hide inactive users and users without license
             "hide_users": "boolean",  # Hide all users (when listing teams only)
         }
@@ -121,7 +120,7 @@ class UsersEnumResolver(BaseEnumResolver):
                 if not active:
                     return True
 
-                if user_pool_ids and udata.get("userPool") not in user_pool_ids:
+                if user_pool_ids and (udata.get("userPool") not in user_pool_ids):
                     return True
 
             return False

--- a/ayon_server/enum/resolvers/enum_users.py
+++ b/ayon_server/enum/resolvers/enum_users.py
@@ -66,6 +66,11 @@ def should_hide_user(
     them, but not selecting them.
     """
 
+    if context.get("hide_users"):
+        # caller only wants teams listed, but users must still resolve
+        # (e.g. metadata for an already-selected user)
+        return True
+
     if (
         current_user
         and (not current_user.data.get("isSupport", False))

--- a/ayon_server/enum/resolvers/enum_users.py
+++ b/ayon_server/enum/resolvers/enum_users.py
@@ -6,6 +6,7 @@ from ayon_server.entities import ProjectEntity, UserEntity
 from ayon_server.enum.base_resolver import BaseEnumResolver
 from ayon_server.enum.enum_item import EnumItem
 from ayon_server.exceptions import ForbiddenException
+from ayon_server.forms.simple_form import SimpleForm
 from ayon_server.helpers.auth_utils import AuthUtils
 from ayon_server.lib.postgres import Postgres
 from ayon_server.models import IconModel
@@ -193,3 +194,11 @@ class UsersEnumResolver(BaseEnumResolver):
                 result.append(item)
 
         return result
+
+    async def get_settings_form(self) -> SimpleForm | None:
+        return (
+            SimpleForm()
+            .boolean("hide_inactive", "Hide inactive users", False)
+            .boolean("hide_users", "Hide all users (for showing teams only)", False)
+            .boolean("include_teams", "Include teams in the list", False)
+        )

--- a/ayon_server/enum/resolvers/enum_users.py
+++ b/ayon_server/enum/resolvers/enum_users.py
@@ -67,7 +67,7 @@ def should_hide_user(
     them, but not selecting them.
     """
 
-    if context.get("hide_users"):
+    if context.get("mode", "users") == "teams":
         # caller only wants teams listed, but users must still resolve
         # (e.g. metadata for an already-selected user)
         return True
@@ -96,9 +96,8 @@ class UsersEnumResolver(BaseEnumResolver):
     async def get_accepted_params(self) -> dict[str, AttributeType]:
         return {
             "project_name": "string",
-            "include_teams": "boolean",
+            "mode": "string",
             "hide_inactive": "boolean",  # Hide inactive users and users without license
-            "hide_users": "boolean",  # Hide all users (when listing teams only)
         }
 
     async def resolve(self, context: dict[str, Any]) -> list[EnumItem]:
@@ -178,7 +177,9 @@ class UsersEnumResolver(BaseEnumResolver):
                 )
                 result.append(item)
 
-        if context.get("include_teams") and context.get("project_name"):
+        mode = context.get("mode", "users")
+
+        if mode in ("teams", "both") and context.get("project_name"):
             project = await ProjectEntity.load(context["project_name"])
             for team in project.data.get("teams", []):
                 team_name = team.get("name") or "Unnamed Team"
@@ -199,6 +200,14 @@ class UsersEnumResolver(BaseEnumResolver):
         return (
             SimpleForm()
             .boolean("hide_inactive", "Hide inactive users", False)
-            .boolean("hide_users", "Hide all users (for showing teams only)", False)
-            .boolean("include_teams", "Include teams in the list", False)
+            .select(
+                "mode",
+                [
+                    {"value": "users", "label": "Users"},
+                    {"value": "teams", "label": "Teams"},
+                    {"value": "both", "label": "Users and teams"},
+                ],
+                "Mode",
+                "users",
+            )
         )


### PR DESCRIPTION
This pull request enhances the `UsersEnumResolver` to provide more flexible and fine-grained control over user and team listings. It introduces new filtering options for hiding inactive users, selectively including teams, and better handling of user visibility based on permissions and licensing.

**Filtering and visibility improvements:**

* Added new accepted parameters to `get_accepted_params`: `include_teams`, `hide_inactive`, and `hide_users`, allowing clients to customize which users and teams are returned.
* Refactored user visibility logic by splitting into `should_list_user` (for access control) and `should_hide_user` (for hiding users from selection but still displaying them when used), improving clarity and permission enforcement.
* Updated the SQL query to fetch the `active` status of users, enabling filtering of inactive users.

**Team inclusion:**

* When `include_teams` and `project_name` are provided, the resolver now appends teams from the specified project to the result, grouping them separately from users.

**Result formatting:**

* Enum items for users are now grouped under `"Users"` and can be marked as hidden based on the new logic, improving frontend handling of selectable and non-selectable users.