### PR TITLE
Service registry authentication

### DIFF
--- a/api/services/services.py
+++ b/api/services/services.py
@@ -31,6 +31,7 @@ class ServiceConfigModel(OPModel):
 
 class ServiceDataModel(ServiceConfigModel):
     image: str | None = Field(None, example="ayon/ftrack-addon-leecher:2.0.0")
+    error: str | None = Field(None, title="Error", example="Failed to start service")
 
 
 class ServiceModel(OPModel):
@@ -131,6 +132,7 @@ async def delete_service(user: CurrentUser, name: str = Path(...)) -> EmptyRespo
 
 class PatchServiceRequestModel(ServiceConfigModel):
     should_run: bool | None = Field(None)
+    error: str | None = Field(None)
     hostname: str | None = Field(None)
 
     # Deprecated, kept for backwards compatibility
@@ -166,6 +168,12 @@ async def patch_service(
 
     if (hostname := patch_dict.pop("hostname", None)) is not None:
         service_data["hostname"] = hostname
+
+    if (error := patch_dict.pop("error", None)) is not None:
+        if service_data["should_run"]:
+            service_data["data"].pop("error", None)
+        else:
+            service_data["data"]["error"] = error
 
     # Old-style config (deprecated)
     if (patch_config := patch_dict.pop("config", None)) is not None:

--- a/api/services/services.py
+++ b/api/services/services.py
@@ -14,6 +14,11 @@ from ayon_server.utils import SQLTool
 from .router import router
 
 
+class RegistryAuth(OPModel):
+    username: str
+    password: str
+
+
 class ServiceConfigModel(OPModel):
     volumes: list[str] | None = Field(None, title="Volumes", example=["/tmp:/tmp"])
     ports: list[str] | None = Field(None, title="Ports", example=["8080:8080"])
@@ -21,6 +26,7 @@ class ServiceConfigModel(OPModel):
     user: str | None = Field(None, title="User", example="1000")
     env: dict[str, Any] = Field(default_factory=dict)
     storage_path: str | None = Field(None, title="Storage", example="/mnt/storage")
+    registry_auth: RegistryAuth | None = None
 
 
 class ServiceDataModel(ServiceConfigModel):


### PR DESCRIPTION
This pull request introduces support for container registry authentication in the service configuration model. The main change is the addition of a new `RegistryAuth` model and its integration into `ServiceConfigModel`.

**New registry authentication support:**

* Added a `RegistryAuth` model with `username` and `password` fields to represent container registry authentication credentials. 
* Added an optional `registry_auth` field to the `ServiceConfigModel`, allowing services to specify registry authentication 

Requires:
- https://github.com/ynput/ayon-frontend/pull/2296
- https://github.com/ynput/ash/pull/17