### PR TITLE
Fix entity import permissions

### DIFF
--- a/api/data_import/import_data.py
+++ b/api/data_import/import_data.py
@@ -170,11 +170,20 @@ async def import_data(
     Returns:
         ImportStatus: Summary of import results
     """
-    if not user.is_manager:
-        raise ForbiddenException("You must be a manager")
-
     if project_name is not None:
         project_name = await normalize_project_name(project_name)
+
+        if not user.is_manager:
+            permissions = user.permissions(project_name=project_name)
+            # If either create or attrib_write permission check is enabled,
+            # raise ForbiddenException to prevent import. User has to have
+            # full write access to the hierarchy in order to import data.
+            if permissions.create.enabled or permissions.attrib_write.enabled:
+                raise ForbiddenException("Insufficient permissions to import data")
+
+    elif not user.is_manager:
+        # For user import, user must be a manager
+        raise ForbiddenException("You must be a manager")
 
     file_bytes = await Redis.get(REDIS_NS, file_id)
     if not file_bytes:

--- a/api/data_import/import_data.py
+++ b/api/data_import/import_data.py
@@ -170,6 +170,10 @@ async def import_data(
     Returns:
         ImportStatus: Summary of import results
     """
+
+    if import_type == "user" and not user.is_admin:
+        raise ForbiddenException("You must be an admin to import users")
+
     if project_name is not None:
         project_name = await normalize_project_name(project_name)
 
@@ -182,8 +186,9 @@ async def import_data(
                 raise ForbiddenException("Insufficient permissions to import data")
 
     elif not user.is_manager:
-        # For user import, user must be a manager
-        raise ForbiddenException("You must be a manager")
+        # This technically should not happen as project_name is required
+        # for folder/task imports, but we check anyway
+        raise ForbiddenException("You must be a manager to import data")
 
     file_bytes = await Redis.get(REDIS_NS, file_id)
     if not file_bytes:

--- a/api/data_import/import_data.py
+++ b/api/data_import/import_data.py
@@ -127,9 +127,6 @@ async def upload_file(
         ForbiddenException: If user is not a manager
         NotFoundException: If file format is not supported
     """
-    # Verify user has manager privileges
-    if not user.is_manager:
-        raise ForbiddenException("You must be a manager")
 
     mime = request.headers.get("Content-Type")
     if mime not in SUPPORTED_MIME_TYPES:

--- a/ayon_server/access/utils.py
+++ b/ayon_server/access/utils.py
@@ -226,6 +226,16 @@ async def ensure_entity_access(
     Should handle both single and multi entity access.
     """
 
+    if entity_id is None and entity_type == "folder":
+        # creating root folder is allowed if user has
+        # no permission limit
+        if user.is_manager:
+            return True
+
+        perms = user.permissions(project_name)
+        if not getattr(perms, access_type).enabled:
+            return True
+
     if entity_id is None:
         raise ForbiddenException("Limited access to project")
 


### PR DESCRIPTION
This pull request updates the permission checks in the `import_data` function to provide more granular control over who can import data, especially when a `project_name` is specified. The main change is that users who are not managers but have full hierarchy write access to the project can now use entity import
