### PR TITLE
Fix folder creation access control

### DIFF
--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -232,14 +232,15 @@ class FolderEntity(ProjectLevelEntity):
         Reimplements the method from the parent class, because in
         case of folders we need to check the parent folder.
         """
-        try:
-            if self.parent_id is None:
+
+        if self.parent_id is None:
+            try:
                 # if user can create a project, they can create a root folders
                 user.check_permissions("studio.create_projects")
-        except ForbiddenException:
-            pass
-        else:
-            return
+            except ForbiddenException:
+                pass
+            else:
+                return
 
         await ensure_entity_access(
             user,

--- a/ayon_server/entities/folder.py
+++ b/ayon_server/entities/folder.py
@@ -235,7 +235,7 @@ class FolderEntity(ProjectLevelEntity):
 
         if self.parent_id is None:
             try:
-                # if user can create a project, they can create a root folders
+                # if user can create a project, they can create root folders
                 user.check_permissions("studio.create_projects")
             except ForbiddenException:
                 pass


### PR DESCRIPTION
Refactored the logic in the `ensure_create_access` method by moving the `try` block inside the `if self.parent_id is None` condition, so that permission checks for creating root folders are only wrapped in exception handling when necessary.