### PR TITLE
Added filter for repre extensions to versions graphql

### DIFF
--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -214,17 +214,6 @@ def available_joins(project_name: str) -> dict[str, str]:
                 LIMIT 1
             ) hv ON true
             """,
-        "repr": f"""
-            INNER JOIN LATERAL (
-                SELECT
-                    versions.id AS id,
-                    r.name as repr_name,
-                    COALESCE(r.attrib->>'path', '') AS repr_path
-                FROM project_{project_name}.representations r
-                WHERE r.version_id = versions.id
-                LIMIT 1
-            ) repr ON true
-        """,
     }
 
 
@@ -326,13 +315,6 @@ async def get_versions(
         list[str] | None,
         argdesc("List of tags to filter by"),
     ] = None,
-    representation_extensions: Annotated[
-        list[str] | None,
-        argdesc(
-            "List of file extensions (e.g. pdf, mov, .jpg) to filter by "
-            "representation path/name"
-        ),
-    ] = None,
     product_ids: Annotated[
         list[str] | None,
         argdesc("List of parent products IDs"),
@@ -416,6 +398,10 @@ async def get_versions(
     product_filter: Annotated[
         str | None,
         argdesc("Filter versions by their product using QueryFilter"),
+    ] = None,
+    representation_filter: Annotated[
+        str | None,
+        argdesc("Filter versions by their representations using QueryFilter"),
     ] = None,
     sort_by: Annotated[
         str | None,
@@ -513,34 +499,6 @@ async def get_versions(
             return VersionsConnection()
         validate_name_list(tags)
         sql_conditions.append(f"versions.tags @> {SQLTool.array(tags, curly=True)}")
-
-    if representation_extensions is not None:
-        if not representation_extensions:
-            return VersionsConnection()
-        normalized_extensions = _normalize_representation_extensions(
-            representation_extensions
-        )
-
-        representation_names = list(
-            dict.fromkeys(
-                [*normalized_extensions, *[f".{ext}" for ext in normalized_extensions]]
-            )
-        )
-        path_conditions = " OR ".join(
-            [
-                f"lower(repr_path) LIKE '%.{extension}'"
-                for extension in normalized_extensions
-            ]
-        )
-        joins.for_filter("repr")
-        sql_conditions.append(
-            f"""
-                (
-                    repr_name IN {SQLTool.array(representation_names)}
-                    OR ({path_conditions})
-                )
-            """
-        )
 
     if product_ids is not None:
         if not product_ids:
@@ -863,6 +821,48 @@ async def get_versions(
             sql_conditions.append(fcond)
             joins.for_filter("folders", "folder_ex")
             use_folder_query = True
+
+    representation_filter_conditions = []
+    if representation_filter:
+        column_whitelist = [
+            "id",
+            "name",
+            "version_id",
+            "files",
+            "attrib",
+            "data",
+            "traits",
+            "status",
+            "tags",
+            "active",
+            "created_at",
+            "updated_at",
+        ]
+
+        fdata = json.loads(representation_filter)
+        fq = QueryFilter(**fdata)
+        if fcond := build_filter(
+            fq,
+            column_whitelist=column_whitelist,
+            table_prefix="representations",
+        ):
+            representation_filter_conditions.append(fcond)
+
+    if representation_filter_conditions:
+        sql_conditions.append(
+            f"""
+                EXISTS (
+                    SELECT 1
+                    FROM project_{project_name}.representations AS representations
+                    {
+                SQLTool.conditions(
+                    ["representations.version_id = versions.id"]
+                    + representation_filter_conditions
+                )
+            }
+                )
+                """
+        )
 
     #
     # Latest version per folder (from the set matching all filters above)

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Annotated
 
 from ayon_server.entities import ProjectEntity
@@ -44,6 +45,8 @@ from .field_stats import (
     generate_stats_columns,
 )
 from .sorting import get_attrib_sort_case, get_status_sort_case
+
+REPRESENTATION_EXTENSION_REGEX = re.compile(r"^[a-z0-9][a-z0-9._+-]*$")
 
 SORT_OPTIONS = {
     "author": "versions.author",
@@ -312,6 +315,13 @@ async def get_versions(
         list[str] | None,
         argdesc("List of tags to filter by"),
     ] = None,
+    representation_extensions: Annotated[
+        list[str] | None,
+        argdesc(
+            "List of file extensions (e.g. pdf, mov, .jpg) to filter by "
+            "representation path/name"
+        ),
+    ] = None,
     product_ids: Annotated[
         list[str] | None,
         argdesc("List of parent products IDs"),
@@ -492,6 +502,38 @@ async def get_versions(
             return VersionsConnection()
         validate_name_list(tags)
         sql_conditions.append(f"versions.tags @> {SQLTool.array(tags, curly=True)}")
+
+    if representation_extensions is not None:
+        if not representation_extensions:
+            return VersionsConnection()
+        normalized_extensions = _normalize_representation_extensions(
+            representation_extensions
+        )
+
+        representation_names = list(
+            dict.fromkeys(
+                [*normalized_extensions, *[f".{ext}" for ext in normalized_extensions]]
+            )
+        )
+        path_conditions = " OR ".join(
+            [
+                f"lower(COALESCE(rep.attrib->>'path', '')) LIKE '%.{extension}'"
+                for extension in normalized_extensions
+            ]
+        )
+        sql_conditions.append(
+            f"""
+            EXISTS (
+                SELECT 1
+                FROM project_{project_name}.representations AS rep
+                WHERE rep.version_id = versions.id
+                AND (
+                    rep.name IN {SQLTool.array(representation_names)}
+                    OR ({path_conditions})
+                )
+            )
+            """
+        )
 
     if product_ids is not None:
         if not product_ids:
@@ -1022,3 +1064,15 @@ async def get_version(root, info: Info, id: str) -> VersionNode:
     if not connection.edges:
         raise NotFoundException("Version not found")
     return connection.edges[0].node
+
+
+def _normalize_representation_extensions(extensions: list[str]) -> list[str]:
+    normalized: list[str] = []
+    for extension in extensions:
+        value = extension.strip().lower().lstrip(".")
+        if not value:
+            raise BadRequestException("Representation extension cannot be empty")
+        if not REPRESENTATION_EXTENSION_REGEX.match(value):
+            raise BadRequestException(f"Invalid representation extension '{extension}'")
+        normalized.append(value)
+    return list(dict.fromkeys(normalized))

--- a/ayon_server/graphql/resolvers/versions.py
+++ b/ayon_server/graphql/resolvers/versions.py
@@ -214,6 +214,17 @@ def available_joins(project_name: str) -> dict[str, str]:
                 LIMIT 1
             ) hv ON true
             """,
