### PR TITLE
Fix projects resolver pagination with ACL

### DIFF
--- a/ayon_server/graphql/resolvers/projects.py
+++ b/ayon_server/graphql/resolvers/projects.py
@@ -78,7 +78,16 @@ async def get_projects(
     if fields.has_any("data", "bundle") or info.context["user"].is_guest:
         cols.append("data")
 
-    if not user.is_manager:
+    if user.is_guest:
+        if guest_access := user.data.get("guestAccess"):
+            pnames = [g.get("projectName") for g in guest_access]
+            sql_conditions.append(f"projects.name IN {SQLTool.array(pnames)}")
+        else:
+            sql_conditions.append(
+                f"data->'guestUsers'->'{user.attrib.email}' IS NOT NULL"
+            )
+
+    elif not user.is_manager:
         sql_cte.append(
             f"""
             accessible_projects AS (
@@ -129,6 +138,11 @@ async def get_projects(
         {SQLTool.conditions(sql_conditions)}
         {ordering}
     """
+
+    # print()
+    # print ("get_projects query")
+    # print(query)
+    # print()
 
     return await resolve(
         ProjectsConnection,

--- a/ayon_server/graphql/resolvers/projects.py
+++ b/ayon_server/graphql/resolvers/projects.py
@@ -40,6 +40,10 @@ async def get_projects(
 ) -> ProjectsConnection:
     """Return a list of projects."""
 
+    user = info.context["user"]
+
+    sql_cte = []
+    sql_joins = []
     sql_conditions = []
     if name is not None:
         validate_name(name)
@@ -74,6 +78,28 @@ async def get_projects(
     if fields.has_any("data", "bundle") or info.context["user"].is_guest:
         cols.append("data")
 
+    if not user.is_manager:
+        sql_cte.append(
+            f"""
+            accessible_projects AS (
+                SELECT
+                    ag.key AS project
+                FROM users u
+                CROSS JOIN LATERAL jsonb_each(u.data->'accessGroups') AS ag(key, value)
+                WHERE u.name = '{user.name}'
+                AND jsonb_typeof(ag.value) = 'array'
+                AND jsonb_array_length(ag.value) > 0
+            )
+            """
+        )
+
+        sql_joins.append(
+            """
+            JOIN accessible_projects ap
+            ON ap.project = projects.name
+            """
+        )
+
     #
     # Pagination
     #
@@ -89,9 +115,17 @@ async def get_projects(
     # Query
     #
 
+    if sql_cte:
+        cte = ", ".join(sql_cte)
+        cte = f"WITH {cte}"
+    else:
+        cte = ""
+
     query = f"""
+        {cte}
         SELECT {", ".join(cols)}
         FROM public.projects
+        {" ".join(sql_joins)}
         {SQLTool.conditions(sql_conditions)}
         {ordering}
     """


### PR DESCRIPTION
This pull request enhances the access control logic for the `get_projects` GraphQL resolver by restricting non-manager users to see only projects they have access to, based on their access groups. The main changes introduce a Common Table Expression (CTE) and JOIN to filter projects for non-manager users.

Previously, access control was implemented at the end of the chain, and when more than a half of projects were skipped cursor never reached the projects at the end of the page the user had access to