### PR TITLE
Resolving icon url for actions in enum

### DIFF
--- a/ayon_server/enum/resolvers/enum_actions.py
+++ b/ayon_server/enum/resolvers/enum_actions.py
@@ -43,6 +43,11 @@ class ActionsEnumResolver(BaseEnumResolver):
                         if action.identifier in action_idents:
                             continue
 
+                        if action.icon and action.icon.url:
+                            action.icon.url = action.icon.url.format(
+                                addon_url=f"/addons/{addon_name}/{addon_version}"
+                            )
+
                         action_idents.add(action.identifier)
                         result.append(
                             EnumItem(


### PR DESCRIPTION
## Description of changes

Resolves `{addon_url}` in AYON based icons for actions with appropriate `addon.name` and `addon.version`.


### Additional context

Use `api/enum/actions` to check addon with actions with AYON based icons for actions. Most likely only `batchdelivery`.

<img width="293" height="188" alt="image" src="https://github.com/user-attachments/assets/ac421e1e-fe62-4905-bdd6-7c09ad3eb5ce" />
