### PR TITLE
Include explicitly requested versions from internal folders in `get_versions` GraphQL resolver

### DIFF
--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -612,7 +612,9 @@ async def get_versions(
             get_has_links_conds(project_name, "versions.id", has_links)
         )
 
-    if not include_internal_folder:
+    has_ids = ids is not None and len(ids) > 0
+
+    if not include_internal_folder and not has_ids:
         joins.for_filter("folder_ex")
         sql_conditions.append(f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
 
@@ -1014,7 +1016,7 @@ async def get_version(root, info: Info, id: str) -> VersionNode:
     """Return a task node based on its ID"""
     if not id:
         raise BadRequestException("Version ID not specified")
-    connection = await get_versions(root, info, ids=[id], include_internal_folder=True)
+    connection = await get_versions(root, info, ids=[id])
     if not connection.edges:
         raise NotFoundException("Version not found")
     return connection.edges[0].node

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -1014,7 +1014,7 @@ async def get_version(root, info: Info, id: str) -> VersionNode:
     """Return a task node based on its ID"""
     if not id:
         raise BadRequestException("Version ID not specified")
-    connection = await get_versions(root, info, ids=[id])
+    connection = await get_versions(root, info, ids=[id], include_internal_folder=True)
     if not connection.edges:
         raise NotFoundException("Version not found")
     return connection.edges[0].node


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [ ] Referenced issue is linked

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

The `get_versions` GraphQL resolver currently doesn't include versions from the AYON internal folder by default. However, there are cases where we already know versions (by their IDs) and need to get information about them (e.g. attributes). This should be possible with versions inside the internal folder without adding the `include_internal_folder` flag - we already know the versions exist, after all.

This PR updates the `get_versions` resolver so it returns versions from the internal folder if `ids` is specified and not empty.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

### Additional context

<!-- Add any other context or screenshots here. -->
