### PR TITLE
Visibility filtering

### DIFF
--- a/api/hierarchy/hierarchy.py
+++ b/api/hierarchy/hierarchy.py
@@ -75,7 +75,7 @@ async def get_folder_hierarchy(
     hierarchy = HierarchyResolver()
 
     conds = [
-        f"path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'",
+        f"NOT starts_with(path, '{AYON_INTERNAL_FOLDER_NAME}')",
     ]
 
     if type_list:

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -27,6 +27,13 @@ class HasLinksFilter(Enum):
     BOTH = "both"
 
 
+@strawberry.enum
+class EntityVisibility(Enum):
+    ALL = "all"
+    VISIBLE = "visible"
+    HIDDEN = "hidden"
+
+
 @strawberry.input
 class AttributeFilterInput:
     name: str
@@ -68,6 +75,13 @@ ARGHasLinks = Annotated[HasLinksFilter | None, argdesc("Filter by links presence
 ARGIncludeInternalFolder = Annotated[
     bool,
     argdesc("Whether to include the AYON internal folder and its descendants"),
+]
+ARGVisibility = Annotated[
+    EntityVisibility,
+    argdesc(
+        "Filter by visibility. 'visible' returns only visible entities, "
+        "'hidden' returns only hidden entities, 'all' (default) returns both."
+    ),
 ]
 
 

--- a/ayon_server/graphql/resolvers/common.py
+++ b/ayon_server/graphql/resolvers/common.py
@@ -79,8 +79,8 @@ ARGIncludeInternalFolder = Annotated[
 ARGVisibility = Annotated[
     EntityVisibility,
     argdesc(
-        "Filter by visibility. 'visible' returns only visible entities, "
-        "'hidden' returns only hidden entities, 'all' (default) returns both."
+        "Filter by visibility. VISIBLE returns only visible entities, "
+        "HIDDEN returns only hidden entities, ALL (default) returns both."
     ),
 ]
 

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -172,12 +172,6 @@ async def get_folders(
     sql_having = []
 
     access_list = await create_folder_access_list(root, info)
-
-    if not include_internal_folder:
-        sql_conditions.append(
-            f"NOT starts_with(COALESCE(ex.path, ''), '{AYON_INTERNAL_FOLDER_NAME}')"
-        )
-
     if access_list is not None:
         sql_conditions.append(
             f"hierarchy.path like ANY ('{{ {','.join(access_list)} }}')"
@@ -210,11 +204,6 @@ async def get_folders(
             ON folders.id = tasks.folder_id
             """
         )
-
-    if visibility == EntityVisibility.VISIBLE:
-        sql_conditions.append("ex.active IS TRUE")
-    elif visibility == EntityVisibility.HIDDEN:
-        sql_conditions.append("ex.active IS FALSE")
 
     # Total count fields (for delete info). Only computed when ids filter
     # is provided to prevent expensive full-project scans.
@@ -257,6 +246,17 @@ async def get_folders(
                 OR starts_with(h2.path, hierarchy.path || '/')) AS total_version_count
                 """
             )
+    else:
+        # If no specific ids are requested,
+        # we can filter by visibility and internal folder
+        if not include_internal_folder:
+            sql_conditions.append(
+                f"NOT starts_with(COALESCE(ex.path, ''), '{AYON_INTERNAL_FOLDER_NAME}')"
+            )
+        if visibility == EntityVisibility.VISIBLE:
+            sql_conditions.append("ex.active IS TRUE")
+        elif visibility == EntityVisibility.HIDDEN:
+            sql_conditions.append("ex.active IS FALSE")
 
     if fields.any_endswith("hasReviewables"):
         sql_cte.append(

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -251,7 +251,8 @@ async def get_folders(
         # we can filter by visibility and internal folder
         if not include_internal_folder:
             sql_conditions.append(
-                f"NOT starts_with(COALESCE(ex.path, ''), '{AYON_INTERNAL_FOLDER_NAME}')"
+                f"(hierarchy.path <> '{AYON_INTERNAL_FOLDER_NAME}' AND "
+                f"NOT starts_with(hierarchy.path, '{AYON_INTERNAL_FOLDER_NAME}/'))"
             )
         if visibility == EntityVisibility.VISIBLE:
             sql_conditions.append("(COALESCE(ex.active, TRUE) AND folders.active)")

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -254,9 +254,11 @@ async def get_folders(
                 f"NOT starts_with(COALESCE(ex.path, ''), '{AYON_INTERNAL_FOLDER_NAME}')"
             )
         if visibility == EntityVisibility.VISIBLE:
-            sql_conditions.append("(ex.active AND folders.active)")
+            sql_conditions.append("(COALESCE(ex.active, TRUE) AND folders.active)")
         elif visibility == EntityVisibility.HIDDEN:
-            sql_conditions.append("(NOT ex.active OR NOT folders.active")
+            sql_conditions.append(
+                "(NOT COALESCE(ex.active, TRUE) OR NOT folders.active)"
+            )
 
     if fields.any_endswith("hasReviewables"):
         sql_cte.append(

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -26,8 +26,10 @@ from .common import (
     ARGIds,
     ARGIncludeInternalFolder,
     ARGLast,
+    ARGVisibility,
     AttributeFilterInput,
     ColumnMetadata,
+    EntityVisibility,
     FieldInfo,
     argdesc,
     build_search_conditions,
@@ -128,6 +130,7 @@ async def get_folders(
         argdesc("Map of attribute names to lists of desired statistical aggregations"),
     ] = None,
     include_internal_folder: ARGIncludeInternalFolder = False,
+    visibility: ARGVisibility = EntityVisibility.ALL,
 ) -> FoldersConnection:
     """Return a list of folders."""
 
@@ -207,6 +210,11 @@ async def get_folders(
             ON folders.id = tasks.folder_id
             """
         )
+
+    if visibility == EntityVisibility.VISIBLE:
+        sql_conditions.append("ex.active IS TRUE")
+    elif visibility == EntityVisibility.HIDDEN:
+        sql_conditions.append("ex.active IS FALSE")
 
     # Total count fields (for delete info). Only computed when ids filter
     # is provided to prevent expensive full-project scans.

--- a/ayon_server/graphql/resolvers/folders.py
+++ b/ayon_server/graphql/resolvers/folders.py
@@ -254,9 +254,9 @@ async def get_folders(
                 f"NOT starts_with(COALESCE(ex.path, ''), '{AYON_INTERNAL_FOLDER_NAME}')"
             )
         if visibility == EntityVisibility.VISIBLE:
-            sql_conditions.append("ex.active IS TRUE")
+            sql_conditions.append("(ex.active AND folders.active)")
         elif visibility == EntityVisibility.HIDDEN:
-            sql_conditions.append("ex.active IS FALSE")
+            sql_conditions.append("(NOT ex.active OR NOT folders.active")
 
     if fields.any_endswith("hasReviewables"):
         sql_cte.append(

--- a/ayon_server/graphql/resolvers/kanban.py
+++ b/ayon_server/graphql/resolvers/kanban.py
@@ -279,7 +279,9 @@ async def get_kanban(
                     ON f.id = t.folder_id
                 JOIN {project_schema}.exported_attributes h
                     ON h.folder_id = f.id
-                    {"AND h.active IS TRUE AND t.active IS TRUE" if not task_ids else ""}
+                    {
+            "AND h.active IS TRUE AND t.active IS TRUE" if not task_ids else ""
+        }
                 {SQLTool.conditions(sq_conds)}
         """
         union_queries.append(uq)

--- a/ayon_server/graphql/resolvers/kanban.py
+++ b/ayon_server/graphql/resolvers/kanban.py
@@ -275,8 +275,11 @@ async def get_kanban(
                     AND v.task_id = t.id
                 ) AS has_reviewables
                 FROM {project_schema}.tasks t
-                JOIN {project_schema}.folders f ON f.id = t.folder_id
-                JOIN {project_schema}.exported_attributes h ON h.folder_id = f.id
+                JOIN {project_schema}.folders f
+                    ON f.id = t.folder_id
+                JOIN {project_schema}.exported_attributes h
+                    ON h.folder_id = f.id
+                    AND h.active IS TRUE
                 {SQLTool.conditions(sq_conds)}
         """
         union_queries.append(uq)

--- a/ayon_server/graphql/resolvers/kanban.py
+++ b/ayon_server/graphql/resolvers/kanban.py
@@ -279,7 +279,7 @@ async def get_kanban(
                     ON f.id = t.folder_id
                 JOIN {project_schema}.exported_attributes h
                     ON h.folder_id = f.id
-                    AND h.active IS TRUE
+                    {"AND h.active IS TRUE AND t.active IS TRUE" if not task_ids else ""}
                 {SQLTool.conditions(sq_conds)}
         """
         union_queries.append(uq)

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -35,7 +35,7 @@ from ayon_server.types import (
 )
 from ayon_server.utils import SQLTool
 
-from .common import build_search_conditions
+from .common import ARGVisibility, EntityVisibility, build_search_conditions
 from .field_stats import (
     MetricTargetInput,
     generate_field_stats,
@@ -141,6 +141,7 @@ async def get_products(
         argdesc("Map of attribute names to lists of desired statistical aggregations"),
     ] = None,
     include_internal_folder: ARGIncludeInternalFolder = False,
+    visibility: ARGVisibility = EntityVisibility.ALL,
 ) -> ProductsConnection:
     """Return a list of products."""
 
@@ -175,13 +176,20 @@ async def get_products(
     sql_cte = []
     sql_conditions = []
 
-    if not include_internal_folder:
-        sql_conditions.append(f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
-
     if ids is not None:
         if not ids:
             return ProductsConnection()
         sql_conditions.append(f"products.id IN {SQLTool.id_array(ids)}")
+    else:
+        if not include_internal_folder:
+            sql_conditions.append(
+                f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
+            )
+
+        if visibility == EntityVisibility.VISIBLE:
+            sql_conditions.append("products.active AND folder_ex.active")
+        elif visibility == EntityVisibility.HIDDEN:
+            sql_conditions.append("(NOT products.active OR NOT folder_ex.active)")
 
     if folder_ids is not None:
         if not folder_ids:

--- a/ayon_server/graphql/resolvers/products.py
+++ b/ayon_server/graphql/resolvers/products.py
@@ -183,7 +183,7 @@ async def get_products(
     else:
         if not include_internal_folder:
             sql_conditions.append(
-                f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
+                f"NOT starts_with(folder_ex.path, '{AYON_INTERNAL_FOLDER_NAME}')"
             )
 
         if visibility == EntityVisibility.VISIBLE:

--- a/ayon_server/graphql/resolvers/projects.py
+++ b/ayon_server/graphql/resolvers/projects.py
@@ -9,6 +9,8 @@ from ayon_server.graphql.resolvers.common import (
     ARGBefore,
     ARGFirst,
     ARGLast,
+    ARGVisibility,
+    EntityVisibility,
     FieldInfo,
     argdesc,
     resolve,
@@ -37,6 +39,7 @@ async def get_projects(
     last: ARGLast = None,
     before: ARGBefore = None,
     include_skeleton: bool = False,
+    visibility: ARGVisibility = EntityVisibility.ALL,
 ) -> ProjectsConnection:
     """Return a list of projects."""
 
@@ -48,6 +51,11 @@ async def get_projects(
     if name is not None:
         validate_name(name)
         sql_conditions.append(f"projects.name ILIKE '{name}'")
+    else:
+        if visibility == EntityVisibility.VISIBLE:
+            sql_conditions.append("projects.active IS TRUE")
+        elif visibility == EntityVisibility.HIDDEN:
+            sql_conditions.append("projects.active IS FALSE")
 
     if code is not None:
         validate_name(code)

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -26,7 +26,7 @@ from ayon_server.sqlfilter import QueryFilter, build_filter
 from ayon_server.types import validate_name_list, validate_status_list
 from ayon_server.utils import SQLTool
 
-from .common import build_search_conditions
+from .common import ARGVisibility, EntityVisibility, build_search_conditions
 
 
 async def get_representations(
@@ -50,6 +50,7 @@ async def get_representations(
     search: Annotated[str | None, argdesc("Fuzzy text search filter")] = None,
     filter: Annotated[str | None, argdesc("Filter tasks using QueryFilter")] = None,
     include_internal_folder: ARGIncludeInternalFolder = False,
+    visibility: ARGVisibility = EntityVisibility.ALL,
 ) -> RepresentationsConnection:
     """Return a list of representations."""
 
@@ -73,6 +74,32 @@ async def get_representations(
         if not ids:
             return RepresentationsConnection()
         sql_conditions.append(f"representations.id IN {SQLTool.id_array(ids)}")
+    else:
+        if visibility == EntityVisibility.VISIBLE:
+            sql_conditions.append(
+                """
+                (
+                    representations.active
+                    AND versions.active
+                    AND products.active
+                    AND f_ex.active
+                )
+                """
+            )
+        elif visibility == EntityVisibility.HIDDEN:
+            sql_conditions.append(
+                """
+                (
+                    NOT representations.active
+                    OR NOT versions.active
+                    OR NOT products.active
+                    OR NOT f_ex.active
+                )
+                """
+            )
+
+        if not include_internal_folder:
+            sql_conditions.append(f"f_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
 
     if version_ids is not None:
         if not version_ids:
@@ -119,6 +146,8 @@ async def get_representations(
         or search
         or fields.any_endswith("path")
         or fields.any_endswith("parents")
+        or visibility != EntityVisibility.ALL
+        or not include_internal_folder
     ):
         sql_joins.extend(
             [
@@ -131,28 +160,23 @@ async def get_representations(
                 ON products.id = versions.product_id
                 """,
                 f"""
-                INNER JOIN project_{project_name}.hierarchy AS hierarchy
-                ON hierarchy.id = products.folder_id
+                INNER JOIN project_{project_name}.exported_attributes AS f_ex
+                ON f_ex.folder_id = products.folder_id
                 """,
             ]
         )
 
         sql_columns.extend(
             [
-                "hierarchy.path AS _folder_path",
+                "f_ex.path AS _folder_path",
                 "products.name AS _product_name",
                 "versions.version AS _version_number",
             ]
         )
 
-        if not include_internal_folder:
-            sql_conditions.append(
-                f"hierarchy.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
-            )
-
         if access_list is not None:
             sql_conditions.append(
-                f"hierarchy.path like ANY ('{{ {','.join(access_list)} }}')"
+                f"f_ex.path like ANY ('{{ {','.join(access_list)} }}')"
             )
 
     if search:
@@ -161,7 +185,7 @@ async def get_representations(
             [
                 "products.name",
                 "products.product_type",
-                "hierarchy.path",
+                "f_ex.path",
                 "representations.name",
             ],
             version_check=True,

--- a/ayon_server/graphql/resolvers/representations.py
+++ b/ayon_server/graphql/resolvers/representations.py
@@ -99,7 +99,9 @@ async def get_representations(
             )
 
         if not include_internal_folder:
-            sql_conditions.append(f"f_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
+            sql_conditions.append(
+                f"NOT starts_with(f_ex.path, '{AYON_INTERNAL_FOLDER_NAME}')"
+            )
 
     if version_ids is not None:
         if not version_ids:

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -295,7 +295,7 @@ async def get_tasks(
     else:
         if not include_internal_folder:
             sql_conditions.append(
-                f"hierarchy.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
+                f"NOT starts_with(hierarchy.path, '{AYON_INTERNAL_FOLDER_NAME}')"
             )
 
         if visibility == EntityVisibility.VISIBLE:

--- a/ayon_server/graphql/resolvers/tasks.py
+++ b/ayon_server/graphql/resolvers/tasks.py
@@ -40,7 +40,7 @@ from ayon_server.types import (
 )
 from ayon_server.utils import SQLTool
 
-from .common import build_search_conditions
+from .common import ARGVisibility, EntityVisibility, build_search_conditions
 from .field_stats import (
     MetricTargetInput,
     generate_field_stats,
@@ -187,6 +187,7 @@ async def get_tasks(
         argdesc("Map of attribute names to lists of desired statistical aggregations"),
     ] = None,
     include_internal_folder: ARGIncludeInternalFolder = False,
+    visibility: ARGVisibility = EntityVisibility.ALL,
 ) -> TasksConnection:
     """Return a list of tasks."""
 
@@ -287,13 +288,20 @@ async def get_tasks(
             """
         )
 
-    if not include_internal_folder:
-        sql_conditions.append(f"hierarchy.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
-
     if ids is not None:
         if not ids:
             return TasksConnection()
         sql_conditions.append(f"tasks.id IN {SQLTool.id_array(ids)}")
+    else:
+        if not include_internal_folder:
+            sql_conditions.append(
+                f"hierarchy.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
+            )
+
+        if visibility == EntityVisibility.VISIBLE:
+            sql_conditions.append("(tasks.active AND f_ex.active)")
+        elif visibility == EntityVisibility.HIDDEN:
+            sql_conditions.append("(NOT tasks.active OR NOT f_ex.active)")
 
     if folder_ids is not None:
         if not folder_ids:

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -472,7 +472,7 @@ async def get_versions(
         if not include_internal_folder:
             joins.for_filter("folder_ex")
             sql_conditions.append(
-                f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
+                f"NOT starts_with(folder_ex.path, '{AYON_INTERNAL_FOLDER_NAME}')"
             )
 
         if visibility == EntityVisibility.VISIBLE:

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -36,7 +36,7 @@ from ayon_server.types import (
 )
 from ayon_server.utils import SQLTool
 
-from .common import build_search_conditions
+from .common import ARGVisibility, EntityVisibility, build_search_conditions
 from .field_stats import (
     MetricTargetInput,
     generate_field_stats,
@@ -408,6 +408,7 @@ async def get_versions(
         argdesc("Map of attribute names to lists of desired statistical aggregations"),
     ] = None,
     include_internal_folder: ARGIncludeInternalFolder = False,
+    visibility: ARGVisibility = EntityVisibility.ALL,
 ) -> VersionsConnection:
     """Return a list of versions."""
 
@@ -459,6 +460,7 @@ async def get_versions(
     #
 
     # Empty overrides. Skip querying
+    # TODO: is this deprecated?
     if ids == ["0" * 32]:
         return VersionsConnection(edges=[])
 
@@ -466,6 +468,23 @@ async def get_versions(
         if not ids:
             return VersionsConnection()
         sql_conditions.append(f"versions.id IN {SQLTool.id_array(ids)}")
+    else:
+        if not include_internal_folder:
+            joins.for_filter("folder_ex")
+            sql_conditions.append(
+                f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
+            )
+
+        if visibility == EntityVisibility.VISIBLE:
+            joins.for_filter("folder_ex")
+            sql_conditions.append(
+                "(products.active and folder_ex.active and versions.active)"
+            )
+        elif visibility == EntityVisibility.HIDDEN:
+            joins.for_filter("folder_ex")
+            sql_conditions.append(
+                "(NOT products.active or NOT folder_ex.active or NOT versions.active)"
+            )
 
     if version:
         sql_conditions.append(f"versions.version = {version}")
@@ -611,12 +630,6 @@ async def get_versions(
         sql_conditions.extend(
             get_has_links_conds(project_name, "versions.id", has_links)
         )
-
-    has_ids = ids is not None and len(ids) > 0
-
-    if not include_internal_folder and not has_ids:
-        joins.for_filter("folder_ex")
-        sql_conditions.append(f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
 
     #
     # Access control

--- a/ayon_server/graphql/resolvers/workfiles.py
+++ b/ayon_server/graphql/resolvers/workfiles.py
@@ -91,7 +91,9 @@ async def get_workfiles(
             )
 
         if not include_internal_folder:
-            sql_conditions.append(f"f_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
+            sql_conditions.append(
+                f"NOT starts_with(f_ex.path, '{AYON_INTERNAL_FOLDER_NAME}')"
+            )
 
     if task_ids is not None:
         if not task_ids:

--- a/ayon_server/graphql/resolvers/workfiles.py
+++ b/ayon_server/graphql/resolvers/workfiles.py
@@ -25,7 +25,7 @@ from ayon_server.helpers.hierarchy_cache import AYON_INTERNAL_FOLDER_NAME
 from ayon_server.types import validate_name_list, validate_status_list
 from ayon_server.utils import SQLTool
 
-from .common import build_search_conditions
+from .common import ARGVisibility, EntityVisibility, build_search_conditions
 
 SORT_OPTIONS = {
     "name": "workfiles.name",
@@ -57,6 +57,7 @@ async def get_workfiles(
     search: Annotated[str | None, argdesc("Fuzzy text search filter")] = None,
     sort_by: Annotated[str | None, sortdesc(SORT_OPTIONS)] = None,
     include_internal_folder: ARGIncludeInternalFolder = False,
+    visibility: ARGVisibility = EntityVisibility.ALL,
 ) -> WorkfilesConnection:
     """Return a list of workfiles."""
 
@@ -81,6 +82,16 @@ async def get_workfiles(
         if not ids:
             return WorkfilesConnection()
         sql_conditions.append(f"workfiles.id IN {SQLTool.id_array(ids)}")
+    else:
+        if visibility == EntityVisibility.VISIBLE:
+            sql_conditions.append("workfiles.active AND tasks.active AND f_ex.active")
+        elif visibility == EntityVisibility.HIDDEN:
+            sql_conditions.append(
+                "(NOT workfiles.active OR NOT tasks.active OR NOT f_ex.active)"
+            )
+
+        if not include_internal_folder:
+            sql_conditions.append(f"f_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'")
 
     if task_ids is not None:
         if not task_ids:
@@ -117,11 +128,18 @@ async def get_workfiles(
         sql_conditions.append(f"workfiles.tags @> {SQLTool.array(tags, curly=True)}")
 
     access_list = await create_folder_access_list(root, info)
-    if access_list is not None or search or fields.any_endswith("parents"):
+    if (
+        access_list is not None
+        or search
+        or fields.any_endswith("parents")
+        or fields.any_endswith("path")
+        or visibility != EntityVisibility.ALL
+        or not include_internal_folder
+    ):
         sql_columns.extend(
             [
                 "tasks.name AS _task_name",
-                "hierarchy.path AS _folder_path",
+                "f_ex.path AS _folder_path",
             ]
         )
 
@@ -132,20 +150,15 @@ async def get_workfiles(
                 ON tasks.id = workfiles.task_id
                 """,
                 f"""
-                INNER JOIN project_{project_name}.hierarchy AS hierarchy
-                ON hierarchy.id = tasks.folder_id
+                INNER JOIN project_{project_name}.exported_attributes AS f_ex
+                ON f_ex.folder_id = tasks.folder_id
                 """,
             ]
         )
 
-        if not include_internal_folder:
-            sql_conditions.append(
-                f"folder_ex.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'"
-            )
-
         if access_list is not None:
             sql_conditions.append(
-                f"hierarchy.path like ANY ('{{ {','.join(access_list)} }}')"
+                f"f_ex.path like ANY ('{{ {','.join(access_list)} }}')"
             )
 
     if search:
@@ -154,7 +167,7 @@ async def get_workfiles(
             [
                 "tasks.name",
                 "tasks.task_type",
-                "hierarchy.path",
+                "f_ex.path",
                 "workfiles.path",
             ],
         ):

--- a/ayon_server/helpers/hierarchy_cache.py
+++ b/ayon_server/helpers/hierarchy_cache.py
@@ -73,7 +73,7 @@ async def rebuild_hierarchy_cache(project_name: str) -> list[dict[str, Any]]:
         LEFT JOIN reviewables r
         ON r.folder_id = f.id
 
-        WHERE ea.path NOT LIKE '{AYON_INTERNAL_FOLDER_NAME}%'
+        WHERE NOT starts_with(ea.path, '{AYON_INTERNAL_FOLDER_NAME}')
 
         GROUP BY f.id, ea.attrib, ea.path, fwv.ancestor_id, r.folder_id
     """

--- a/ayon_server/helpers/inherited_attributes.py
+++ b/ayon_server/helpers/inherited_attributes.py
@@ -10,8 +10,13 @@ async def _rebuild_from(project_name: str, project_attrib: dict[str, Any]) -> No
     st_crawl = await Postgres.prepare(
         f"""
         SELECT
-            h.id, h.path, f.attrib as own,
-            e.attrib as exported, e.path as exported_path
+            h.id,
+            h.path,
+            f.attrib as own,
+            f.active as own_active,
+            e.attrib as exported,
+            e.path as exported_path,
+            e.active as exported_active
         FROM project_{project_name}.hierarchy h
         INNER JOIN project_{project_name}.folders f
         ON h.id = f.id
@@ -24,42 +29,54 @@ async def _rebuild_from(project_name: str, project_attrib: dict[str, Any]) -> No
     st_upsert = await Postgres.prepare(
         f"""
          INSERT INTO project_{project_name}.exported_attributes
-             (folder_id, path, attrib)
+             (folder_id, path, attrib, active)
          VALUES
-            ($1, $2, $3)
+            ($1, $2, $3, $4)
          ON CONFLICT (folder_id)
-         DO UPDATE SET path = EXCLUDED.path, attrib = EXCLUDED.attrib
+         DO UPDATE SET
+            path = EXCLUDED.path,
+            attrib = EXCLUDED.attrib,
+            active = EXCLUDED.active
          """
     )
 
     # path: attrib_set cache to use when returning from child to parent
     caching: dict[tuple[str, ...], dict[str, Any]] = {}
+    active_caching: dict[tuple[str, ...], bool] = {}
 
     current_attrib_set: dict[str, Any] = {}
-    buff: list[tuple[str, str, dict[str, Any]]] = []
+    current_active = True
+    buff: list[tuple[str, str, dict[str, Any], bool]] = []
 
     async for record in st_crawl.cursor():
         path_elements = tuple(record["path"].split("/"))
         if len(path_elements) == 1:
             current_attrib_set = project_attrib.copy()
+            current_active = True
 
         elif path_elements[:-1] in caching:
             current_attrib_set = caching[path_elements[:-1]]
+            current_active = active_caching[path_elements[:-1]]
 
         new_attrib_set = current_attrib_set.copy()
         new_attrib_set.update(record["own"])
 
+        new_active = current_active and record["own_active"]
+
         caching[path_elements] = new_attrib_set
+        active_caching[path_elements] = new_active
 
         if (
             record["exported"] != new_attrib_set
             or record["exported_path"] != record["path"]
+            or record["exported_active"] != new_active
         ):
             buff.append(
                 (
                     record["id"],
                     record["path"],
                     new_attrib_set,
+                    new_active,
                 )
             )
 
@@ -68,6 +85,7 @@ async def _rebuild_from(project_name: str, project_attrib: dict[str, Any]) -> No
             buff = []
 
         current_attrib_set = new_attrib_set
+        current_active = new_active
 
     if buff:
         await st_upsert.executemany(buff)

--- a/schemas/migrations/00000013.sql
+++ b/schemas/migrations/00000013.sql
@@ -1,0 +1,38 @@
+--
+-- Add active column to exported_attributes
+--
+-- Stores the inherited "active" state of a folder (false if the folder
+-- itself or any of its parents has active = false). Populated by
+-- rebuild_inherited_attributes, defaults to true so existing rows
+-- are treated as visible until the next rebuild (that runs automatically 
+-- after this migration).
+--
+
+DO $$
+DECLARE rec RECORD;
+BEGIN
+  FOR rec IN
+    SELECT ns.nspname AS project_schema, cl.relname AS table_name
+    FROM pg_namespace ns
+    JOIN pg_class cl
+      ON cl.relnamespace = ns.oid
+    LEFT JOIN pg_attribute att
+      ON att.attrelid = cl.oid
+      AND att.attname = 'active'
+    WHERE
+      ns.nspname LIKE 'project_%'
+      AND cl.relname = 'exported_attributes'
+      AND att.attname IS NULL
+    LOOP
+        BEGIN
+          RAISE WARNING 'Adding active to %.%', rec.project_schema, rec.table_name;
+          EXECUTE 'SET LOCAL search_path TO ' || quote_ident(rec.project_schema);
+
+          ALTER TABLE exported_attributes ADD COLUMN IF NOT EXISTS active BOOLEAN NOT NULL DEFAULT TRUE;
+
+        EXCEPTION
+          WHEN OTHERS THEN
+             RAISE WARNING 'Skipping schema % due to error: %', rec.project_schema, SQLERRM;
+        END;
+    END LOOP;
+END $$;

--- a/schemas/schema.project.sql
+++ b/schemas/schema.project.sql
@@ -233,7 +233,8 @@ CREATE INDEX hierarchy_path_idx ON hierarchy(path);
 CREATE TABLE exported_attributes(
   folder_id UUID NOT NULL PRIMARY KEY REFERENCES folders(id) ON DELETE CASCADE,
   path VARCHAR NOT NULL,
-  attrib JSONB NOT NULL DEFAULT '{}'::JSONB
+  attrib JSONB NOT NULL DEFAULT '{}'::JSONB,
+  active BOOLEAN NOT NULL DEFAULT TRUE
 );
 
 -----------


### PR DESCRIPTION
## Summary

This PR introduces a consistent **visibility filter** across the GraphQL API, letting clients ask for only visible entities, only hidden (inactive) entities, or everything.

A new `EntityVisibility` enum (`ALL`, `VISIBLE`, `HIDDEN`) is added as a `visibility` argument on the main list queries for folders, tasks, products, versions, representations, workfiles, and projects. Previously, "active" filtering was inconsistent between resolvers (some ignored it, some only checked the entity's own `active` flag); this PR makes visibility inheritance explicit and uniform.

## Expected behavior (visibility inheritance)

An entity is **visible** only if it and everything it inherits visibility from are active. Concretely:

* **Project** — only its own active state.
* **Folder** — its own active state *and* all ancestor folders active.
* **Task** — its own active state *and* all ancestor folders (its folder and that folder's ancestors) active.
* **Product** — its own active state *and* all ancestor folders active.
* **Version** — its own active state, its product's active state, *and* all ancestor folders active.
* **Representation** — its own active state, its version's active state, its product's active state, *and* all ancestor folders active.
* **Workfile** — its own active state, its task's active state, *and* all ancestor folders active.

**Note:** Products, versions, and representations do **not** take the *task*'s active state into account, even when a version is linked to a task. This is intentional:
- Products aren't linked to a task at all, only versions are.
- Versions don't require a task link either, so some versions could never be hidden by task state even if all tasks were deactivated.
- The task → version relationship is treated as metadata/tracking, not as something that should drive visibility - archiving a task shouldn't suddenly hide products/versions/representations that live under the same folder.

Workfiles are the exception, since they are directly owned by a task, so a workfile's visibility does depend on its task's active state.

`HIDDEN` is the logical negation of `VISIBLE` (i.e. "not everything in the chain above is active"), not simply "this entity's own `active` flag is false".

## Other changes

- SQL conditions for folders, kanban, and other resolvers were adjusted to correctly combine the entity's own state with its inherited/ancestor state (including edge cases like root folders, which have no parent).
- Internal (`__ayon_internal__`) folders and their descendants continue to be excluded from results unless explicitly requested via `includeInternalFolder`, now matched by exact path segment rather than a `LIKE` pattern.
- Visibility and internal-folder filtering are only applied when no specific `ids` are requested, so explicitly requesting an entity by ID still returns it regardless of visibility.

## Testing notes

Run `ayon setup` to apply the required database migration (adds an `active` column to `exported_attributes` and backfills inherited visibility)