+        "repr": f"""
+            INNER JOIN LATERAL (
+                SELECT
+                    versions.id AS id,
+                    r.name as repr_name,
+                    COALESCE(r.attrib->>'path', '') AS repr_path
+                FROM project_{project_name}.representations r
+                WHERE r.version_id = versions.id
+                LIMIT 1
+            ) repr ON true
+        """,
     }
 
 
@@ -517,21 +528,17 @@ async def get_versions(
         )
         path_conditions = " OR ".join(
             [
-                f"lower(COALESCE(rep.attrib->>'path', '')) LIKE '%.{extension}'"
+                f"lower(repr_path) LIKE '%.{extension}'"
                 for extension in normalized_extensions
             ]
         )
+        joins.for_filter("repr")
         sql_conditions.append(
             f"""
-            EXISTS (
-                SELECT 1
-                FROM project_{project_name}.representations AS rep
-                WHERE rep.version_id = versions.id
-                AND (
-                    rep.name IN {SQLTool.array(representation_names)}
+                (
+                    repr_name IN {SQLTool.array(representation_names)}
                     OR ({path_conditions})
                 )
-            )
             """
         )
 

--- a/ayon_server/sqlfilter.py
+++ b/ayon_server/sqlfilter.py
@@ -30,6 +30,7 @@ ValueType = (
 OperatorType = Literal[
     "eq",
     "like",
+    "re",
     "lt",
     "gt",
     "lte",
@@ -257,13 +258,13 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
                 else:
                     raise ValueError("Invalid value type in list")
 
-        if operator == "like":
+        if operator in ("like", "re"):
             # JSON Field is a string, so we need to cast it to text
             if isinstance(value, str):
                 safe_value = value.replace("'", "''")
                 safe_value = f"'{safe_value}'"
             else:
-                raise ValueError("Value must be a string for 'like' operator")
+                raise ValueError("Value must be a string for 'like' or 're' operators")
 
         else:
             safe_value = json.dumps(value).replace("'", "''")
@@ -407,6 +408,10 @@ def build_condition(c: QueryCondition, **kwargs) -> str:
         # replace last -> with ->> to get text value
         column = re.sub(r"->(?!.*->)", "->>", column)
         return f"({column}) ILIKE {safe_value}"
+    elif operator == "re":
+        # replace last -> with ->> to get text value
+        column = re.sub(r"->(?!.*->)", "->>", column)
+        return f"({column}) SIMILAR TO {safe_value}"
     elif operator == "lt":
         return f"{column} < {safe_value}"
     elif operator == "gt":


### PR DESCRIPTION
## Description of changes

Adds additional `representation_extensions` filter to search for versions having representation of particular extension.

This should be used for Loader and desktop tools to locate appropriate versions faster.

### Additional context

This could be tested only via calling `get_versions` via Postman or similar
